### PR TITLE
Gate the terminal v1 release

### DIFF
--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -6,7 +6,6 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | Blocker | Goal | Category | Request | Impact | Raised |
 | --- | --- | --- | --- | --- | --- |
 | B-001 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | human-action | Reopen checkout at `C:\dev\zzzops` and verify Codex group label. | Final branding verification only. | 2026-07-16 |
-| B-002 | [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | access-approval | Authorize integrating `dev` into `main` to publish expected `v1.0.0`. | Final production-release verification. | 2026-07-16 |
 
 ## Active claims
 | Goal | Owner | Claimed | Expires | Checkpoint |
@@ -16,7 +15,7 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 ## New goals awaiting triage
 | Goal | Priority | Created | Provisional outcome |
 | --- | --- | --- | --- |
-| [G-20260716-007](items/G-20260716-007-squash-v1-main-history.md) | P1 | 2026-07-16 | Publish the completed first release as the sole `main` root commit tagged `v1.0.0`. |
+| None | - | - | - |
 
 ## Ready queue
 | Goal | Parent | Priority | Value | Difficulty | Unlocks | Next action |
@@ -27,15 +26,13 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | Goal | Priority | Blockers | Recheck trigger | Safe work? |
 | --- | --- | --- | --- | --- |
 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | P1 | B-001 `human-action` | Workspace reopened at `C:\dev\zzzops` | No repository work remains; release goal is safe. |
-| [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | P1 | B-002 `access-approval` | Explicit first-release authorization | No safe production-release work remains. |
 
 ## Root goals
 | Goal | Status | Priority | Value | Difficulty | Progress summary |
 | --- | --- | --- | --- | --- | --- |
-| [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | blocked | P1 | high | M | Two live `dev` dry runs passed; awaiting `v1.0.0` release approval. |
+| [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | triaged | P1 | high | M | Release authorized; terminal child `G-007` awaits `G-002` UI check. |
 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | blocked | P1 | high | M | Repository rename verified; awaiting ZzzOps-path UI check. |
 | [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | done | P2 | medium | S | Canonical LF byte counting and regression test verified. |
-| [G-20260716-007](items/G-20260716-007-squash-v1-main-history.md) | new | P1 | high | M | Terminal squash/release goal; gated by all earlier incomplete work. |
 
 ## Recently completed or cancelled
 | Goal | Final status | Date | Evidence/rationale |

--- a/goals/items/G-20260716-001-automate-semantic-releases.md
+++ b/goals/items/G-20260716-001-automate-semantic-releases.md
@@ -1,7 +1,7 @@
 ---
 id: G-20260716-001-automate-semantic-releases
 title: Automate semantic GitHub releases
-status: blocked
+status: triaged
 priority: P1
 value: high
 difficulty: M
@@ -15,7 +15,7 @@ review_after: null
 parent: null
 depends_on: []
 blocks: []
-needs_human: true
+needs_human: false
 tags: [ci, release, semantic-versioning, github-actions]
 external_refs: ["user-request:2026-07-16"]
 claim: {owner: null, claimed_at: null, expires_at: null}
@@ -70,7 +70,7 @@ ZzzOps derives semantic versions from repository history and publishes reproduci
 ## Relationships
 
 - Parent: none
-- Children (required/optional + purpose/status): [G-20260716-003](G-20260716-003-document-dev-branch-workflow.md) (required; initial `dev`-first Git/release guidance; `done`); [G-20260716-005](G-20260716-005-document-pr-workflow.md) (required; document `dev`-targeted PR and atomic commit policy; `done`); [G-20260716-006](G-20260716-006-protect-main-and-dev.md) (required; PR CI plus protection/fallback; `done`).
+- Children (required/optional + purpose/status): [G-20260716-003](G-20260716-003-document-dev-branch-workflow.md) (required; initial `dev`-first Git/release guidance; `done`); [G-20260716-005](G-20260716-005-document-pr-workflow.md) (required; document `dev`-targeted PR and atomic commit policy; `done`); [G-20260716-006](G-20260716-006-protect-main-and-dev.md) (required; PR CI plus protection/fallback; `done`); [G-20260716-007](G-20260716-007-squash-v1-main-history.md) (required; publish audited single-root `v1.0.0`; `triaged`).
 - Dependencies (status/reason): none recorded; repository settings or branch creation may become a human-action blocker during investigation.
 - Blocks (impact): none recorded.
 
@@ -78,23 +78,23 @@ ZzzOps derives semantic versions from repository history and publishes reproduci
 
 ### Open
 
-### B-002 - Authorize the first production release
-- Status/category/raised/owner: open / `access-approval` / 2026-07-16 / user
-- Blocks: live verification that a qualifying `main` push creates the expected tag and GitHub Release
-- Question or required action: authorize integrating current `dev` into `main`; this is expected to publish `v1.0.0`.
-- Why/options/recommendation: root `AGENTS.md` reserves `main` for explicit release intent. Recommended: approve after reviewing the two successful dry runs; otherwise leave `dev` as the verified staging state.
-- Evidence gathered: runs `29535036331` and `29535149186` passed; both skipped release; remote has no releases/tags; real-history preview plans `v1.0.0`.
-- Continuation: `stop-affected-work`
-- Safe work remaining/recheck trigger: none for this goal; recheck when the user explicitly authorizes or declines the release.
-- Resolution/resolved/resolved by: pending
+None.
 
 ### Resolved
 
-None.
+### B-002 - Authorize the first production release
+- Status/category/raised/owner: resolved / `access-approval` / 2026-07-16 / user
+- Blocks: resolved; release remains dependency-gated.
+- Question or required action: authorize the first `main` release.
+- Why/options/recommendation: user explicitly requested terminal goal `G-007` to owner-force-push a single-root `main` and publish `v1.0.0`.
+- Evidence gathered: prior dry runs passed; user specified exact final release/history outcome.
+- Continuation: `stop-affected-work`
+- Safe work remaining/recheck trigger: execute `G-007` after `G-002` completes.
+- Resolution/resolved/resolved by: authorized through `G-007` request / 2026-07-16 / user
 
 ## Progress and evidence
 
-Shared planner, tests, workflow, and docs are on `dev`. Live dry runs `29535036331` and `29535149186` passed; release jobs were skipped and remote releases/tags stayed empty. The goal awaits explicit authorization to merge/push `dev` to `main` and verify the expected `v1.0.0` release.
+Shared planner, tests, workflow, and docs are on `dev`; live dry runs passed without mutation. Release authorization is resolved. Parent remains `triaged` until required terminal child `G-007` publishes and verifies the single-root `v1.0.0` after `G-002`.
 
 ## History
 
@@ -109,3 +109,4 @@ Shared planner, tests, workflow, and docs are on `dev`. Live dry runs `295350363
 | 2026-07-16 | Codex | Added required children `G-20260716-005` and `G-20260716-006` | User expanded the release-safety workflow with PR/commit guidance and GitHub enforcement. |
 | 2026-07-16 | Codex/R-20260716-queued | Required child `G-20260716-005` completed | PR/commit policy is now explicit in root instructions. |
 | 2026-07-16 | Codex/R-20260716-queued | Required child `G-20260716-006` completed | Live PR CI passed; unavailable protection is covered by the user's documented manual fallback. |
+| 2026-07-16 | user/Codex | Resolved `B-002`; added required child `G-007` | User explicitly authorized the terminal single-root `v1.0.0` release operation. |

--- a/goals/items/G-20260716-002-brand-skills-as-zzzops.md
+++ b/goals/items/G-20260716-002-brand-skills-as-zzzops.md
@@ -88,7 +88,7 @@ Every installed and repository-local skill is unmistakably part of ZzzOps in age
 - Why/options/recommendation: Codex groups project-local `.agents/skills` by workspace path; keep the canonical discovery folder and rename the checkout rather than moving skills out of `.agents/skills`.
 - Evidence gathered: current workspace and skill source paths are rooted at `C:\dev\agent-goals`; README already instructs cloning to `C:\dev\zzzops`.
 - Continuation: `continue-bounded`
-- Safe work remaining/recheck trigger: release-CI goal can continue; recheck after the workspace is reopened at the new path.
+- Safe work remaining/recheck trigger: correctly named checkout now exists at `C:\dev\zzzops`; recheck after the user opens it in Codex.
 - Resolution/resolved/resolved by: pending
 
 ### Resolved
@@ -97,7 +97,7 @@ None.
 
 ## Progress and evidence
 
-Repository-side rename is complete and committed as one pending checkpoint. Remaining work is the human UI verification after reopening the checkout at `C:\dev\zzzops`.
+Repository-side rename is complete. A fresh `dev` checkout now exists at `C:\dev\zzzops`; remaining work is the human UI verification after opening that folder in Codex.
 
 ## History
 
@@ -106,3 +106,4 @@ Repository-side rename is complete and committed as one pending checkpoint. Rema
 | 2026-07-16 | Codex | Created `new` | User requested clear ZzzOps skill grouping and “Add ZzzOps TODO” naming. |
 | 2026-07-16 | Codex/R-20260716-zzzops | Triaged `ready`; difficulty `M` | Full rename surface and observable fresh/update-install probes are defined. |
 | 2026-07-16 | Codex/R-20260716-1500-root | Repository rename verified; set `blocked` | Fresh/update installs and scans pass; Codex group header requires reopening a ZzzOps-named checkout. |
+| 2026-07-16 | Codex/R-20260716-queued | Created `C:\dev\zzzops` checkout | Removed the filesystem action; user must reopen it once for UI evidence. |

--- a/goals/items/G-20260716-007-squash-v1-main-history.md
+++ b/goals/items/G-20260716-007-squash-v1-main-history.md
@@ -1,7 +1,7 @@
 ---
 id: G-20260716-007-squash-v1-main-history
 title: Publish v1.0.0 as the single main root commit
-status: new
+status: triaged
 priority: P1
 value: high
 difficulty: M
@@ -12,8 +12,8 @@ updated: 2026-07-16
 target_date: null
 last_reviewed: 2026-07-16
 review_after: null
-parent: null
-depends_on: [G-20260716-001-automate-semantic-releases, G-20260716-002-brand-skills-as-zzzops, G-20260716-006-protect-main-and-dev]
+parent: G-20260716-001-automate-semantic-releases
+depends_on: [G-20260716-002-brand-skills-as-zzzops, G-20260716-006-protect-main-and-dev]
 blocks: []
 needs_human: false
 tags: [git, history-rewrite, release, v1, main]
@@ -46,7 +46,7 @@ After every earlier queued goal is complete, `main` contains exactly one root co
 ## Context and decisions
 
 - User explicitly requested this terminal goal on 2026-07-16 and authorized squashing all work into a single `main` commit.
-- This goal is deliberately behind every previously queued item; it must not be selected while `G-001`, `G-002`, or `G-006` is incomplete.
+- This required child is the operation that completes parent `G-001`; it is deliberately behind every other previously queued item and must not execute while `G-002` or `G-006` is incomplete.
 - The root commit must trigger semantic release as `v1.0.0`; use a real breaking Conventional Commit marker rather than manually falsifying the calculated version.
 - History rewriting is destructive externally, so use `--force-with-lease` against a freshly observed `origin/main` SHA and retain a verified local recovery artifact through final audit.
 - Durable state finalization must be designed before the rewrite so completing this goal does not require a second commit on `main` or move `v1.0.0` away from the sole root commit.
@@ -73,9 +73,9 @@ After every earlier queued goal is complete, `main` contains exactly one root co
 
 ## Relationships
 
-- Parent: none
+- Parent: [G-20260716-001](G-20260716-001-automate-semantic-releases.md)
 - Children (required/optional + purpose/status): none
-- Dependencies (status/reason): `G-001`, `G-002`, and `G-006` collectively cover all earlier unfinished work and must be `done` first.
+- Dependencies (status/reason): `G-002` must complete its renamed-checkout UI verification; `G-006` is done. Parent `G-001` completes from this child's release evidence rather than forming a dependency cycle.
 - Blocks (impact): none; this is the terminal release operation.
 
 ## Blockers
@@ -90,10 +90,11 @@ None.
 
 ## Progress and evidence
 
-Captured as the last queued goal. No history rewrite, tag, release, or `main` update has occurred.
+Triaged as the final required child of `G-001`. No history rewrite, tag, release, or `main` update has occurred. `C:\dev\zzzops` was cloned from `dev`; terminal execution awaits its Codex grouping check.
 
 ## History
 
 | Date | Actor/run | Change | Reason/evidence |
 | --- | --- | --- | --- |
 | 2026-07-16 | Codex | Created `new` as terminal goal | User requested a single-commit `main` history with `v1.0.0` on the initial/root commit after all earlier work completes. |
+| 2026-07-16 | Codex/R-20260716-queued | Triaged; linked as required child of `G-001` | Removed the release parent/child dependency cycle; `G-002` remains the only unfinished prerequisite besides this operation. |


### PR DESCRIPTION
## What changed

- link the terminal squash as the release goal's required child
- resolve explicit release authorization
- record the correctly named local checkout
- remove the parent/dependency cycle

## Validation

- goal relationship audit
- git diff --check