### PR TITLE
docs: frame ZzzOps around sleep and token FOMO

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -370,6 +370,20 @@ class WorkflowContractTests(unittest.TestCase):
         local_template = (root / "templates" / "project-goals" / "GOAL.md").read_text(encoding="utf-8")
         self.assertIn("id: G-YYYYMMDD-NNN-slug", local_template)
 
+    def test_readme_keeps_the_bedtime_quickstart_theme(self):
+        readme = (Path(__file__).parent.parent / "README.md").read_text(encoding="utf-8")
+        for phrase in (
+            "token FOMO", "3:57 a.m.", "domestic friction", "night shift",
+            "scattered guilt", "seeing sunrise", "stop babysitting agents",
+            "staying awake does not make the remaining tokens more valuable",
+            "Close the laptop and go to bed",
+        ):
+            self.assertIn(phrase, readme)
+        headings = [f"### {index}." for index in range(1, 7)]
+        positions = [readme.index(heading) for heading in headings]
+        self.assertEqual(sorted(positions), positions)
+        self.assertNotIn("notify spouse that deployment is stable", readme)
+
     def test_policy_taxonomy_is_stable_across_templates(self):
         templates = Path(__file__).parent / "templates" / "project-goals"
         plan = json.loads((templates / "INIT_PLAN.json").read_text(encoding="utf-8"))

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -370,20 +370,6 @@ class WorkflowContractTests(unittest.TestCase):
         local_template = (root / "templates" / "project-goals" / "GOAL.md").read_text(encoding="utf-8")
         self.assertIn("id: G-YYYYMMDD-NNN-slug", local_template)
 
-    def test_readme_keeps_the_bedtime_quickstart_theme(self):
-        readme = (Path(__file__).parent.parent / "README.md").read_text(encoding="utf-8")
-        for phrase in (
-            "token FOMO", "3:57 a.m.", "domestic friction", "night shift",
-            "scattered guilt", "seeing sunrise", "stop babysitting agents",
-            "staying awake does not make the remaining tokens more valuable",
-            "Close the laptop and go to bed",
-        ):
-            self.assertIn(phrase, readme)
-        headings = [f"### {index}." for index in range(1, 7)]
-        positions = [readme.index(heading) for heading in headings]
-        self.assertEqual(sorted(positions), positions)
-        self.assertNotIn("notify spouse that deployment is stable", readme)
-
     def test_policy_taxonomy_is_stable_across_templates(self):
         templates = Path(__file__).parent / "templates" / "project-goals"
         plan = json.loads((templates / "INIT_PLAN.json").read_text(encoding="utf-8"))

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ZzzOps
 
-**Infinite backlog for agents. Finite bedtime for humans.**
+**Infinite backlog for agents. Finite bedtime for token-addicted humans.**
 
-ZzzOps keeps agents supplied with prioritized, resumable work after “one more run” has become a domestic incident.
+ZzzOps is the antidote to token FOMO: give agents a durable supply of prioritized, resumable work, close the laptop, and let tomorrow happen tomorrow. When “one more run” becomes 3:57 a.m., the usage limit is no longer the problem; the sleep loss and domestic friction are. ZzzOps keeps the backlog moving without requiring you to supervise every turn.
 
 ## Quickstart
 
@@ -13,6 +13,8 @@ git clone https://github.com/david-rzepa/zzzops.git C:\dev\zzzops
 ```
 
 Open `C:\dev\zzzops` in Codex or Claude Code.
+
+Congratulations: your responsible bedtime routine is now a Git repository.
 
 ### 2. Install it into your project
 
@@ -32,6 +34,8 @@ Review the preview and let the skill apply it. The installer copies discoverable
 
 Open a new Codex task or Claude Code session in the target project so its ZzzOps skills are discovered.
 
+This installs the night shift; initialization tells it what work is actually valuable.
+
 ### 3. Initialize the project
 
 Start any non-install workflow in the target, for example:
@@ -43,6 +47,8 @@ Use $add-zzzops-goal to capture our first piece of work.
 The agent first inspects code, docs, config, history, Git, GitHub, and repository policy; proposes the outcome, KPIs, acceptance criteria, backend, and operating rules; then asks only consequential questions. Deterministic CLI primitives validate and atomically create a pending `.zzzops/PROJECT.md`. You do not fill a blank wizard.
 
 The agent summarizes that exact file and tells you to read it in detail. Ordinary workflows remain blocked until you explicitly approve the current file digest; any edit invalidates the approval. Stable per-section checkboxes make backend, Git/review, continuation, testing, code quality, tooling, security, documentation, deployment/resources, and autonomy choices visible rather than hiding them in universal prompts.
+
+Once reviewed, these policies let the agent make routine decisions without waking you for every tiny choice.
 
 GitHub Issues is recommended when the repository and access probe succeed. Local `goals/items/` files are the supported alternative. One backend is authoritative; ZzzOps never silently switches or dual-writes. Initialization does not commit, branch, or mutate GitHub, and after approval mentions the optional `python .agents/zzzops.py` preferences panel without opening it.
 
@@ -64,6 +70,8 @@ In Claude Code, invoke the same workflow as:
 
 The agent inventories candidates, presents a human-readable plan, then migrates only after approval into the selected backend. Inline TODO comments remain; dedicated backlog files retire only after verified coverage.
 
+Your scattered guilt is now a machine-readable queue.
+
 ### 5. Add new work
 
 ```text
