### PR TITLE
feat(policy): default to one PR per goal

### DIFF
--- a/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
+++ b/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
@@ -11,6 +11,8 @@ Use this only for source-changing goals and apply reviewed PROJECT Git/review po
 
 Create/resume the recorded branch before source edits. If dirty work cannot be proven to belong to this goal, stop and ask. Repository rules or explicit instructions may justify a different topology or no branch; record the evidence and decision.
 
+When PROJECT `pull_request_unit` is `per_goal`, each source-changing goal owns one branch and one PR when the repository supports PRs. Related/small goals or one execute run do not imply bundling. A repository rule or explicit user instruction may authorize a shared PR only under `shared_pull_request`; before combining work, record the override/rationale, shared branch/PR, target, and review effect in every affected goal. Reuse that identity after blockers—never open a duplicate. Parent and child goals keep distinct PRs targeting the resolved pseudo-trunk/dependency topology. One PR may retain multiple coherent semantic commits; commit/squash policy is separate. Capture stays Git-free, and repositories without PR capability follow reviewed PROJECT integration policy or block when required authority/capability is missing.
+
 ## Review gate
 
 After implementation, automated checks, and required self-review pass, apply PROJECT `review_gate`. `human_after_checks` creates a `human-action` blocker containing branch/commit/PR links, checks, material risks, and the exact approval/change request needed; do not merge or mark done and surface it through the normal human queue.

--- a/.agents/skills/install-zzzops/scripts/test_install_zzzops.py
+++ b/.agents/skills/install-zzzops/scripts/test_install_zzzops.py
@@ -39,6 +39,10 @@ class InstallerInitializationTests(unittest.TestCase):
             self.assertTrue((target / ".claude" / "skills" / "add-zzzops-goal" / "SKILL.md").is_file())
             self.assertTrue((target / ".agents" / "skills" / "execute-zzzops" / "references" / "BRANCH_REVIEW.md").is_file())
             self.assertTrue((target / ".claude" / "skills" / "execute-zzzops" / "references" / "BRANCH_REVIEW.md").is_file())
+            for harness in (".agents", ".claude"):
+                branch_review = (target / harness / "skills" / "execute-zzzops" / "references" / "BRANCH_REVIEW.md").read_text(encoding="utf-8")
+                self.assertIn("each source-changing goal owns one branch and one PR", branch_review)
+                self.assertIn("explicit user instruction may authorize a shared PR", branch_review)
             self.assertTrue((target / ".agents" / "skills" / "execute-zzzops" / "references" / "SELF_REVIEW.md").is_file())
             self.assertTrue((target / ".claude" / "skills" / "execute-zzzops" / "references" / "SELF_REVIEW.md").is_file())
             obsolete = "-".join(("add", "zzzops", "todo"))

--- a/.agents/templates/project-goals/INIT_PLAN.json
+++ b/.agents/templates/project-goals/INIT_PLAN.json
@@ -61,6 +61,7 @@
         "settings": {
           "execution_branch": "per_goal", "branch_base": "nearest_authorized_trunk", "dependency_base": "dependency_branch",
           "multiple_dependency_base": "reviewed_base_containing_all", "parent_pseudo_trunk": true, "child_target": "nearest_parent_branch",
+          "pull_request_unit": "per_goal", "shared_pull_request": "explicit_reviewed_override",
           "commit_unit": "verified_subgoal", "commit_style": "conventional", "review_gate": "human_after_checks",
           "pr_approval": "required_when_repository_requires_pr", "conversational_approval": "allowed_otherwise", "merge_after_approval": "when_authorized"
         },

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -337,12 +337,17 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertEqual("nearest_authorized_trunk", git_policy["branch_base"])
         self.assertEqual("dependency_branch", git_policy["dependency_base"])
         self.assertTrue(git_policy["parent_pseudo_trunk"])
+        self.assertEqual("per_goal", git_policy["pull_request_unit"])
+        self.assertEqual("explicit_reviewed_override", git_policy["shared_pull_request"])
         self.assertEqual("human_after_checks", git_policy["review_gate"])
         workflow = (root / "skills" / "execute-zzzops" / "references" / "BRANCH_REVIEW.md").read_text(encoding="utf-8")
         for phrase in (
             "one stable `implementation` identity per goal", "multiple_dependency_base", "parent pseudo-trunk",
             "recursively", "dependency order", "human-action", "PR UI approval",
             "explicit conversational approval", "Changes requested", "Missing merge authority",
+            "each source-changing goal owns one branch and one PR", "Related/small goals",
+            "explicit user instruction", "record the override/rationale", "Parent and child goals keep distinct PRs",
+            "commit/squash policy is separate", "Capture stays Git-free", "without PR capability",
         ):
             self.assertIn(phrase, workflow)
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ python .agents/prompt_stats.py --check
 | `.agents/skills/add-zzzops-goal/SKILL.md` | 1241 | 311 |
 | `.agents/skills/analyze-zzzops-usage/SKILL.md` | 2412 | 603 |
 | `.agents/skills/execute-zzzops/SKILL.md` | 2427 | 607 |
-| `.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md` | 2618 | 655 |
+| `.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md` | 3454 | 864 |
 | `.agents/skills/execute-zzzops/references/CREATE.md` | 2746 | 687 |
 | `.agents/skills/execute-zzzops/references/EXECUTE.md` | 3324 | 831 |
 | `.agents/skills/execute-zzzops/references/SELF_REVIEW.md` | 1345 | 337 |
@@ -220,7 +220,7 @@ python .agents/prompt_stats.py --check
 | `.zzzops/rules/USAGE_ACCOUNTING.md` | 2505 | 627 |
 | `AGENTS.md` | 2963 | 741 |
 | `CLAUDE.md` | 217 | 55 |
-| **Total** | **53487** | **13383** |
+| **Total** | **54323** | **13592** |
 <!-- PROMPT_BUDGET_END -->
 
 </details>

--- a/docs/EXECUTION.md
+++ b/docs/EXECUTION.md
@@ -2,6 +2,8 @@
 
 Branch/review behavior is project policy, proposed during initialization from repository evidence. The first-release fallback uses one branch per source-changing goal, bases independent goals on the nearest authorized trunk, and stacks dependent goals from dependency branches. A parent with children owns a pseudo-trunk; children integrate there in dependency order before combined parent verification.
 
+Where pull requests are supported, the fallback also uses one PR per source-changing goal. Being small, related, or selected in one run is not enough to bundle goals. Repository policy or an explicit user instruction may permit a shared PR, but every affected goal records the override, rationale, shared branch/PR, target, and review consequence before work is combined. Parent and child goals retain separate PRs targeting their resolved pseudo-trunks. PR granularity is independent of commit/squash policy, and capture-only goal creation remains Git-free.
+
 | Scenario | Base | Integration target |
 | --- | --- | --- |
 | Independent root goal | Nearest authorized trunk | Repository-policy target |


### PR DESCRIPTION
## Summary

- propose `pull_request_unit: per_goal` as the reviewed initialization fallback
- require explicit, recorded repository/user overrides before sharing a PR across goals
- preserve parent/dependency PR topology, Git-free capture, and independent commit/squash policy
- verify installed Codex and Claude Code guidance

## Verification

- `.agents/test_zzzops.py` — 33 passed
- installer suite — 3 passed
- prompt-budget test and `prompt_stats.py --check` passed
- completion self-review found no unresolved in-scope issue or dead compatibility path

Goal: #35
