### PR TITLE
chore(goals): verify ZzzOps branding

### DIFF
--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -5,7 +5,7 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 ## Human input queue
 | Blocker | Goal | Category | Request | Impact | Raised |
 | --- | --- | --- | --- | --- | --- |
-| B-001 | [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | human-action | Reopen checkout at `C:\dev\zzzops` and verify Codex group label. | Final branding verification only. | 2026-07-16 |
+| None | - | - | - | - | - |
 
 ## Active claims
 | Goal | Owner | Claimed | Expires | Checkpoint |
@@ -20,18 +20,18 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 ## Ready queue
 | Goal | Parent | Priority | Value | Difficulty | Unlocks | Next action |
 | --- | --- | --- | --- | --- | --- | --- |
-| None | - | - | - | - | - | - |
+| [G-20260716-007](items/G-20260716-007-squash-v1-main-history.md) | G-20260716-001 | P1 | high | M | Completes semantic-release parent | Build and audit the exact root candidate before the leased `main` update. |
 
 ## Blocked goals
 | Goal | Priority | Blockers | Recheck trigger | Safe work? |
 | --- | --- | --- | --- | --- |
-| [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | P1 | B-001 `human-action` | Workspace reopened at `C:\dev\zzzops` | No repository work remains; release goal is safe. |
+| None | - | - | - | - |
 
 ## Root goals
 | Goal | Status | Priority | Value | Difficulty | Progress summary |
 | --- | --- | --- | --- | --- | --- |
-| [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | triaged | P1 | high | M | Release authorized; terminal child `G-007` awaits `G-002` UI check. |
-| [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | blocked | P1 | high | M | Repository rename verified; awaiting ZzzOps-path UI check. |
+| [G-20260716-001](items/G-20260716-001-automate-semantic-releases.md) | triaged | P1 | high | M | Release authorized; terminal child `G-007` is ready. |
+| [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | done | P1 | high | M | Repository rename and ZzzOps-path Codex grouping verified. |
 | [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | done | P2 | medium | S | Canonical LF byte counting and regression test verified. |
 
 ## Recently completed or cancelled
@@ -41,7 +41,7 @@ Derived from `goals/items/`; repair drift. **Reviewed:** 2026-07-16.
 | [G-20260716-005](items/G-20260716-005-document-pr-workflow.md) | done | 2026-07-16 | Root policy now requires `dev`-targeted PRs and intentional atomic commit boundaries. |
 | [G-20260716-004](items/G-20260716-004-stabilize-prompt-budget-line-endings.md) | done | 2026-07-16 | LF/CRLF/CR estimates match; regenerated prompt budget passes. |
 | [G-20260716-006](items/G-20260716-006-protect-main-and-dev.md) | done | 2026-07-16 | PR #1 passed `dev-required-tests`; Free-plan limitation and exact manual fallback documented. |
+| [G-20260716-002](items/G-20260716-002-brand-skills-as-zzzops.md) | done | 2026-07-16 | Fresh install/update probes passed and the user confirmed Codex groups the renamed checkout under ZzzOps. |
 
 ## Portfolio notes
-- Release tooling remains intentionally undecided pending repository investigation.
-- Skill identifier compatibility remains intentionally undecided pending a complete rename map.
+- Terminal release `G-007` is the only actionable goal and is explicitly authorized to update `main` by leased owner force-push after its audit passes.

--- a/goals/USAGE_LEDGER.md
+++ b/goals/USAGE_LEDGER.md
@@ -17,12 +17,14 @@ Append only; corrections identify superseded rows. Follow `.zzzops/rules/USAGE_A
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-004 | Fixed line-ending-dependent prompt counts | - | - | - | - | unavailable | n/a | Focused LF/CRLF/CR regression and repository check passed. |
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-006 | Implemented/published PR CI; inspected GitHub protection capability | - | - | - | - | unavailable | n/a | Local checks pass; auth and private Free-plan limitations block live PR/settings completion. |
 | R-20260716-queued-root | root/goal-work | 2026-07-16 | G-20260716-006 | Verified live PR CI and documented protection fallback | - | - | - | - | unavailable | n/a | Run 29537194082 passed; API 403 and force-only semantic limitation documented. |
+| R-20260716-release-root | root/goal-management | 2026-07-16 | G-20260716-002 | Resolved UI blocker and unlocked terminal release | - | - | - | - | unavailable | n/a | Harness exposes no callable token counter; user confirmed Codex groups `C:\dev\zzzops` correctly. |
 
 ## Limit snapshots
 | Run ID | Date/time | Source | Context | Rate/credit state | Notes |
 | --- | --- | --- | --- | --- | --- |
 | None | - | - | - | - | - |
 | R-20260716-1500-root | 2026-07-16 15:00 -06:00 | unavailable | Codex desktop task | unavailable | No callable exact usage/limit surface. |
+| R-20260716-release-root | 2026-07-16 | unavailable | Codex desktop task | unavailable | No callable exact usage/limit surface. |
 
 ## Calibration summary
 | Work type | Difficulty | Samples | Median work tokens | Outcome | Confidence |

--- a/goals/items/G-20260716-002-brand-skills-as-zzzops.md
+++ b/goals/items/G-20260716-002-brand-skills-as-zzzops.md
@@ -1,7 +1,7 @@
 ---
 id: G-20260716-002-brand-skills-as-zzzops
 title: Brand all skills clearly as ZzzOps
-status: blocked
+status: done
 priority: P1
 value: high
 difficulty: M
@@ -15,7 +15,7 @@ review_after: null
 parent: null
 depends_on: []
 blocks: []
-needs_human: true
+needs_human: false
 tags: [skills, naming, branding, discovery, installer]
 external_refs: ["user-request:2026-07-16"]
 claim: {owner: null, claimed_at: null, expires_at: null}
@@ -36,7 +36,7 @@ Every installed and repository-local skill is unmistakably part of ZzzOps in age
 - [x] A clean install into a temporary repository makes the skills discoverable under clear ZzzOps names in supported harness layouts. Evidence: installer preview/apply succeeded with 46 mechanical files and exact Codex/Claude directory listings.
 - [x] The compatibility policy for repositories that already contain the first-release skill names is explicit and verified; stale aliases are intentionally retained and documented. Evidence: update preview reported `Legacy skill directories retained: add-project-todo`; README explains manual removal after verification.
 - [x] Prompt budget counts are regenerated and pass `.agents/prompt_stats.py --check`. Evidence: 22 prompts, 39,983 bytes, ~10,006 estimated tokens.
-- [ ] Reopen the checkout at `C:\dev\zzzops` and verify Codex groups its project-local skills under ZzzOps rather than `agent-goals`.
+- [x] Reopen the checkout at `C:\dev\zzzops` and verify Codex groups its project-local skills under ZzzOps rather than `agent-goals`. Evidence: user confirmed “the zzzops folder worked” after opening the renamed checkout in Codex.
 
 ## Scope
 
@@ -52,7 +52,7 @@ Every installed and repository-local skill is unmistakably part of ZzzOps in age
 
 ## Approach and next action
 
-**Next action:** Inventory every skill-facing identifier and path, propose the shortest consistent ZzzOps rename map plus first-release compatibility behavior, and stop after proving the mapping covers every repository reference.
+**Next action:** Complete; preserve the verified ZzzOps-named checkout and skill paths.
 
 ### Fast feedback
 
@@ -61,7 +61,7 @@ Every installed and repository-local skill is unmistakably part of ZzzOps in age
 - Observation surface (test/harness/API/UI/log/MCP/etc.): Repository search, installer dry run/apply output, installed `.agents/skills` and `.claude/skills` trees, and harness skill discovery lists.
 - Smallest chunk: Express the old-to-new naming map as a table and validate that each old identifier/path occurrence is assigned exactly one disposition.
 - Probe/action and expected signal: Scan all tracked files and a clean install; no unapproved old skill name remains and each renamed skill is discoverable once.
-- Actual result/evidence: Fresh install, legacy-update preview, old-name scan, Python parse, and prompt-budget probes passed. UI group remains tied to the current checkout path.
+- Actual result/evidence: Fresh install, legacy-update preview, old-name scan, Python parse, and prompt-budget probes passed. The user reopened `C:\dev\zzzops` and confirmed Codex displayed the expected ZzzOps grouping.
 - Wider checks after local proof: Fresh install, update over a first-release install, prompt-budget verification, Python parsing, and README quickstart command validation.
 
 ### Execution constraints
@@ -81,23 +81,23 @@ Every installed and repository-local skill is unmistakably part of ZzzOps in age
 
 ### Open
 
+None.
+
+### Resolved
+
 ### B-001 - Reopen from a ZzzOps-named checkout
-- Status/category/raised/owner: open / `human-action` / 2026-07-16 / user
+- Status/category/raised/owner: resolved / `human-action` / 2026-07-16 / user
 - Blocks: final UI grouping verification only
 - Question or required action: after this run, rename or clone the checkout to `C:\dev\zzzops`, reopen it in Codex, and confirm the group label is ZzzOps.
 - Why/options/recommendation: Codex groups project-local `.agents/skills` by workspace path; keep the canonical discovery folder and rename the checkout rather than moving skills out of `.agents/skills`.
 - Evidence gathered: current workspace and skill source paths are rooted at `C:\dev\agent-goals`; README already instructs cloning to `C:\dev\zzzops`.
 - Continuation: `continue-bounded`
 - Safe work remaining/recheck trigger: correctly named checkout now exists at `C:\dev\zzzops`; recheck after the user opens it in Codex.
-- Resolution/resolved/resolved by: pending
-
-### Resolved
-
-None.
+- Resolution/resolved/resolved by: user confirmed “the zzzops folder worked” / 2026-07-16 / user
 
 ## Progress and evidence
 
-Repository-side rename is complete. A fresh `dev` checkout now exists at `C:\dev\zzzops`; remaining work is the human UI verification after opening that folder in Codex.
+Repository-side rename and UI discovery are complete. A fresh `dev` checkout at `C:\dev\zzzops` exposes the project-local skills under ZzzOps, as confirmed by the user.
 
 ## History
 
@@ -107,3 +107,4 @@ Repository-side rename is complete. A fresh `dev` checkout now exists at `C:\dev
 | 2026-07-16 | Codex/R-20260716-zzzops | Triaged `ready`; difficulty `M` | Full rename surface and observable fresh/update-install probes are defined. |
 | 2026-07-16 | Codex/R-20260716-1500-root | Repository rename verified; set `blocked` | Fresh/update installs and scans pass; Codex group header requires reopening a ZzzOps-named checkout. |
 | 2026-07-16 | Codex/R-20260716-queued | Created `C:\dev\zzzops` checkout | Removed the filesystem action; user must reopen it once for UI evidence. |
+| 2026-07-16 | user/Codex/R-20260716-release-root | Confirmed UI grouping; set `done` | User reported that the ZzzOps-named folder worked, satisfying the final observable criterion and resolving B-001. |

--- a/goals/items/G-20260716-007-squash-v1-main-history.md
+++ b/goals/items/G-20260716-007-squash-v1-main-history.md
@@ -1,7 +1,7 @@
 ---
 id: G-20260716-007-squash-v1-main-history
 title: Publish v1.0.0 as the single main root commit
-status: triaged
+status: ready
 priority: P1
 value: high
 difficulty: M
@@ -53,7 +53,7 @@ After every earlier queued goal is complete, `main` contains exactly one root co
 
 ## Approach and next action
 
-**Next action:** Wait until all dependencies are verified `done`, then design the state-finalization/release observation sequence and stop unless it proves the final `main` can remain one root commit with `v1.0.0` pointing to it.
+**Next action:** Build an exact-tree candidate root locally, run the complete release audit, and prove the root/version plan before touching remote refs.
 
 ### Fast feedback
 
@@ -62,7 +62,7 @@ After every earlier queued goal is complete, `main` contains exactly one root co
 - Observation surface (test/harness/API/UI/log/MCP/etc.): Git commit graph/tree hashes, local bundle verification, GitHub Actions, remote refs, tag target, and GitHub Release metadata.
 - Smallest chunk: In a disposable local ref, build the candidate root commit and prove its tree/parent count/version plan without touching remote refs.
 - Probe/action and expected signal: Candidate has zero parents, tree equals audited source, planner reports `v1.0.0`, and all checks pass.
-- Actual result/evidence: Not run.
+- Actual result/evidence: Dependency `G-002` is now verified `done`; candidate construction and release probes have not run yet.
 - Wider checks after local proof: Verify lease SHA, backup, force-push, Actions release, tag/release target, single-commit graph, and reconciled `dev`.
 
 ### Execution constraints
@@ -75,7 +75,7 @@ After every earlier queued goal is complete, `main` contains exactly one root co
 
 - Parent: [G-20260716-001](G-20260716-001-automate-semantic-releases.md)
 - Children (required/optional + purpose/status): none
-- Dependencies (status/reason): `G-002` must complete its renamed-checkout UI verification; `G-006` is done. Parent `G-001` completes from this child's release evidence rather than forming a dependency cycle.
+- Dependencies (status/reason): `G-002` and `G-006` are done. Parent `G-001` completes from this child's release evidence rather than forming a dependency cycle.
 - Blocks (impact): none; this is the terminal release operation.
 
 ## Blockers
@@ -90,7 +90,7 @@ None.
 
 ## Progress and evidence
 
-Triaged as the final required child of `G-001`. No history rewrite, tag, release, or `main` update has occurred. `C:\dev\zzzops` was cloned from `dev`; terminal execution awaits its Codex grouping check.
+Ready as the final required child of `G-001`. No history rewrite, tag, release, or `main` update has occurred. The user confirmed the renamed checkout's Codex grouping, clearing the final dependency gate.
 
 ## History
 
@@ -98,3 +98,4 @@ Triaged as the final required child of `G-001`. No history rewrite, tag, release
 | --- | --- | --- | --- |
 | 2026-07-16 | Codex | Created `new` as terminal goal | User requested a single-commit `main` history with `v1.0.0` on the initial/root commit after all earlier work completes. |
 | 2026-07-16 | Codex/R-20260716-queued | Triaged; linked as required child of `G-001` | Removed the release parent/child dependency cycle; `G-002` remains the only unfinished prerequisite besides this operation. |
+| 2026-07-16 | user/Codex/R-20260716-release-root | Set `ready` | User confirmed the ZzzOps UI grouping; both dependencies are now done. |


### PR DESCRIPTION
## Summary
- record the user's successful ZzzOps skill-group verification
- resolve the retained human-action blocker
- unlock the terminal v1 release goal

## Checks
- prompt accounting test
- semantic release tests
- prompt budget check
- Python compileall
- git diff --check