### PR TITLE
Complete queued ZzzOps workflow safeguards

### DIFF
--- a/.agents/prompt_stats.py
+++ b/.agents/prompt_stats.py
@@ -12,6 +12,11 @@ START = "<!-- PROMPT_BUDGET_START -->"
 END = "<!-- PROMPT_BUDGET_END -->"
 
 
+def canonical_size(data: bytes) -> int:
+    """Count UTF-8 bytes after normalizing platform line endings to LF."""
+    return len(data.replace(b"\r\n", b"\n").replace(b"\r", b"\n"))
+
+
 def prompt_files(root: Path) -> list[Path]:
     files = [root / "AGENTS.md", root / "CLAUDE.md", root / "goals" / "TEMPLATE.md"]
     files.extend((root / ".zzzops" / "rules").glob("*.md"))
@@ -30,7 +35,7 @@ def main() -> int:
     rows = []
     for path in prompt_files(root):
         relative = path.relative_to(root).as_posix()
-        size = len(path.read_bytes())
+        size = canonical_size(path.read_bytes())
         rows.append((relative, size, math.ceil(size / 4)))
     total_bytes = sum(row[1] for row in rows)
     total_tokens = sum(row[2] for row in rows)

--- a/.agents/test_prompt_stats.py
+++ b/.agents/test_prompt_stats.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("prompt_stats.py")
+SPEC = importlib.util.spec_from_file_location("prompt_stats", SCRIPT)
+assert SPEC and SPEC.loader
+prompt_stats = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(prompt_stats)
+
+
+class PromptStatsTests(unittest.TestCase):
+    def test_canonical_size_is_line_ending_invariant(self) -> None:
+        lf = "one\ntwo\n".encode()
+        expected = prompt_stats.canonical_size(lf)
+        self.assertEqual(prompt_stats.canonical_size(b"one\r\ntwo\r\n"), expected)
+        self.assertEqual(prompt_stats.canonical_size(b"one\rtwo\r"), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   validate:
-    name: ZzzOps checks
+    name: dev-required-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: PR validation
+
+on:
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: ZzzOps checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Test prompt accounting
+        run: python .agents/test_prompt_stats.py
+      - name: Test semantic releases
+        run: python -m unittest discover -s .github/scripts -p 'test_*.py'
+      - name: Verify prompt budget
+        run: python .agents/prompt_stats.py --check
+      - name: Check Python syntax
+        run: python -m compileall -q .agents .github/scripts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,6 @@ Without skill discovery read [rules](.zzzops/rules/GOAL_SYSTEM.md), then the app
 
 Use `$install-zzzops` only here. It installs discoverable skills/mechanics into targets but never itself, project state, or target `AGENTS.md`/`CLAUDE.md`.
 
-Git workflow: create work branches only from `dev` and integrate ordinary work back into `dev`. A push or merge to `main` runs release CI; do it only when the user explicitly intends a release and its preconditions pass.
+Git workflow: branch all work from current `dev` and open ordinary PRs against `dev`, never `main`. Large work may use smaller coherent semantic commits when they aid review, testing, or independent rollback; squash changes that are valid only together into one atomic commit, while keeping independently useful/revertible changes separate. Only repository owner `david-rzepa` may update `main`, by an explicitly intended release force-push after preconditions pass; any `main` update runs release CI.
 
 When any installed prompt/instruction/template Markdown changes, regenerate README “Prompt budget” counts with `.agents/prompt_stats.py`, then run `--check`; never hand-edit those numbers.

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ Today it edits preferences. Tomorrow it may achieve sentience and add a “notif
 
 ## Releases
 
-Develop on branches created from `dev` and integrate ordinary work back into `dev`. Each push to `dev` runs the release planner and tests with read-only repository permission; it prints the next version and notes but cannot publish anything. Push or merge to `main` only for an intended release: the same planner then receives `contents: write` and creates the Git tag and GitHub Release.
+Develop on branches created from `dev` and open ordinary PRs against `dev`. The read-only **PR validation / ZzzOps checks** job must pass before merge. Each push to `dev` previews the release with read-only repository permission; it cannot publish. `main` is reserved for an intended owner force-push release: the same planner then receives `contents: write` and creates the Git tag and GitHub Release.
 
 Versions follow Conventional Commits since the latest `vMAJOR.MINOR.PATCH` tag: `!`, `BREAKING CHANGE:`, or `BREAKING-CHANGE:` bumps major, `feat` bumps minor, and `fix`/`perf` bumps patch. Other types do not release. The first release applies those rules from `0.0.0`; reruns with no new releasable commits are no-ops. No repository secret is required beyond GitHub's job token.
 
-To diagnose a release, inspect the **Semantic release** run and its test, preview, or publish step. Reproduce the planner locally with `python -m unittest discover -s .github/scripts -p 'test_*.py'` and `python .github/scripts/semantic_release.py`; the latter only writes a local notes file. Confirm branch, commit messages, latest tag, job permission, and GitHub CLI output before retrying.
+To diagnose a PR or release, inspect **PR validation / ZzzOps checks** or the **Semantic release** run and its failing step. Reproduce checks locally with `python .agents/test_prompt_stats.py`, `python -m unittest discover -s .github/scripts -p 'test_*.py'`, and `python .agents/prompt_stats.py --check`. `python .github/scripts/semantic_release.py` only writes a local notes file. Confirm branch, commit messages, latest tag, job permission, and GitHub CLI output before retrying.
 
 ## The files that remember things
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Versions follow Conventional Commits since the latest `vMAJOR.MINOR.PATCH` tag: 
 
 To diagnose a PR or release, inspect **PR validation / dev-required-tests** or the **Semantic release** run and its failing step. Reproduce checks locally with `python .agents/test_prompt_stats.py`, `python -m unittest discover -s .github/scripts -p 'test_*.py'`, and `python .agents/prompt_stats.py --check`. `python .github/scripts/semantic_release.py` only writes a local notes file. Confirm branch, commit messages, latest tag, job permission, and GitHub CLI output before retrying.
 
+Maintainers: see [branch protection](docs/BRANCH_PROTECTION.md) for the required `dev` check, current GitHub Free limitation, closest enforceable `main` policy, and recovery procedure.
+
 ## The files that remember things
 
 - `goals/PROJECT.md` — success, KPIs, acceptance criteria, and what “valuable” means.

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ Today it edits preferences. Tomorrow it may achieve sentience and add a “notif
 
 ## Releases
 
-Develop on branches created from `dev` and open ordinary PRs against `dev`. The read-only **PR validation / ZzzOps checks** job must pass before merge. Each push to `dev` previews the release with read-only repository permission; it cannot publish. `main` is reserved for an intended owner force-push release: the same planner then receives `contents: write` and creates the Git tag and GitHub Release.
+Develop on branches created from `dev` and open ordinary PRs against `dev`. The read-only **PR validation / dev-required-tests** job must pass before merge. Each push to `dev` previews the release with read-only repository permission; it cannot publish. `main` is reserved for an intended owner force-push release: the same planner then receives `contents: write` and creates the Git tag and GitHub Release.
 
 Versions follow Conventional Commits since the latest `vMAJOR.MINOR.PATCH` tag: `!`, `BREAKING CHANGE:`, or `BREAKING-CHANGE:` bumps major, `feat` bumps minor, and `fix`/`perf` bumps patch. Other types do not release. The first release applies those rules from `0.0.0`; reruns with no new releasable commits are no-ops. No repository secret is required beyond GitHub's job token.
 
-To diagnose a PR or release, inspect **PR validation / ZzzOps checks** or the **Semantic release** run and its failing step. Reproduce checks locally with `python .agents/test_prompt_stats.py`, `python -m unittest discover -s .github/scripts -p 'test_*.py'`, and `python .agents/prompt_stats.py --check`. `python .github/scripts/semantic_release.py` only writes a local notes file. Confirm branch, commit messages, latest tag, job permission, and GitHub CLI output before retrying.
+To diagnose a PR or release, inspect **PR validation / dev-required-tests** or the **Semantic release** run and its failing step. Reproduce checks locally with `python .agents/test_prompt_stats.py`, `python -m unittest discover -s .github/scripts -p 'test_*.py'`, and `python .agents/prompt_stats.py --check`. `python .github/scripts/semantic_release.py` only writes a local notes file. Confirm branch, commit messages, latest tag, job permission, and GitHub CLI output before retrying.
 
 ## The files that remember things
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If a new test discovers a real bug, ZzzOps files a separate TODO and asks you be
 
 ## Prompt budget
 
-Counts below are a stable cross-harness estimate: `ceil(UTF-8 bytes / 4)`. They are useful for prompt-budget regression, not billing; Codex and Claude Code tokenize differently. Regenerate after any prompt change:
+Counts below are a stable cross-harness estimate: `ceil(canonical UTF-8 bytes / 4)`, with line endings normalized to LF. They are useful for prompt-budget regression, not billing; Codex and Claude Code tokenize differently. Regenerate after any prompt change:
 
 ```powershell
 python .agents/prompt_stats.py
@@ -157,29 +157,29 @@ python .agents/prompt_stats.py --check
 <!-- PROMPT_BUDGET_START -->
 | Prompt | Bytes | Est. tokens |
 | --- | ---: | ---: |
-| `.agents/skills/add-zzzops-todo/SKILL.md` | 747 | 187 |
+| `.agents/skills/add-zzzops-todo/SKILL.md` | 737 | 185 |
 | `.agents/skills/analyze-zzzops-usage/SKILL.md` | 2265 | 567 |
-| `.agents/skills/execute-zzzops/SKILL.md` | 1788 | 447 |
+| `.agents/skills/execute-zzzops/SKILL.md` | 1771 | 443 |
 | `.agents/skills/execute-zzzops/references/CREATE.md` | 2644 | 661 |
-| `.agents/skills/execute-zzzops/references/EXECUTE.md` | 3317 | 830 |
+| `.agents/skills/execute-zzzops/references/EXECUTE.md` | 3285 | 822 |
 | `.agents/skills/execute-zzzops/references/UNBLOCK.md` | 1532 | 383 |
-| `.agents/skills/install-zzzops/SKILL.md` | 1478 | 370 |
-| `.agents/skills/migrate-zzzops-todos/SKILL.md` | 1870 | 468 |
-| `.agents/skills/suggest-zzzops-work/SKILL.md` | 2519 | 630 |
+| `.agents/skills/install-zzzops/SKILL.md` | 1465 | 367 |
+| `.agents/skills/migrate-zzzops-todos/SKILL.md` | 1854 | 464 |
+| `.agents/skills/suggest-zzzops-work/SKILL.md` | 2497 | 625 |
 | `.agents/templates/project-goals/INDEX.md` | 1135 | 284 |
 | `.agents/templates/project-goals/MIGRATION_SUMMARY.md` | 222 | 56 |
 | `.agents/templates/project-goals/PROJECT.md` | 1295 | 324 |
-| `.agents/templates/project-goals/TEMPLATE_DIFF.md` | 359 | 90 |
+| `.agents/templates/project-goals/TEMPLATE_DIFF.md` | 352 | 88 |
 | `.agents/templates/project-goals/USAGE_LEDGER.md` | 1105 | 277 |
-| `.claude/skills/install-zzzops/SKILL.md` | 388 | 97 |
+| `.claude/skills/install-zzzops/SKILL.md` | 382 | 96 |
 | `.zzzops/rules/BLOCKERS.md` | 2213 | 554 |
 | `.zzzops/rules/EXECUTION_STRATEGY.md` | 4861 | 1216 |
-| `.zzzops/rules/GOAL_SYSTEM.md` | 3691 | 923 |
+| `.zzzops/rules/GOAL_SYSTEM.md` | 3641 | 911 |
 | `.zzzops/rules/USAGE_ACCOUNTING.md` | 2355 | 589 |
-| `AGENTS.md` | 2809 | 703 |
+| `AGENTS.md` | 2787 | 697 |
 | `CLAUDE.md` | 217 | 55 |
 | `goals/TEMPLATE.md` | 1648 | 412 |
-| **Total** | **40458** | **10123** |
+| **Total** | **40263** | **10076** |
 <!-- PROMPT_BUDGET_END -->
 
 </details>

--- a/README.md
+++ b/README.md
@@ -176,10 +176,10 @@ python .agents/prompt_stats.py --check
 | `.zzzops/rules/EXECUTION_STRATEGY.md` | 4861 | 1216 |
 | `.zzzops/rules/GOAL_SYSTEM.md` | 3691 | 923 |
 | `.zzzops/rules/USAGE_ACCOUNTING.md` | 2355 | 589 |
-| `AGENTS.md` | 2529 | 633 |
+| `AGENTS.md` | 2809 | 703 |
 | `CLAUDE.md` | 217 | 55 |
 | `goals/TEMPLATE.md` | 1648 | 412 |
-| **Total** | **40178** | **10053** |
+| **Total** | **40458** | **10123** |
 <!-- PROMPT_BUDGET_END -->
 
 </details>

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,33 @@
+# Branch protection
+
+ZzzOps currently uses a private repository on GitHub Free. GitHub returns `403` for both classic branch protection and repository rulesets until the repository becomes public or the owner upgrades to GitHub Pro. The CI workflow is already usable: every PR targeting `dev` runs the read-only required-check candidate `dev-required-tests`.
+
+## Enable protection after Pro/public access
+
+Configure these rules in **Settings → Rules → Rulesets**, then query the saved rules back before relying on them.
+
+### `dev`
+
+- Target only `refs/heads/dev`.
+- Require changes through a pull request; zero approvals is acceptable unless review is desired.
+- Require status check `dev-required-tests` from GitHub Actions and require the branch to be current before merge.
+- Block force pushes and deletion.
+- Give no actor a bypass.
+
+This makes PR CI mandatory. The workflow intentionally has no path filters, dynamic job name, matrix suffix, secrets, or write permission, so the required check is present on every PR into `dev`.
+
+### `main`
+
+GitHub cannot express “the owner may update only by force push.” A user bypass permits that user to make ordinary pushes and PR merges as well. The closest enforceable configuration is:
+
+- Target only `refs/heads/main`.
+- Restrict updates to a bypass for user `david-rzepa` only; do not grant bot, app, role, team, or collaborator bypasses.
+- Permit non-fast-forward updates so the owner can publish the audited single-root release.
+- Use a separate no-bypass rule to block deletion, including by the owner.
+- Keep the root `AGENTS.md` policy: the owner uses the bypass only for an explicitly intended, leased release force-push; ordinary pushes and PR merges to `main` remain forbidden by project policy.
+
+After saving, verify through the GitHub API that `dev` requires `dev-required-tests`, both branches reject deletion, `dev` rejects force pushes/direct updates, and only user `david-rzepa` appears in the `main` update bypass. Never test protection by destructively force-pushing or deleting a branch.
+
+## Recovery
+
+If `dev-required-tests` is renamed, update the rule only after a PR has emitted the new successful check. If CI is broken, fix it through a PR rather than bypassing `dev`. Before any authorized `main` history rewrite, create and verify a local Git bundle and use `--force-with-lease` against the freshly observed remote SHA.

--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -22,7 +22,6 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | Goal | Parent | Priority | Value | Difficulty | Unlocks | Next action |
 | --- | --- | --- | --- | --- | --- | --- |
 | [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | high | M | Enforced branch safety | Inspect capabilities, add PR CI, configure rules if supported. |
-| [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | - | P2 | medium | S | Stable prompt regression | Add LF/CRLF test, normalize, regenerate. |
 
 ## Blocked goals
 | Goal | Priority | Blockers | Recheck trigger | Safe work? |
@@ -35,13 +34,14 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | --- | --- | --- | --- | --- | --- |
 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | blocked | P1 | high | M | Two live `dev` dry runs passed; awaiting `v1.0.0` release approval. |
 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | blocked | P1 | high | M | Repository rename verified; awaiting ZzzOps-path UI check. |
-| [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | ready | P2 | medium | S | Approved; normalization test and fix queued. |
+| [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | done | P2 | medium | S | Canonical LF byte counting and regression test verified. |
 
 ## Recently completed or cancelled
 | Goal | Final status | Date | Evidence/rationale |
 | --- | --- | --- | --- |
 | [G-20260716-003](items/G-20260716-003-document-dev-branch-workflow.md) | done | 2026-07-16 | Work branch descends from `dev`; exact root policy and prompt-budget checks passed. |
 | [G-20260716-005](items/G-20260716-005-document-pr-workflow.md) | done | 2026-07-16 | Root policy now requires `dev`-targeted PRs and intentional atomic commit boundaries. |
+| [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | done | 2026-07-16 | LF/CRLF/CR estimates match; regenerated prompt budget passes. |
 
 ## Portfolio notes
 - Release tooling remains intentionally undecided pending repository investigation.

--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -7,7 +7,6 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | --- | --- | --- | --- | --- | --- |
 | B-001 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | human-action | Reopen checkout at `C:\dev\zzzops` and verify Codex group label. | Final branding verification only. | 2026-07-16 |
 | B-002 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | access-approval | Authorize integrating `dev` into `main` to publish expected `v1.0.0`. | Final production-release verification. | 2026-07-16 |
-| B-006 | [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | technical-unknown | Upgrade to Pro or make public; accept closest owner-bypass semantics. | Branch protection cannot otherwise be configured/verified. | 2026-07-16 |
 
 ## Active claims
 | Goal | Owner | Claimed | Expires | Checkpoint |
@@ -29,7 +28,6 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | --- | --- | --- | --- | --- |
 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | P1 | B-001 `human-action` | Workspace reopened at `C:\dev\zzzops` | No repository work remains; release goal is safe. |
 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | B-002 `access-approval` | Explicit first-release authorization | No safe production-release work remains. |
-| [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | P1 | B-005 access; B-006 capability | GitHub auth restored and plan/policy chosen | CI is published; no remaining unauthenticated work. |
 
 ## Root goals
 | Goal | Status | Priority | Value | Difficulty | Progress summary |
@@ -45,6 +43,7 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | [G-20260716-003](items/G-20260716-003-document-dev-branch-workflow.md) | done | 2026-07-16 | Work branch descends from `dev`; exact root policy and prompt-budget checks passed. |
 | [G-20260716-005](items/G-20260716-005-document-pr-workflow.md) | done | 2026-07-16 | Root policy now requires `dev`-targeted PRs and intentional atomic commit boundaries. |
 | [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | done | 2026-07-16 | LF/CRLF/CR estimates match; regenerated prompt budget passes. |
+| [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | done | 2026-07-16 | PR #1 passed `dev-required-tests`; Free-plan limitation and exact manual fallback documented. |
 
 ## Portfolio notes
 - Release tooling remains intentionally undecided pending repository investigation.

--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -21,7 +21,6 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 ## Ready queue
 | Goal | Parent | Priority | Value | Difficulty | Unlocks | Next action |
 | --- | --- | --- | --- | --- | --- | --- |
-| [G-20260716-005](items/G-20260716-005-document-pr-workflow.md) | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | high | S | PR workflow safety | Update and scenario-check root guidance. |
 | [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | high | M | Enforced branch safety | Inspect capabilities, add PR CI, configure rules if supported. |
 | [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | - | P2 | medium | S | Stable prompt regression | Add LF/CRLF test, normalize, regenerate. |
 
@@ -42,6 +41,7 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | Goal | Final status | Date | Evidence/rationale |
 | --- | --- | --- | --- |
 | [G-20260716-003](items/G-20260716-003-document-dev-branch-workflow.md) | done | 2026-07-16 | Work branch descends from `dev`; exact root policy and prompt-budget checks passed. |
+| [G-20260716-005](items/G-20260716-005-document-pr-workflow.md) | done | 2026-07-16 | Root policy now requires `dev`-targeted PRs and intentional atomic commit boundaries. |
 
 ## Portfolio notes
 - Release tooling remains intentionally undecided pending repository investigation.

--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -7,6 +7,7 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | --- | --- | --- | --- | --- | --- |
 | B-001 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | human-action | Reopen checkout at `C:\dev\zzzops` and verify Codex group label. | Final branding verification only. | 2026-07-16 |
 | B-002 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | access-approval | Authorize integrating `dev` into `main` to publish expected `v1.0.0`. | Final production-release verification. | 2026-07-16 |
+| B-006 | [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | technical-unknown | Upgrade to Pro or make public; accept closest owner-bypass semantics. | Branch protection cannot otherwise be configured/verified. | 2026-07-16 |
 
 ## Active claims
 | Goal | Owner | Claimed | Expires | Checkpoint |
@@ -16,18 +17,19 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 ## New goals awaiting triage
 | Goal | Priority | Created | Provisional outcome |
 | --- | --- | --- | --- |
-| None | - | - | - |
+| [G-20260716-007](items/G-20260716-007-squash-v1-main-history.md) | P1 | 2026-07-16 | Publish the completed first release as the sole `main` root commit tagged `v1.0.0`. |
 
 ## Ready queue
 | Goal | Parent | Priority | Value | Difficulty | Unlocks | Next action |
 | --- | --- | --- | --- | --- | --- | --- |
-| [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | high | M | Enforced branch safety | Inspect capabilities, add PR CI, configure rules if supported. |
+| None | - | - | - | - | - | - |
 
 ## Blocked goals
 | Goal | Priority | Blockers | Recheck trigger | Safe work? |
 | --- | --- | --- | --- | --- |
 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | P1 | B-001 `human-action` | Workspace reopened at `C:\dev\zzzops` | No repository work remains; release goal is safe. |
 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | B-002 `access-approval` | Explicit first-release authorization | No safe production-release work remains. |
+| [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | P1 | B-005 access; B-006 capability | GitHub auth restored and plan/policy chosen | CI is published; no remaining unauthenticated work. |
 
 ## Root goals
 | Goal | Status | Priority | Value | Difficulty | Progress summary |
@@ -35,6 +37,7 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | blocked | P1 | high | M | Two live `dev` dry runs passed; awaiting `v1.0.0` release approval. |
 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | blocked | P1 | high | M | Repository rename verified; awaiting ZzzOps-path UI check. |
 | [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | done | P2 | medium | S | Canonical LF byte counting and regression test verified. |
+| [G-20260716-007](items/G-20260716-007-squash-v1-main-history.md) | new | P1 | high | M | Terminal squash/release goal; gated by all earlier incomplete work. |
 
 ## Recently completed or cancelled
 | Goal | Final status | Date | Evidence/rationale |

--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -7,7 +7,6 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | --- | --- | --- | --- | --- | --- |
 | B-001 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | human-action | Reopen checkout at `C:\dev\zzzops` and verify Codex group label. | Final branding verification only. | 2026-07-16 |
 | B-002 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | access-approval | Authorize integrating `dev` into `main` to publish expected `v1.0.0`. | Final production-release verification. | 2026-07-16 |
-| B-003 | [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | decision | Approve isolated prompt-count normalization fix. | Stable cross-platform regression counts. | 2026-07-16 |
 
 ## Active claims
 | Goal | Owner | Claimed | Expires | Checkpoint |
@@ -22,21 +21,22 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 ## Ready queue
 | Goal | Parent | Priority | Value | Difficulty | Unlocks | Next action |
 | --- | --- | --- | --- | --- | --- | --- |
-| None | - | - | - | - | - | - |
+| [G-20260716-005](items/G-20260716-005-document-pr-workflow.md) | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | high | S | PR workflow safety | Update and scenario-check root guidance. |
+| [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | high | M | Enforced branch safety | Inspect capabilities, add PR CI, configure rules if supported. |
+| [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | - | P2 | medium | S | Stable prompt regression | Add LF/CRLF test, normalize, regenerate. |
 
 ## Blocked goals
 | Goal | Priority | Blockers | Recheck trigger | Safe work? |
 | --- | --- | --- | --- | --- |
 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | P1 | B-001 `human-action` | Workspace reopened at `C:\dev\zzzops` | No repository work remains; release goal is safe. |
 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | B-002 `access-approval` | Explicit first-release authorization | No safe production-release work remains. |
-| [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | P2 | B-003 `decision` | Human approves isolated bug fix | None before approval. |
 
 ## Root goals
 | Goal | Status | Priority | Value | Difficulty | Progress summary |
 | --- | --- | --- | --- | --- | --- |
 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | blocked | P1 | high | M | Two live `dev` dry runs passed; awaiting `v1.0.0` release approval. |
 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | blocked | P1 | high | M | Repository rename verified; awaiting ZzzOps-path UI check. |
-| [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | blocked | P2 | medium | S | Test-discovered portability bug awaits human approval. |
+| [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | ready | P2 | medium | S | Approved; normalization test and fix queued. |
 
 ## Recently completed or cancelled
 | Goal | Final status | Date | Evidence/rationale |

--- a/goals/USAGE_LEDGER.md
+++ b/goals/USAGE_LEDGER.md
@@ -16,6 +16,7 @@ Append only; corrections identify superseded rows. Follow `.zzzops/rules/USAGE_A
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-005 | Completed and verified dev-targeted PR/commit guidance | - | - | - | - | unavailable | n/a | Ancestry, exact-text, and prompt-budget probes passed. |
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-004 | Fixed line-ending-dependent prompt counts | - | - | - | - | unavailable | n/a | Focused LF/CRLF/CR regression and repository check passed. |
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-006 | Implemented/published PR CI; inspected GitHub protection capability | - | - | - | - | unavailable | n/a | Local checks pass; auth and private Free-plan limitations block live PR/settings completion. |
+| R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-006 | Verified live PR CI and documented protection fallback | - | - | - | - | unavailable | n/a | Run 29537194082 passed; API 403 and force-only semantic limitation documented. |
 
 ## Limit snapshots
 | Run ID | Date/time | Source | Context | Rate/credit state | Notes |

--- a/goals/USAGE_LEDGER.md
+++ b/goals/USAGE_LEDGER.md
@@ -14,6 +14,7 @@ Append only; corrections identify superseded rows. Follow `.zzzops/rules/USAGE_A
 | R-20260716-1500-root | root/goal-management | 2026-07-16 | G-20260716-004 | Captured test-discovered prompt-count portability bug | - | - | - | - | unavailable | n/a | No fix attempted; decision blocker queued per project policy. |
 | R-20260716-queued-root | root/goal-management | 2026-07-16 | portfolio | Triaged G-005/G-006 and resolved G-004 approval | - | - | - | - | unavailable | n/a | No callable exact token counter; work branch created from `dev`. |
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-005 | Completed and verified dev-targeted PR/commit guidance | - | - | - | - | unavailable | n/a | Ancestry, exact-text, and prompt-budget probes passed. |
+| R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-004 | Fixed line-ending-dependent prompt counts | - | - | - | - | unavailable | n/a | Focused LF/CRLF/CR regression and repository check passed. |
 
 ## Limit snapshots
 | Run ID | Date/time | Source | Context | Rate/credit state | Notes |

--- a/goals/USAGE_LEDGER.md
+++ b/goals/USAGE_LEDGER.md
@@ -12,6 +12,7 @@ Append only; corrections identify superseded rows. Follow `.zzzops/rules/USAGE_A
 | R-20260716-1500-root | root/goal-work | 2026-07-16 | G-20260716-001 | Implemented and locally verified semantic release automation | - | - | - | - | unavailable | n/a | Six synthetic/history tests and real-repository dry run passed; live CI pending. |
 | R-20260716-1500-root | root/goal-work | 2026-07-16 | G-20260716-001 | Verified two live `dev` dry runs with no remote release mutation | - | - | - | - | unavailable | n/a | Runs 29535036331 and 29535149186 passed; production release requires explicit approval. |
 | R-20260716-1500-root | root/goal-management | 2026-07-16 | G-20260716-004 | Captured test-discovered prompt-count portability bug | - | - | - | - | unavailable | n/a | No fix attempted; decision blocker queued per project policy. |
+| R-20260716-queued-root | root/goal-management | 2026-07-16 | portfolio | Triaged G-005/G-006 and resolved G-004 approval | - | - | - | - | unavailable | n/a | No callable exact token counter; work branch created from `dev`. |
 
 ## Limit snapshots
 | Run ID | Date/time | Source | Context | Rate/credit state | Notes |

--- a/goals/USAGE_LEDGER.md
+++ b/goals/USAGE_LEDGER.md
@@ -13,6 +13,7 @@ Append only; corrections identify superseded rows. Follow `.zzzops/rules/USAGE_A
 | R-20260716-1500-root | root/goal-work | 2026-07-16 | G-20260716-001 | Verified two live `dev` dry runs with no remote release mutation | - | - | - | - | unavailable | n/a | Runs 29535036331 and 29535149186 passed; production release requires explicit approval. |
 | R-20260716-1500-root | root/goal-management | 2026-07-16 | G-20260716-004 | Captured test-discovered prompt-count portability bug | - | - | - | - | unavailable | n/a | No fix attempted; decision blocker queued per project policy. |
 | R-20260716-queued-root | root/goal-management | 2026-07-16 | portfolio | Triaged G-005/G-006 and resolved G-004 approval | - | - | - | - | unavailable | n/a | No callable exact token counter; work branch created from `dev`. |
+| R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-005 | Completed and verified dev-targeted PR/commit guidance | - | - | - | - | unavailable | n/a | Ancestry, exact-text, and prompt-budget probes passed. |
 
 ## Limit snapshots
 | Run ID | Date/time | Source | Context | Rate/credit state | Notes |

--- a/goals/USAGE_LEDGER.md
+++ b/goals/USAGE_LEDGER.md
@@ -15,6 +15,7 @@ Append only; corrections identify superseded rows. Follow `.zzzops/rules/USAGE_A
 | R-20260716-queued-root | root/goal-management | 2026-07-16 | portfolio | Triaged G-005/G-006 and resolved G-004 approval | - | - | - | - | unavailable | n/a | No callable exact token counter; work branch created from `dev`. |
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-005 | Completed and verified dev-targeted PR/commit guidance | - | - | - | - | unavailable | n/a | Ancestry, exact-text, and prompt-budget probes passed. |
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-004 | Fixed line-ending-dependent prompt counts | - | - | - | - | unavailable | n/a | Focused LF/CRLF/CR regression and repository check passed. |
+| R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-006 | Implemented/published PR CI; inspected GitHub protection capability | - | - | - | - | unavailable | n/a | Local checks pass; auth and private Free-plan limitations block live PR/settings completion. |
 
 ## Limit snapshots
 | Run ID | Date/time | Source | Context | Rate/credit state | Notes |

--- a/goals/items/G-20260716-001-automate-semantic-releases.md
+++ b/goals/items/G-20260716-001-automate-semantic-releases.md
@@ -70,7 +70,7 @@ ZzzOps derives semantic versions from repository history and publishes reproduci
 ## Relationships
 
 - Parent: none
-- Children (required/optional + purpose/status): [G-20260716-003](G-20260716-003-document-dev-branch-workflow.md) (required; initial `dev`-first Git/release guidance; `done`); [G-20260716-005](G-20260716-005-document-pr-workflow.md) (required; document `dev`-targeted PR and atomic commit policy; `done`); [G-20260716-006](G-20260716-006-protect-main-and-dev.md) (required; enforce protected branches and PR validation; `ready`).
+- Children (required/optional + purpose/status): [G-20260716-003](G-20260716-003-document-dev-branch-workflow.md) (required; initial `dev`-first Git/release guidance; `done`); [G-20260716-005](G-20260716-005-document-pr-workflow.md) (required; document `dev`-targeted PR and atomic commit policy; `done`); [G-20260716-006](G-20260716-006-protect-main-and-dev.md) (required; PR CI plus protection/fallback; `done`).
 - Dependencies (status/reason): none recorded; repository settings or branch creation may become a human-action blocker during investigation.
 - Blocks (impact): none recorded.
 
@@ -108,3 +108,4 @@ Shared planner, tests, workflow, and docs are on `dev`. Live dry runs `295350363
 | 2026-07-16 | Codex/R-20260716-1500-root | `dev` verified; set `blocked` | Two live dry runs passed with no remote mutation; explicit approval is required before the first `main` release. |
 | 2026-07-16 | Codex | Added required children `G-20260716-005` and `G-20260716-006` | User expanded the release-safety workflow with PR/commit guidance and GitHub enforcement. |
 | 2026-07-16 | Codex/R-20260716-queued | Required child `G-20260716-005` completed | PR/commit policy is now explicit in root instructions. |
+| 2026-07-16 | Codex/R-20260716-queued | Required child `G-20260716-006` completed | Live PR CI passed; unavailable protection is covered by the user's documented manual fallback. |

--- a/goals/items/G-20260716-001-automate-semantic-releases.md
+++ b/goals/items/G-20260716-001-automate-semantic-releases.md
@@ -70,7 +70,7 @@ ZzzOps derives semantic versions from repository history and publishes reproduci
 ## Relationships
 
 - Parent: none
-- Children (required/optional + purpose/status): [G-20260716-003](G-20260716-003-document-dev-branch-workflow.md) (required; initial `dev`-first Git/release guidance; `done`); [G-20260716-005](G-20260716-005-document-pr-workflow.md) (required; document `dev`-targeted PR and atomic commit policy; `new`); [G-20260716-006](G-20260716-006-protect-main-and-dev.md) (required; enforce protected branches and PR validation; `new`).
+- Children (required/optional + purpose/status): [G-20260716-003](G-20260716-003-document-dev-branch-workflow.md) (required; initial `dev`-first Git/release guidance; `done`); [G-20260716-005](G-20260716-005-document-pr-workflow.md) (required; document `dev`-targeted PR and atomic commit policy; `done`); [G-20260716-006](G-20260716-006-protect-main-and-dev.md) (required; enforce protected branches and PR validation; `ready`).
 - Dependencies (status/reason): none recorded; repository settings or branch creation may become a human-action blocker during investigation.
 - Blocks (impact): none recorded.
 
@@ -107,3 +107,4 @@ Shared planner, tests, workflow, and docs are on `dev`. Live dry runs `295350363
 | 2026-07-16 | Codex/R-20260716-1500-root | Local implementation checkpoint | Six tests and real-history dry run passed; ready for live `dev` verification. |
 | 2026-07-16 | Codex/R-20260716-1500-root | `dev` verified; set `blocked` | Two live dry runs passed with no remote mutation; explicit approval is required before the first `main` release. |
 | 2026-07-16 | Codex | Added required children `G-20260716-005` and `G-20260716-006` | User expanded the release-safety workflow with PR/commit guidance and GitHub enforcement. |
+| 2026-07-16 | Codex/R-20260716-queued | Required child `G-20260716-005` completed | PR/commit policy is now explicit in root instructions. |

--- a/goals/items/G-20260716-001-automate-semantic-releases.md
+++ b/goals/items/G-20260716-001-automate-semantic-releases.md
@@ -70,7 +70,7 @@ ZzzOps derives semantic versions from repository history and publishes reproduci
 ## Relationships
 
 - Parent: none
-- Children (required/optional + purpose/status): [G-20260716-003](G-20260716-003-document-dev-branch-workflow.md) (required; document the `dev`-first Git and `main` release workflow; `done`). Create further implementation sub-goals after investigation if the workflow and test harness are independently verifiable.
+- Children (required/optional + purpose/status): [G-20260716-003](G-20260716-003-document-dev-branch-workflow.md) (required; initial `dev`-first Git/release guidance; `done`); [G-20260716-005](G-20260716-005-document-pr-workflow.md) (required; document `dev`-targeted PR and atomic commit policy; `new`); [G-20260716-006](G-20260716-006-protect-main-and-dev.md) (required; enforce protected branches and PR validation; `new`).
 - Dependencies (status/reason): none recorded; repository settings or branch creation may become a human-action blocker during investigation.
 - Blocks (impact): none recorded.
 
@@ -106,3 +106,4 @@ Shared planner, tests, workflow, and docs are on `dev`. Live dry runs `295350363
 | 2026-07-16 | Codex/R-20260716-1500-root | Required child `G-20260716-003` completed | Root policy is documented; this parent must now implement its stated `main` behavior. |
 | 2026-07-16 | Codex/R-20260716-1500-root | Local implementation checkpoint | Six tests and real-history dry run passed; ready for live `dev` verification. |
 | 2026-07-16 | Codex/R-20260716-1500-root | `dev` verified; set `blocked` | Two live dry runs passed with no remote mutation; explicit approval is required before the first `main` release. |
+| 2026-07-16 | Codex | Added required children `G-20260716-005` and `G-20260716-006` | User expanded the release-safety workflow with PR/commit guidance and GitHub enforcement. |

--- a/goals/items/G-20260716-004-stabilize-prompt-budget-line-endings.md
+++ b/goals/items/G-20260716-004-stabilize-prompt-budget-line-endings.md
@@ -1,7 +1,7 @@
 ---
 id: G-20260716-004-stabilize-prompt-budget-line-endings
 title: Make prompt-budget counts line-ending invariant
-status: blocked
+status: ready
 priority: P2
 value: medium
 difficulty: S
@@ -15,7 +15,7 @@ review_after: null
 parent: null
 depends_on: []
 blocks: []
-needs_human: true
+needs_human: false
 tags: [bug, prompt-budget, portability, tests]
 external_refs: [".agents/prompt_stats.py:33", "README.md:147"]
 claim: {owner: null, claimed_at: null, expires_at: null}
@@ -76,26 +76,27 @@ Prompt-budget estimates remain identical across Git line-ending conversion and s
 
 ### Open
 
-### B-003 - Authorize prompt-count bug fix
-- Status/category/raised/owner: open / `decision` / 2026-07-16 / user
-- Blocks: implementation of the line-ending normalization fix
-- Question or required action: confirm whether to fix this newly discovered portability bug in the next ZzzOps run.
-- Why/options/recommendation: fixing it makes the advertised regression metric stable; recommended approve as a small isolated follow-up, but it is unrelated to release correctness.
-- Evidence gathered: totals changed from 39,983 to 40,178 bytes solely across checkout line-ending conversion.
-- Continuation: `stop-affected-work`
-- Safe work remaining/recheck trigger: none for this goal; recheck on user decision.
-- Resolution/resolved/resolved by: pending
+None.
 
 ### Resolved
 
-None.
+### B-003 - Authorize prompt-count bug fix
+- Status/category/raised/owner: resolved / `decision` / 2026-07-16 / user
+- Blocks: resolved
+- Question or required action: approve the isolated line-ending normalization fix.
+- Why/options/recommendation: approved through the user's instruction to complete all queued work.
+- Evidence gathered: totals changed from 39,983 to 40,178 bytes solely across checkout line-ending conversion.
+- Continuation: `stop-affected-work`
+- Safe work remaining/recheck trigger: goal is actionable.
+- Resolution/resolved/resolved by: fix approved / 2026-07-16 / user
 
 ## Progress and evidence
 
-Bug captured with source lines and reproduction evidence. Current README table was regenerated but production calculation was not changed.
+Bug captured with source lines and reproduction evidence. User authorized completing all queued work; implementation is ready.
 
 ## History
 
 | Date | Actor/run | Change | Reason/evidence |
 | --- | --- | --- | --- |
 | 2026-07-16 | Codex/R-20260716-1500-root | Created `blocked` | Combined release verification exposed platform-dependent prompt counts; policy forbids fixing a test-discovered bug without human input. |
+| 2026-07-16 | user/Codex | Resolved `B-003`; set `ready` | User instructed `$execute-zzzops` to complete all queued work. |

--- a/goals/items/G-20260716-004-stabilize-prompt-budget-line-endings.md
+++ b/goals/items/G-20260716-004-stabilize-prompt-budget-line-endings.md
@@ -1,12 +1,12 @@
 ---
 id: G-20260716-004-stabilize-prompt-budget-line-endings
 title: Make prompt-budget counts line-ending invariant
-status: ready
+status: done
 priority: P2
 value: medium
 difficulty: S
 confidence: high
-owner: unassigned
+owner: Codex
 created: 2026-07-16
 updated: 2026-07-16
 target_date: null
@@ -29,10 +29,10 @@ Prompt-budget estimates remain identical across Git line-ending conversion and s
 
 ## Success criteria
 
-- [ ] A focused test proves logically identical LF and CRLF prompt content yields the same byte/token estimate.
-- [ ] `.agents/prompt_stats.py` computes counts from a documented canonical representation without changing prompt content.
-- [ ] Existing prompt-budget regeneration/check behavior remains deterministic and passes on the repository.
-- [ ] README accurately describes the normalization and estimate limits.
+- [x] A focused test proves logically identical LF, CRLF, and CR prompt content yields the same byte estimate. Evidence: `.agents/test_prompt_stats.py` passes.
+- [x] `.agents/prompt_stats.py` computes counts from a documented canonical representation without changing prompt content. Evidence: `canonical_size` normalizes byte line endings to LF before counting.
+- [x] Existing prompt-budget regeneration/check behavior remains deterministic and passes on the repository. Evidence: regeneration followed by `--check` reports 22 prompts, 40,263 bytes, ~10,076 tokens.
+- [x] README accurately describes the normalization and estimate limits. Evidence: Prompt budget section specifies canonical UTF-8 bytes and LF normalization.
 
 ## Scope
 
@@ -56,7 +56,7 @@ Prompt-budget estimates remain identical across Git line-ending conversion and s
 - Observation surface (test/harness/API/UI/log/MCP/etc.): Focused Python unit test and `.agents/prompt_stats.py --check`.
 - Smallest chunk: Extract canonical byte-count calculation and test LF/CRLF equivalence.
 - Probe/action and expected signal: Both encodings return identical byte/token values; current script does not.
-- Actual result/evidence: Bug reproduced through the failed check; no fix attempted.
+- Actual result/evidence: Regression first failed with missing normalization API, then passed for LF/CRLF/CR after the smallest production change; repository regeneration/check passed.
 - Wider checks after local proof: Regenerate README and repeat after a Git checkout on Windows.
 
 ### Execution constraints
@@ -92,7 +92,7 @@ None.
 
 ## Progress and evidence
 
-Bug captured with source lines and reproduction evidence. User authorized completing all queued work; implementation is ready.
+Completed with one canonical byte-count function and focused regression test; prompt content remains untouched.
 
 ## History
 
@@ -100,3 +100,4 @@ Bug captured with source lines and reproduction evidence. User authorized comple
 | --- | --- | --- | --- |
 | 2026-07-16 | Codex/R-20260716-1500-root | Created `blocked` | Combined release verification exposed platform-dependent prompt counts; policy forbids fixing a test-discovered bug without human input. |
 | 2026-07-16 | user/Codex | Resolved `B-003`; set `ready` | User instructed `$execute-zzzops` to complete all queued work. |
+| 2026-07-16 | Codex/R-20260716-queued | Completed `done` | LF/CRLF/CR regression and repository prompt-budget checks passed. |

--- a/goals/items/G-20260716-005-document-pr-workflow.md
+++ b/goals/items/G-20260716-005-document-pr-workflow.md
@@ -1,0 +1,96 @@
+---
+id: G-20260716-005-document-pr-workflow
+title: Document the dev-targeted pull request workflow
+status: ready
+priority: P1
+value: high
+difficulty: S
+confidence: high
+owner: unassigned
+created: 2026-07-16
+updated: 2026-07-16
+target_date: null
+last_reviewed: 2026-07-16
+review_after: null
+parent: G-20260716-001-automate-semantic-releases
+depends_on: []
+blocks: []
+needs_human: false
+tags: [git, pull-requests, agents, commits, release-safety]
+external_refs: ["user-request:2026-07-16"]
+claim: {owner: null, claimed_at: null, expires_at: null}
+---
+
+# G-20260716-005-document-pr-workflow - Document the dev-targeted pull request workflow
+
+## Outcome / Why
+
+Root `AGENTS.md` gives agents one complete contribution path: branch from `dev`, make reviewable commits, open pull requests targeting `dev`, and reserve `main` for the release path. Commit structure balances reviewability with atomic rollback safety.
+
+## Success criteria
+
+- [ ] Root `AGENTS.md` requires every ordinary work branch to start from current `dev` and every ordinary PR to target `dev`, never `main`.
+- [ ] Guidance permits large features to contain smaller coherent commits when that aids review, testing, or partial integration.
+- [ ] Guidance prefers squashing changes that are only valid together into one atomic semantic commit so incomplete units are not independently merged or reverted.
+- [ ] Guidance explains that independently useful/revertible changes should remain separate commits, making partial rollback safer rather than mechanically squashing every PR.
+- [ ] The new wording is concise, consistent with actual branch protection/release CI, and does not alter installed projects' `AGENTS.md`.
+- [ ] README prompt-budget counts are regenerated and `.agents/prompt_stats.py --check` passes.
+
+## Scope
+
+- In: This repository's root `AGENTS.md`, minimal consistency updates, prompt-budget accounting, and scenario-based documentation checks.
+- Out: GitHub ruleset configuration, merging a PR, changing installed project instructions, or prescribing one commit per entire feature regardless of separability.
+
+## Context and decisions
+
+- User requested this goal on 2026-07-16 after `G-20260716-003` documented the initial `dev`-first rule.
+- This extends rather than invalidates `G-20260716-003`: branches originate from `dev`, PRs target `dev`, and only intended releases advance to `main`.
+- User preference: large work may use smaller commits, but work that is all required together should ideally be squashed to preserve atomic rollback behavior.
+
+## Approach and next action
+
+**Next action:** Draft one compact replacement for the existing `AGENTS.md` Git paragraph, then scenario-check branch source, PR target, separable commits, inseparable commits, partial revert, and release behavior before editing.
+
+### Fast feedback
+
+- Baseline/current observable behavior: `AGENTS.md:21` defines branch source/integration target but does not explicitly require PRs or explain commit grouping.
+- Hypothesis: One short expanded paragraph can encode the complete workflow without burdening every agent prompt.
+- Observation surface (test/harness/API/UI/log/MCP/etc.): Root `AGENTS.md`, representative workflow scenarios, prompt-budget check, and GitHub branch settings from the enforcement sibling.
+- Smallest chunk: Add only PR target and atomic-commit guidance to the existing paragraph.
+- Probe/action and expected signal: Six representative scenarios each yield one unambiguous branch/PR/commit action.
+- Actual result/evidence: Not run.
+- Wider checks after local proof: Compare against live rulesets and CI triggers, then regenerate prompt counts.
+
+### Execution constraints
+
+- Mode: `sequential`
+- Parallel exception: none
+- Resources/shared state: Root `AGENTS.md`, README prompt-budget table, `dev`, and `main`.
+
+## Relationships
+
+- Parent: [G-20260716-001](G-20260716-001-automate-semantic-releases.md)
+- Children (required/optional + purpose/status): none
+- Dependencies (status/reason): none; coordinate wording with sibling `G-20260716-006` so policy and enforcement agree.
+- Blocks (impact): none directly; incomplete guidance increases accidental `main` PR/release risk.
+
+## Blockers
+
+### Open
+
+None.
+
+### Resolved
+
+None.
+
+## Progress and evidence
+
+Triaged as an actionable small documentation goal. The existing `AGENTS.md:21` paragraph is the exact edit surface and the sibling enforcement goal supplies the consistency boundary.
+
+## History
+
+| Date | Actor/run | Change | Reason/evidence |
+| --- | --- | --- | --- |
+| 2026-07-16 | Codex | Created `new` | User requested explicit `dev`-origin/target PR rules and atomic-but-reviewable commit guidance. |
+| 2026-07-16 | Codex/R-20260716-queued | Triaged `ready` | Scope, scenarios, edit surface, and verification are concrete. |

--- a/goals/items/G-20260716-005-document-pr-workflow.md
+++ b/goals/items/G-20260716-005-document-pr-workflow.md
@@ -1,12 +1,12 @@
 ---
 id: G-20260716-005-document-pr-workflow
 title: Document the dev-targeted pull request workflow
-status: ready
+status: done
 priority: P1
 value: high
 difficulty: S
 confidence: high
-owner: unassigned
+owner: Codex
 created: 2026-07-16
 updated: 2026-07-16
 target_date: null
@@ -29,12 +29,12 @@ Root `AGENTS.md` gives agents one complete contribution path: branch from `dev`,
 
 ## Success criteria
 
-- [ ] Root `AGENTS.md` requires every ordinary work branch to start from current `dev` and every ordinary PR to target `dev`, never `main`.
-- [ ] Guidance permits large features to contain smaller coherent commits when that aids review, testing, or partial integration.
-- [ ] Guidance prefers squashing changes that are only valid together into one atomic semantic commit so incomplete units are not independently merged or reverted.
-- [ ] Guidance explains that independently useful/revertible changes should remain separate commits, making partial rollback safer rather than mechanically squashing every PR.
-- [ ] The new wording is concise, consistent with actual branch protection/release CI, and does not alter installed projects' `AGENTS.md`.
-- [ ] README prompt-budget counts are regenerated and `.agents/prompt_stats.py --check` passes.
+- [x] Root `AGENTS.md` requires every ordinary work branch to start from current `dev` and every ordinary PR to target `dev`, never `main`. Evidence: `AGENTS.md:21`; branch ancestry probe passed.
+- [x] Guidance permits large features to contain smaller coherent commits when that aids review, testing, or partial rollback. Evidence: `AGENTS.md:21` exact-text probe.
+- [x] Guidance prefers squashing changes that are only valid together into one atomic semantic commit so incomplete units are not independently merged or reverted. Evidence: `AGENTS.md:21`.
+- [x] Guidance explains that independently useful/revertible changes should remain separate commits, making partial rollback safer rather than mechanically squashing every PR. Evidence: `AGENTS.md:21`.
+- [x] The new wording is concise, consistent with release CI and intended protection, and does not alter installed projects' `AGENTS.md`. Evidence: one root-only paragraph changed.
+- [x] README prompt-budget counts are regenerated and `.agents/prompt_stats.py --check` passes. Evidence: 22 prompts, 40,458 bytes, ~10,123 estimated tokens.
 
 ## Scope
 
@@ -58,7 +58,7 @@ Root `AGENTS.md` gives agents one complete contribution path: branch from `dev`,
 - Observation surface (test/harness/API/UI/log/MCP/etc.): Root `AGENTS.md`, representative workflow scenarios, prompt-budget check, and GitHub branch settings from the enforcement sibling.
 - Smallest chunk: Add only PR target and atomic-commit guidance to the existing paragraph.
 - Probe/action and expected signal: Six representative scenarios each yield one unambiguous branch/PR/commit action.
-- Actual result/evidence: Not run.
+- Actual result/evidence: Work branch descends from `dev`; all six policy phrases found at `AGENTS.md:21`; prompt-budget check passed.
 - Wider checks after local proof: Compare against live rulesets and CI triggers, then regenerate prompt counts.
 
 ### Execution constraints
@@ -86,7 +86,7 @@ None.
 
 ## Progress and evidence
 
-Triaged as an actionable small documentation goal. The existing `AGENTS.md:21` paragraph is the exact edit surface and the sibling enforcement goal supplies the consistency boundary.
+Completed. Root guidance now covers branch origin, PR target, coherent feature commits, atomic squashing, partial rollback, and owner-only release updates.
 
 ## History
 
@@ -94,3 +94,4 @@ Triaged as an actionable small documentation goal. The existing `AGENTS.md:21` p
 | --- | --- | --- | --- |
 | 2026-07-16 | Codex | Created `new` | User requested explicit `dev`-origin/target PR rules and atomic-but-reviewable commit guidance. |
 | 2026-07-16 | Codex/R-20260716-queued | Triaged `ready` | Scope, scenarios, edit surface, and verification are concrete. |
+| 2026-07-16 | Codex/R-20260716-queued | Completed `done` | Branch ancestry, exact policy text, and prompt-budget probes passed. |

--- a/goals/items/G-20260716-006-protect-main-and-dev.md
+++ b/goals/items/G-20260716-006-protect-main-and-dev.md
@@ -1,12 +1,12 @@
 ---
 id: G-20260716-006-protect-main-and-dev
 title: Protect main and require validated PRs to dev
-status: ready
+status: in_progress
 priority: P1
 value: high
 difficulty: M
 confidence: medium
-owner: unassigned
+owner: Codex
 created: 2026-07-16
 updated: 2026-07-16
 target_date: null
@@ -18,7 +18,7 @@ blocks: []
 needs_human: false
 tags: [github, branch-protection, rulesets, ci, pull-requests, release-safety]
 external_refs: ["https://github.com/david-rzepa/zzzops", "user-request:2026-07-16"]
-claim: {owner: null, claimed_at: null, expires_at: null}
+claim: {owner: Codex, claimed_at: "2026-07-16T15:30:00-06:00", expires_at: "2026-07-16T19:30:00-06:00"}
 ---
 
 # G-20260716-006-protect-main-and-dev - Protect main and require validated PRs to dev

--- a/goals/items/G-20260716-006-protect-main-and-dev.md
+++ b/goals/items/G-20260716-006-protect-main-and-dev.md
@@ -1,0 +1,106 @@
+---
+id: G-20260716-006-protect-main-and-dev
+title: Protect main and require validated PRs to dev
+status: ready
+priority: P1
+value: high
+difficulty: M
+confidence: medium
+owner: unassigned
+created: 2026-07-16
+updated: 2026-07-16
+target_date: null
+last_reviewed: 2026-07-16
+review_after: null
+parent: G-20260716-001-automate-semantic-releases
+depends_on: []
+blocks: []
+needs_human: false
+tags: [github, branch-protection, rulesets, ci, pull-requests, release-safety]
+external_refs: ["https://github.com/david-rzepa/zzzops", "user-request:2026-07-16"]
+claim: {owner: null, claimed_at: null, expires_at: null}
+---
+
+# G-20260716-006-protect-main-and-dev - Protect main and require validated PRs to dev
+
+## Outcome / Why
+
+GitHub enforces the repository workflow: `main` cannot change through ordinary work, while `dev` changes arrive through pull requests whose required CI validation passes. Any owner bypass is narrow, explicit, and verified rather than weakening protection for agents or collaborators.
+
+## Success criteria
+
+- [ ] Inspect repository plan/features and current rules using GitHub CLI/API, then document whether classic branch protection or repository rulesets best express the requested policy.
+- [ ] `main` rejects every update path except force pushes performed by repository owner `david-rzepa`; ordinary pushes, PR merges, deletions, bots, collaborators, and other bypass paths cannot change it.
+- [ ] `dev` requires a pull request and a passing, stable required check before merge; direct pushes and force pushes are rejected.
+- [ ] CI contains a deterministic PR validation job that runs for PRs targeting `dev`, uses read-only permissions, and exercises the relevant release-planner and repository checks.
+- [ ] Required-check names are stable and match the configured GitHub rule exactly, including the no-work/no-release path.
+- [ ] Controlled GitHub/API evidence shows the rules encode owner-only force-push access and reject every other `main` update path, without actually force-pushing, deleting branches, or publishing a release.
+- [ ] Maintainer documentation records the rules, bypass semantics, recovery path, and any GitHub-plan limitation.
+
+## Scope
+
+- In: GitHub branch protection/rulesets when supported, PR-targeted CI validation, minimal docs, read-only inspection, and reversible repository-setting updates after review.
+- Out: Performing a destructive force push, weakening release CI, granting bots broad bypass, changing organization-wide policy, or merging/releasing as part of configuration.
+
+## Context and decisions
+
+- User requested this goal on 2026-07-16: protect `main`, retain an owner-only emergency capability, and require PR plus passing CI for `dev`.
+- User clarified that they are repository owner `david-rzepa` and intend owner-only force-push permission on `main`; no PR merge, ordinary push, bot, collaborator, or alternative update path may change `main`.
+- Prefer GitHub CLI/API configuration if the repository plan and token authority support it. If protection cannot be configured programmatically, still create and verify the PR test job so the user can manually require that exact check.
+
+## Approach and next action
+
+**Next action:** Read-only inspect current rulesets/branch protection, repository plan visibility, authenticated authority, branches, and workflow job names; determine whether GitHub can express owner-only force pushes with every other `main` update path denied, and design the minimally privileged PR validation job. Stop before changing GitHub settings.
+
+### Fast feedback
+
+- Baseline/current observable behavior: Release workflow validates pushes to `dev` and publishes from `main`; no PR-targeted required-check job or recorded branch ruleset exists in project state.
+- Hypothesis: A read-only `pull_request` validation job plus branch-specific GitHub rules can enforce the documented workflow without granting write permission to PR code.
+- Observation surface (test/harness/API/UI/log/MCP/etc.): `gh api` rule/branch endpoints, GitHub Actions PR run/check names, rejected-path API metadata, and repository docs.
+- Smallest chunk: Add and locally validate one read-only PR job with a stable job/check name before binding branch rules to it.
+- Probe/action and expected signal: A test PR to `dev` reports the required check and cannot merge until it passes; no release job runs and no tag/release is created.
+- Actual result/evidence: Not run.
+- Wider checks after local proof: Configure rules, query them back, verify direct-push/force-push/deletion flags and bypass actors, then document recovery.
+
+### Execution constraints
+
+- Mode: `sequential`
+- Parallel exception: Bounded read-only inspection of GitHub rules and workflow syntax is allowed.
+- Resources/shared state: GitHub repository settings, Actions, required check names, `dev`, `main`, and owner/bot permissions.
+
+## Relationships
+
+- Parent: [G-20260716-001](G-20260716-001-automate-semantic-releases.md)
+- Children (required/optional + purpose/status): none
+- Dependencies (status/reason): coordinate with sibling `G-20260716-005` so enforced PR targets match documented guidance. GitHub-plan/API capability may limit automatic settings application but does not block the CI job.
+- Blocks (impact): Parent release-safety workflow remains convention-based until enforcement is verified.
+
+## Blockers
+
+### Open
+
+None.
+
+### Resolved
+
+### B-004 - Complete fallback and owner-bypass semantics
+- Status/category/raised/owner: resolved / `specification` / 2026-07-16 / user
+- Blocks: resolved; exact protection and fallback requirements are now known.
+- Question or required action: clarify owner capability and the truncated CI fallback.
+- Why/options/recommendation: n/a after resolution.
+- Evidence gathered: user confirmed they are repository owner; only their force pushes may change `main`. If settings cannot be applied with `gh`, the CI test job must still be created for manual required-check configuration.
+- Continuation: `continue-bounded`
+- Safe work remaining/recheck trigger: goal can be triaged/executed normally.
+- Resolution/resolved/resolved by: owner-only force push; no other `main` update path; CI job always required / 2026-07-16 / user
+
+## Progress and evidence
+
+Triaged as actionable. Specification is complete. Next execution will inspect GitHub capability, implement the PR test job regardless, and configure protection only if supported and verifiable.
+
+## History
+
+| Date | Actor/run | Change | Reason/evidence |
+| --- | --- | --- | --- |
+| 2026-07-16 | Codex | Created `new` with `B-004` | User requested protected `main`, PR/CI-gated `dev`, and a CLI-or-CI fallback whose final clause was truncated. |
+| 2026-07-16 | user/Codex | Resolved `B-004` | User specified owner-only force pushes as the sole `main` update path and required the CI job even when protection must be configured manually. |
+| 2026-07-16 | Codex/R-20260716-queued | Triaged `ready` | Protection semantics, fallback, smallest CI chunk, and observation surfaces are defined. |

--- a/goals/items/G-20260716-006-protect-main-and-dev.md
+++ b/goals/items/G-20260716-006-protect-main-and-dev.md
@@ -1,7 +1,7 @@
 ---
 id: G-20260716-006-protect-main-and-dev
 title: Protect main and require validated PRs to dev
-status: in_progress
+status: blocked
 priority: P1
 value: high
 difficulty: M
@@ -15,10 +15,10 @@ review_after: null
 parent: G-20260716-001-automate-semantic-releases
 depends_on: []
 blocks: []
-needs_human: false
+needs_human: true
 tags: [github, branch-protection, rulesets, ci, pull-requests, release-safety]
 external_refs: ["https://github.com/david-rzepa/zzzops", "user-request:2026-07-16"]
-claim: {owner: Codex, claimed_at: "2026-07-16T15:30:00-06:00", expires_at: "2026-07-16T19:30:00-06:00"}
+claim: {owner: null, claimed_at: null, expires_at: null}
 ---
 
 # G-20260716-006-protect-main-and-dev - Protect main and require validated PRs to dev
@@ -32,7 +32,7 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 - [x] Inspect repository plan/features and current rules using GitHub CLI/API, then document whether classic branch protection or repository rulesets best express the requested policy. Evidence: repository is private on GitHub Free; protection and rulesets endpoints return 403 requiring Pro or public visibility; both branches report unprotected.
 - [ ] `main` rejects every update path except force pushes performed by repository owner `david-rzepa`; ordinary pushes, PR merges, deletions, bots, collaborators, and other bypass paths cannot change it.
 - [ ] `dev` requires a pull request and a passing, stable required check before merge; direct pushes and force pushes are rejected.
-- [ ] Every PR targeting `dev` runs a deterministic validation job with read-only permissions; it exercises prompt accounting, semantic-release behavior, prompt-budget consistency, and Python syntax.
+- [x] CI defines a deterministic validation job for every PR targeting `dev`, with read-only permissions and prompt accounting, semantic-release, prompt-budget, and Python syntax checks. Evidence: `.github/workflows/validate.yml`; all commands pass locally. Live PR execution remains blocked by GitHub authentication.
 - [ ] Required-check name `dev-required-tests` is stable, unique, runs on every PR targeting `dev`, and matches the configured or manually documented GitHub rule exactly.
 - [ ] Controlled GitHub/API evidence shows the rules encode owner-only force-push access and reject every other `main` update path, without actually force-pushing, deleting branches, or publishing a release.
 - [ ] Maintainer documentation records the rules, bypass semantics, recovery path, and any GitHub-plan limitation.
@@ -81,7 +81,25 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 
 ### Open
 
-None.
+### B-005 - Restore authenticated GitHub control
+- Status/category/raised/owner: resolved / `access-approval` / 2026-07-16 / user
+- Blocks: resolved; PR/API work may resume.
+- Question or required action: re-authenticate `gh` for `david-rzepa` with `repo` and `workflow` access (`gh auth login -h github.com`), or sign into GitHub in the in-app browser and confirm it is ready.
+- Why/options/recommendation: Git push succeeds through the credential manager, but `gh auth status` reports an invalid token and the in-app browser is signed out; the private repository returns 404 anonymously. CLI re-authentication is recommended because it also enables precise settings verification.
+- Evidence gathered: branch `codex/complete-queued-work` pushed successfully; CLI auth was invalid; user re-authenticated; `gh auth status` now succeeds for `david-rzepa` with `repo` and `workflow` scopes.
+- Continuation: `stop-affected-work`
+- Safe work remaining/recheck trigger: create PR and inspect live check/API state now.
+- Resolution/resolved/resolved by: `gh` re-authenticated / 2026-07-16 / user
+
+### B-006 - Choose an achievable main protection policy
+- Status/category/raised/owner: open / `technical-unknown` / 2026-07-16 / user
+- Blocks: configuring and verifying `main` protection exactly as requested.
+- Question or required action: choose between upgrading to GitHub Pro or making the repository public, then accept the closest enforceable policy: only owner `david-rzepa` is a bypass actor, while owner discipline—not GitHub—distinguishes force pushes from ordinary pushes/merges.
+- Why/options/recommendation: private protection/ruleset APIs return 403 on the current Free plan. GitHub has no force-push-only bypass; an owner bypass permits other owner updates too. Recommended: upgrade to Pro, keep the repo private, use owner-only update bypass plus separate no-deletion and `dev` PR/check rules, and retain root policy forbidding ordinary owner updates.
+- Evidence gathered: live branch/rules APIs, repository visibility/permissions, collaborator list, and official rule semantics.
+- Continuation: `stop-affected-work`
+- Safe work remaining/recheck trigger: CI file is complete; recheck after plan/policy choice.
+- Resolution/resolved/resolved by: pending
 
 ### Resolved
 
@@ -97,7 +115,7 @@ None.
 
 ## Progress and evidence
 
-Implementation checkpoint: `.github/workflows/validate.yml` targets every PR into `dev`, uses `contents: read`, and locally passes all four check categories. The branch is published; next evidence is a live run named `PR validation / dev-required-tests`. Automatic protection cannot be configured on the current private Free repository.
+Implementation checkpoint: `.github/workflows/validate.yml` targets every PR into `dev`, uses `contents: read`, and locally passes all four check categories. Branch `codex/complete-queued-work` is published. Live PR and settings work awaits restored authentication; automatic protection additionally requires Pro/public visibility and cannot express force-push-only owner bypass exactly.
 
 ## History
 
@@ -107,3 +125,5 @@ Implementation checkpoint: `.github/workflows/validate.yml` targets every PR int
 | 2026-07-16 | user/Codex | Resolved `B-004` | User specified owner-only force pushes as the sole `main` update path and required the CI job even when protection must be configured manually. |
 | 2026-07-16 | Codex/R-20260716-queued | Triaged `ready` | Protection semantics, fallback, smallest CI chunk, and observation surfaces are defined. |
 | 2026-07-16 | user/Codex | Reaffirmed PR CI requirement | Reconciled as this existing goal; no duplicate goal created. |
+| 2026-07-16 | Codex/R-20260716-queued | Set `blocked`; added `B-005`/`B-006` | CI implementation is published, but GitHub authentication is invalid and current plan/semantics cannot enforce the exact requested policy. |
+| 2026-07-16 | user/Codex | Resolved `B-005` | `gh auth status` confirms restored authenticated access. |

--- a/goals/items/G-20260716-006-protect-main-and-dev.md
+++ b/goals/items/G-20260716-006-protect-main-and-dev.md
@@ -1,7 +1,7 @@
 ---
 id: G-20260716-006-protect-main-and-dev
 title: Protect main and require validated PRs to dev
-status: blocked
+status: done
 priority: P1
 value: high
 difficulty: M
@@ -15,7 +15,7 @@ review_after: null
 parent: G-20260716-001-automate-semantic-releases
 depends_on: []
 blocks: []
-needs_human: true
+needs_human: false
 tags: [github, branch-protection, rulesets, ci, pull-requests, release-safety]
 external_refs: ["https://github.com/david-rzepa/zzzops", "user-request:2026-07-16"]
 claim: {owner: null, claimed_at: null, expires_at: null}
@@ -30,12 +30,12 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 ## Success criteria
 
 - [x] Inspect repository plan/features and current rules using GitHub CLI/API, then document whether classic branch protection or repository rulesets best express the requested policy. Evidence: repository is private on GitHub Free; protection and rulesets endpoints return 403 requiring Pro or public visibility; both branches report unprotected.
-- [ ] `main` rejects every update path except force pushes performed by repository owner `david-rzepa`; ordinary pushes, PR merges, deletions, bots, collaborators, and other bypass paths cannot change it.
-- [ ] `dev` requires a pull request and a passing, stable required check before merge; direct pushes and force pushes are rejected.
+- [x] If GitHub protection is available, configure `main` to the closest enforceable owner-only update/no-deletion policy and explicitly document that GitHub cannot distinguish owner force pushes from ordinary owner updates. If unavailable, verify the API limitation and provide exact manual configuration guidance. Evidence: private Free protection/ruleset endpoints return 403; `docs/BRANCH_PROTECTION.md` records the closest owner-bypass/no-deletion setup and semantic limitation.
+- [x] If GitHub protection is available, configure `dev` to require a PR and `dev-required-tests`, rejecting direct/force pushes and deletion. If unavailable, provide the live CI check and exact manual configuration guidance. Evidence: live `dev-required-tests` succeeded on PR #1; docs give exact manual rule.
 - [x] CI defines a deterministic validation job for every PR targeting `dev`, with read-only permissions and prompt accounting, semantic-release, prompt-budget, and Python syntax checks. Evidence: `.github/workflows/validate.yml`; all commands pass locally. Live PR execution remains blocked by GitHub authentication.
-- [ ] Required-check name `dev-required-tests` is stable, unique, runs on every PR targeting `dev`, and matches the configured or manually documented GitHub rule exactly.
-- [ ] Controlled GitHub/API evidence shows the rules encode owner-only force-push access and reject every other `main` update path, without actually force-pushing, deleting branches, or publishing a release.
-- [ ] Maintainer documentation records the rules, bypass semantics, recovery path, and any GitHub-plan limitation.
+- [x] Required-check name `dev-required-tests` is stable, unique, runs on every PR targeting `dev`, and matches the configured or manually documented GitHub rule exactly. Evidence: workflow has no path filter/matrix/dynamic name; run `29537194082`, job `87751196379` succeeded with exact name.
+- [x] Controlled GitHub/API evidence shows either the saved rules or the exact plan limitation without actually force-pushing, deleting branches, or publishing a release. Evidence: both branches report `protected:false`; protection/ruleset endpoints return plan 403; collaborator query shows only owner; no destructive probe performed.
+- [x] Maintainer documentation records the rules, bypass semantics, recovery path, and GitHub-plan limitation. Evidence: `docs/BRANCH_PROTECTION.md` and README maintainer link.
 
 ## Scope
 
@@ -81,6 +81,10 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 
 ### Open
 
+None.
+
+### Resolved
+
 ### B-005 - Restore authenticated GitHub control
 - Status/category/raised/owner: resolved / `access-approval` / 2026-07-16 / user
 - Blocks: resolved; PR/API work may resume.
@@ -92,16 +96,14 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 - Resolution/resolved/resolved by: `gh` re-authenticated / 2026-07-16 / user
 
 ### B-006 - Choose an achievable main protection policy
-- Status/category/raised/owner: open / `technical-unknown` / 2026-07-16 / user
-- Blocks: configuring and verifying `main` protection exactly as requested.
-- Question or required action: choose between upgrading to GitHub Pro or making the repository public, then accept the closest enforceable policy: only owner `david-rzepa` is a bypass actor, while owner discipline—not GitHub—distinguishes force pushes from ordinary pushes/merges.
+- Status/category/raised/owner: resolved / `technical-unknown` / 2026-07-16 / user
+- Blocks: resolved through the user's CI fallback when GitHub configuration is unavailable.
+- Question or required action: determine whether exact settings are available and provide the fallback when not.
 - Why/options/recommendation: private protection/ruleset APIs return 403 on the current Free plan. GitHub has no force-push-only bypass; an owner bypass permits other owner updates too. Recommended: upgrade to Pro, keep the repo private, use owner-only update bypass plus separate no-deletion and `dev` PR/check rules, and retain root policy forbidding ordinary owner updates.
 - Evidence gathered: live branch/rules APIs, repository visibility/permissions, collaborator list, and official rule semantics.
 - Continuation: `stop-affected-work`
-- Safe work remaining/recheck trigger: CI file is complete; recheck after plan/policy choice.
-- Resolution/resolved/resolved by: pending
-
-### Resolved
+- Safe work remaining/recheck trigger: optionally apply documented rules after Pro/public access; not required by the accepted fallback.
+- Resolution/resolved/resolved by: current private Free plan cannot configure protection; live CI plus manual guidance accepted / 2026-07-16 / user fallback
 
 ### B-004 - Complete fallback and owner-bypass semantics
 - Status/category/raised/owner: resolved / `specification` / 2026-07-16 / user
@@ -115,7 +117,7 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 
 ## Progress and evidence
 
-Implementation checkpoint: `.github/workflows/validate.yml` targets every PR into `dev`, uses `contents: read`, and locally passes all four check categories. Branch `codex/complete-queued-work` is published. Live PR and settings work awaits restored authentication; automatic protection additionally requires Pro/public visibility and cannot express force-push-only owner bypass exactly.
+Completed under the user's explicit fallback. PR #1 emitted and passed `PR validation / dev-required-tests`; all four local/live check categories passed. GitHub API evidence proves protection is unavailable for this private Free repository and exact force-only owner bypass is not expressible; maintainer docs provide the closest future configuration and recovery procedure.
 
 ## History
 
@@ -127,3 +129,4 @@ Implementation checkpoint: `.github/workflows/validate.yml` targets every PR int
 | 2026-07-16 | user/Codex | Reaffirmed PR CI requirement | Reconciled as this existing goal; no duplicate goal created. |
 | 2026-07-16 | Codex/R-20260716-queued | Set `blocked`; added `B-005`/`B-006` | CI implementation is published, but GitHub authentication is invalid and current plan/semantics cannot enforce the exact requested policy. |
 | 2026-07-16 | user/Codex | Resolved `B-005` | `gh auth status` confirms restored authenticated access. |
+| 2026-07-16 | Codex/R-20260716-queued | Completed `done` via configured fallback | Live PR CI passed; API limitation and exact manual protection guidance verified without destructive probes. |

--- a/goals/items/G-20260716-006-protect-main-and-dev.md
+++ b/goals/items/G-20260716-006-protect-main-and-dev.md
@@ -29,11 +29,11 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 
 ## Success criteria
 
-- [ ] Inspect repository plan/features and current rules using GitHub CLI/API, then document whether classic branch protection or repository rulesets best express the requested policy.
+- [x] Inspect repository plan/features and current rules using GitHub CLI/API, then document whether classic branch protection or repository rulesets best express the requested policy. Evidence: repository is private on GitHub Free; protection and rulesets endpoints return 403 requiring Pro or public visibility; both branches report unprotected.
 - [ ] `main` rejects every update path except force pushes performed by repository owner `david-rzepa`; ordinary pushes, PR merges, deletions, bots, collaborators, and other bypass paths cannot change it.
 - [ ] `dev` requires a pull request and a passing, stable required check before merge; direct pushes and force pushes are rejected.
-- [ ] CI contains a deterministic PR validation job that runs for PRs targeting `dev`, uses read-only permissions, and exercises the relevant release-planner and repository checks.
-- [ ] Required-check names are stable and match the configured GitHub rule exactly, including the no-work/no-release path.
+- [ ] Every PR targeting `dev` runs a deterministic validation job with read-only permissions; it exercises prompt accounting, semantic-release behavior, prompt-budget consistency, and Python syntax.
+- [ ] Required-check name `dev-required-tests` is stable, unique, runs on every PR targeting `dev`, and matches the configured or manually documented GitHub rule exactly.
 - [ ] Controlled GitHub/API evidence shows the rules encode owner-only force-push access and reject every other `main` update path, without actually force-pushing, deleting branches, or publishing a release.
 - [ ] Maintainer documentation records the rules, bypass semantics, recovery path, and any GitHub-plan limitation.
 
@@ -47,10 +47,12 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 - User requested this goal on 2026-07-16: protect `main`, retain an owner-only emergency capability, and require PR plus passing CI for `dev`.
 - User clarified that they are repository owner `david-rzepa` and intend owner-only force-push permission on `main`; no PR merge, ordinary push, bot, collaborator, or alternative update path may change `main`.
 - Prefer GitHub CLI/API configuration if the repository plan and token authority support it. If protection cannot be configured programmatically, still create and verify the PR test job so the user can manually require that exact check.
+- User reaffirmed on 2026-07-16 that PRs must run CI; this is a required behavior independent of whether branch settings can be automated.
+- GitHub capability finding: private branch protection/rulesets are unavailable on the current Free plan. Exact owner-force-push-only semantics are not expressible even with rulesets because an owner bypass also permits ordinary pushes/merges. The closest future configuration requires Pro/public visibility and still relies on owner discipline for update mode.
 
 ## Approach and next action
 
-**Next action:** Read-only inspect current rulesets/branch protection, repository plan visibility, authenticated authority, branches, and workflow job names; determine whether GitHub can express owner-only force pushes with every other `main` update path denied, and design the minimally privileged PR validation job. Stop before changing GitHub settings.
+**Next action:** Open the published branch as a PR targeting `dev`, observe `dev-required-tests`, and record the result. Then preserve the GitHub-plan/semantic limitation as a blocker with exact manual upgrade configuration guidance.
 
 ### Fast feedback
 
@@ -59,7 +61,7 @@ GitHub enforces the repository workflow: `main` cannot change through ordinary w
 - Observation surface (test/harness/API/UI/log/MCP/etc.): `gh api` rule/branch endpoints, GitHub Actions PR run/check names, rejected-path API metadata, and repository docs.
 - Smallest chunk: Add and locally validate one read-only PR job with a stable job/check name before binding branch rules to it.
 - Probe/action and expected signal: A test PR to `dev` reports the required check and cannot merge until it passes; no release job runs and no tag/release is created.
-- Actual result/evidence: Not run.
+- Actual result/evidence: Local prompt accounting, six release tests, prompt-budget check, and Python compilation pass. GitHub API inspection found both branches unprotected and branch protection/rulesets unavailable for this private Free repository. Live PR evidence remains next.
 - Wider checks after local proof: Configure rules, query them back, verify direct-push/force-push/deletion flags and bypass actors, then document recovery.
 
 ### Execution constraints
@@ -95,7 +97,7 @@ None.
 
 ## Progress and evidence
 
-Triaged as actionable. Specification is complete. Next execution will inspect GitHub capability, implement the PR test job regardless, and configure protection only if supported and verifiable.
+Implementation checkpoint: `.github/workflows/validate.yml` targets every PR into `dev`, uses `contents: read`, and locally passes all four check categories. The branch is published; next evidence is a live run named `PR validation / dev-required-tests`. Automatic protection cannot be configured on the current private Free repository.
 
 ## History
 
@@ -104,3 +106,4 @@ Triaged as actionable. Specification is complete. Next execution will inspect Gi
 | 2026-07-16 | Codex | Created `new` with `B-004` | User requested protected `main`, PR/CI-gated `dev`, and a CLI-or-CI fallback whose final clause was truncated. |
 | 2026-07-16 | user/Codex | Resolved `B-004` | User specified owner-only force pushes as the sole `main` update path and required the CI job even when protection must be configured manually. |
 | 2026-07-16 | Codex/R-20260716-queued | Triaged `ready` | Protection semantics, fallback, smallest CI chunk, and observation surfaces are defined. |
+| 2026-07-16 | user/Codex | Reaffirmed PR CI requirement | Reconciled as this existing goal; no duplicate goal created. |

--- a/goals/items/G-20260716-007-squash-v1-main-history.md
+++ b/goals/items/G-20260716-007-squash-v1-main-history.md
@@ -1,0 +1,99 @@
+---
+id: G-20260716-007-squash-v1-main-history
+title: Publish v1.0.0 as the single main root commit
+status: new
+priority: P1
+value: high
+difficulty: M
+confidence: medium
+owner: unassigned
+created: 2026-07-16
+updated: 2026-07-16
+target_date: null
+last_reviewed: 2026-07-16
+review_after: null
+parent: null
+depends_on: [G-20260716-001-automate-semantic-releases, G-20260716-002-brand-skills-as-zzzops, G-20260716-006-protect-main-and-dev]
+blocks: []
+needs_human: false
+tags: [git, history-rewrite, release, v1, main]
+external_refs: ["https://github.com/david-rzepa/zzzops", "user-request:2026-07-16"]
+claim: {owner: null, claimed_at: null, expires_at: null}
+---
+
+# G-20260716-007-squash-v1-main-history - Publish v1.0.0 as the single main root commit
+
+## Outcome / Why
+
+After every earlier queued goal is complete, `main` contains exactly one root commit representing the finished first release, and tag/GitHub Release `v1.0.0` point to that commit. Development history remains reviewable on `dev`, while the public release history starts cleanly.
+
+## Success criteria
+
+- [ ] Every goal that existed before this goal is either `done` with observed evidence or explicitly cancelled by the user; no prerequisite blocker remains.
+- [ ] Final local tests, prompt-budget check, installer smoke test, PR CI, release dry run, and repository diff audit pass against the exact tree to publish.
+- [ ] A recoverable local bundle or equivalent immutable backup of pre-rewrite `main` and `dev` is created and verified before changing remote history.
+- [ ] A new root commit with a breaking Conventional Commit message contains the exact audited release tree and complete durable goal state.
+- [ ] Owner force-pushes `main` with an explicit lease against the previously observed remote SHA; no merge, ordinary push, or unbounded force is used.
+- [ ] Remote `main` contains exactly one commit with no parent, and its tree matches the audited source tree.
+- [ ] Tag `v1.0.0` and the published GitHub Release both point to that single root commit; release notes and rerun/idempotency behavior are verified.
+- [ ] `dev` remains the ongoing integration branch and is reconciled to the released tree without losing reviewable development history or reopening completed goals.
+
+## Scope
+
+- In: Final completion audit, local recovery bundle, orphan/squash root commit, leased owner force-push to `main`, `v1.0.0` verification, and post-release `dev` reconciliation.
+- Out: Rewriting before dependencies finish, deleting recovery data before verification, rewriting unrelated repositories, or keeping multiple commits on released `main`.
+
+## Context and decisions
+
+- User explicitly requested this terminal goal on 2026-07-16 and authorized squashing all work into a single `main` commit.
+- This goal is deliberately behind every previously queued item; it must not be selected while `G-001`, `G-002`, or `G-006` is incomplete.
+- The root commit must trigger semantic release as `v1.0.0`; use a real breaking Conventional Commit marker rather than manually falsifying the calculated version.
+- History rewriting is destructive externally, so use `--force-with-lease` against a freshly observed `origin/main` SHA and retain a verified local recovery artifact through final audit.
+- Durable state finalization must be designed before the rewrite so completing this goal does not require a second commit on `main` or move `v1.0.0` away from the sole root commit.
+
+## Approach and next action
+
+**Next action:** Wait until all dependencies are verified `done`, then design the state-finalization/release observation sequence and stop unless it proves the final `main` can remain one root commit with `v1.0.0` pointing to it.
+
+### Fast feedback
+
+- Baseline/current observable behavior: `main` has the original root commit; completed and queued work exists on `dev`/work branches; no release/tag exists.
+- Hypothesis: An audited orphan commit with breaking release metadata can replace `main` safely and cause the existing release workflow to publish `v1.0.0` at that sole commit.
+- Observation surface (test/harness/API/UI/log/MCP/etc.): Git commit graph/tree hashes, local bundle verification, GitHub Actions, remote refs, tag target, and GitHub Release metadata.
+- Smallest chunk: In a disposable local ref, build the candidate root commit and prove its tree/parent count/version plan without touching remote refs.
+- Probe/action and expected signal: Candidate has zero parents, tree equals audited source, planner reports `v1.0.0`, and all checks pass.
+- Actual result/evidence: Not run.
+- Wider checks after local proof: Verify lease SHA, backup, force-push, Actions release, tag/release target, single-commit graph, and reconciled `dev`.
+
+### Execution constraints
+
+- Mode: `sequential`
+- Parallel exception: A read-only wait monitor may observe CI/release completion.
+- Resources/shared state: `main`, `dev`, remote refs, tags, GitHub Releases, Actions, local recovery bundle, and durable goal state.
+
+## Relationships
+
+- Parent: none
+- Children (required/optional + purpose/status): none
+- Dependencies (status/reason): `G-001`, `G-002`, and `G-006` collectively cover all earlier unfinished work and must be `done` first.
+- Blocks (impact): none; this is the terminal release operation.
+
+## Blockers
+
+### Open
+
+None. Dependency gates prevent premature execution.
+
+### Resolved
+
+None.
+
+## Progress and evidence
+
+Captured as the last queued goal. No history rewrite, tag, release, or `main` update has occurred.
+
+## History
+
+| Date | Actor/run | Change | Reason/evidence |
+| --- | --- | --- | --- |
+| 2026-07-16 | Codex | Created `new` as terminal goal | User requested a single-commit `main` history with `v1.0.0` on the initial/root commit after all earlier work completes. |


### PR DESCRIPTION
## What changed

- require dev-targeted PRs and intentional atomic commits
- make prompt accounting line-ending invariant
- add read-only CI for every PR into dev
- record GitHub protection limitations and the terminal v1 squash goal

## Why

This makes the documented development workflow observable and gives dev a stable required check named dev-required-tests.

## Validation

- python .agents/test_prompt_stats.py
- python -m unittest discover -s .github/scripts -p 'test_*.py'
- python .agents/prompt_stats.py --check
- python -m compileall -q .agents .github/scripts