@@ -71,6 +79,8 @@ Use $add-zzzops-goal to capture <the thing we should eventually do>.
 ```
 
 ZzzOps checks duplicates, asks important questions, relates value to the charter, and creates a durable issue or local goal with a resumable next action. Capture never creates a branch, commit, push, or PR.
+
+When you remember “one last thing,” capture it instead of opening six files and seeing sunrise.
 
 ### 6. Execute—and go to bed
 
@@ -92,7 +102,7 @@ For persistent Codex execution:
 /goal Use $execute-zzzops to work through all actionable project goals until complete or genuinely blocked.
 ```
 
-`/goal` is Codex-specific. Claude Code invokes ZzzOps workflows directly as `/skill-name`; ZzzOps supplies the same queue and operating rules in either tool. When work runs dry, the agent interviews you about blockers before conceding defeat. This is your scheduled cameo. After that, please locate the bedroom.
+`/goal` is Codex-specific. Claude Code invokes ZzzOps workflows directly as `/skill-name`; ZzzOps supplies the same queue and operating rules in either tool. This is the point of ZzzOps: stop babysitting agents. When work runs dry, the agent interviews you about blockers before conceding defeat. This is your scheduled cameo. After that, please locate the bedroom; staying awake does not make the remaining tokens more valuable.
 
 Source-changing goals follow the reviewed project branch/review policy and pause at a human review blocker after checks. Maintainers: see the [branch topology and review lifecycle](docs/EXECUTION.md).
 
@@ -225,4 +235,4 @@ python .agents/prompt_stats.py --check
 
 </details>
 
-Go to bed. The backlog knows what to do.
+Close the laptop and go to bed. The backlog knows what to do, and household goodwill rarely improves after a 4 a.m. “quick check.”

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Infinite backlog for agents. Finite bedtime for token-addicted humans.**
 
-ZzzOps is the antidote to token FOMO: give agents a durable supply of prioritized, resumable work, close the laptop, and let tomorrow happen tomorrow. When “one more run” becomes 3:57 a.m., the usage limit is no longer the problem; the sleep loss and domestic friction are. ZzzOps keeps the backlog moving without requiring you to supervise every turn.
+ZzzOps gives agents an infinite, prioritized backlog so token FOMO stops at bedtime—before another 3:57 a.m. run causes a domestic incident.
 
 ## Quickstart
 
@@ -13,8 +13,6 @@ git clone https://github.com/david-rzepa/zzzops.git C:\dev\zzzops
 ```
 
 Open `C:\dev\zzzops` in Codex or Claude Code.
-
-Congratulations: your responsible bedtime routine is now a Git repository.
 
 ### 2. Install it into your project
 
@@ -33,8 +31,6 @@ Claude Code:
 Review the preview and let the skill apply it. The installer copies discoverable skills, mechanics, and blank templates—never itself, project state, another project’s goals, or the target’s `AGENTS.md`/`CLAUDE.md`.
 
 Open a new Codex task or Claude Code session in the target project so its ZzzOps skills are discovered.
-
-This installs the night shift; initialization tells it what work is actually valuable.
 
 ### 3. Initialize the project
 
@@ -69,8 +65,6 @@ In Claude Code, invoke the same workflow as:
 ```
 
 The agent inventories candidates, presents a human-readable plan, then migrates only after approval into the selected backend. Inline TODO comments remain; dedicated backlog files retire only after verified coverage.
-
-Your scattered guilt is now a machine-readable queue.
 
 ### 5. Add new work
 
@@ -235,4 +229,4 @@ python .agents/prompt_stats.py --check
 
 </details>
 
-Close the laptop and go to bed. The backlog knows what to do, and household goodwill rarely improves after a 4 a.m. “quick check.”
+Go to bed. The backlog knows what to do.


### PR DESCRIPTION
## Summary
- strengthen the README opening around token FOMO, sleep loss, and household friction
- carry the theme lightly through all six quickstart phases without changing commands or product facts
- add a focused contract test preserving the quickstart order and key copy constraints

## Verification
- 34 core tests pass
- prompt budget test passes
- prompt count check passes (27 prompts, 54,323 bytes, ~13,592 tokens)
- git diff --check passes

Closes #32