### PR TITLE
feat: batch portfolio audits across goal backends

### DIFF
--- a/.agents/skills/add-zzzops-goal/SKILL.md
+++ b/.agents/skills/add-zzzops-goal/SKILL.md
@@ -5,7 +5,7 @@ description: Capture, add, create, or record one durable ZzzOps goal/TODO. Use f
 
 # Add ZzzOps Goal
 
-Run `.zzzops/rules/INITIALIZATION.md`, then `.zzzops/rules/BACKENDS.md`. Inspect context and the selected backend for duplicates. Handle consequential ambiguity using reviewed PROJECT interview policy. Create one canonical goal using the human-first managed GitHub issue schema in one call or, for `local_files`, `.agents/templates/project-goals/GOAL.md` plus derived index/backlinks.
+Run `.zzzops/rules/INITIALIZATION.md`, then `.zzzops/rules/BACKENDS.md`. Use its complete batch snapshot for duplicate/relationship checks; re-read only a likely match. Handle consequential ambiguity using reviewed PROJECT interview policy. Create one canonical goal using the human-first managed GitHub issue schema in one call or, for `local_files`, `.agents/templates/project-goals/GOAL.md` plus derived index/backlinks.
 
 Run applicable `.zzzops/rules/HEALTH.md` hooks from reviewed PROJECT policy; health remains user opt-in and nonblocking.
 

--- a/.agents/skills/analyze-zzzops-usage/SKILL.md
+++ b/.agents/skills/analyze-zzzops-usage/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze ZzzOps tokens, usage, cost, management overhead, delivered 
 
 # Analyze ZzzOps Usage
 
-Run `../../../.zzzops/rules/INITIALIZATION.md`, then `../../../.zzzops/rules/BACKENDS.md`. Read the charter, usage ledger, canonical goals, and `../../../.zzzops/rules/USAGE_ACCOUNTING.md`.
+Run `../../../.zzzops/rules/INITIALIZATION.md`, then `../../../.zzzops/rules/BACKENDS.md`. Read the charter, usage ledger, its complete compact portfolio snapshot, and `../../../.zzzops/rules/USAGE_ACCOUNTING.md`; re-read only goals whose evidence enters the analysis.
 Run applicable `../../../.zzzops/rules/HEALTH.md` hooks from reviewed PROJECT policy; do not count health state as project value.
 
 1. Validate comparability: separate exact/estimated/unavailable usage and token classes; exclude or label incompatible rows. Allocate shared management overhead consistently and show the method.

--- a/.agents/skills/execute-zzzops/references/CREATE.md
+++ b/.agents/skills/execute-zzzops/references/CREATE.md
@@ -1,6 +1,6 @@
 # Create and triage
 
-1. Search goals/project/trackers for duplicates and authoritative facts. Capture outcome, value, constraints, owner, dates, evidence, and non-goals. Link/refine existing work rather than duplicate it.
+1. Use the complete BACKENDS portfolio snapshot plus project/trackers for duplicates and authoritative facts. Capture outcome, value, constraints, owner, dates, evidence, and non-goals; refine existing work rather than duplicate it.
 2. Promptly create a provisional canonical goal using `BACKENDS.md`: one human-first managed issue with GitHub-assigned identity, or a local file from `.agents/templates/project-goals/GOAL.md`; use PROJECT capture defaults and override them only with evidence.
 3. Investigate boundedly: observable end state/beneficiary; completion evidence; scope; relevant components/decisions; dependencies/risks/authority; and whether this is a goal, checklist item, duplicate, or child. Persist findings, not raw logs.
 4. If consequential ambiguity remains, follow `.zzzops/rules/BLOCKERS.md`: record it, expose the backend-derived human queue (or local `needs_human`), and interview per PROJECT policy with recommendations and continuation boundaries. Proceed on reversible cosmetic assumptions; never speculate across foundational choices.

--- a/.agents/skills/execute-zzzops/references/EXECUTE.md
+++ b/.agents/skills/execute-zzzops/references/EXECUTE.md
@@ -5,14 +5,14 @@
 ## Select
 
 1. Create a run ID and inspect callable usage per `.zzzops/rules/USAGE_ACCOUNTING.md`.
-2. Read project charter, `.zzzops/PREFERENCES.json`, the canonical backend portfolio, and selection-critical relationships/claims/reviews. Repair only derived drift needed to select safely. If the user is present and the human queue is non-empty, run `UNBLOCK.md` first.
+2. Read charter/preferences, then run the BACKENDS portfolio command once. Require `complete:true` and `valid:true`; resolve findings instead of selecting from an invalid graph, and use its compact relationships/claims/reviews rather than rereading every goal. If the user is present and its human queue is non-empty, run `UNBLOCK.md` first.
 3. Route `new` goals through `CREATE.md` according to PROJECT triage/continuation policy.
 4. Actionable = `ready` or resumable `in_progress`, authorized concrete next action, gates satisfied, no invalidating blocker/live foreign claim. Recheck blocked work only on its trigger.
 5. Rank by evidenced charter/KPI movement and unlock value, then apply PROJECT priority, easy-win, tie-break, and resume policy.
 
 ## Execute
 
-1. Re-read goal, parent, dependencies, rules, and artifacts; claim it with expiry/checkpoint.
+1. Re-read only the selected goal and selection-critical parent/dependencies; compare snapshot revision/digest, then claim with expiry/checkpoint.
 2. For source changes, establish/resume the policy-selected topology from `BRANCH_REVIEW.md` and persist branch/base/target before editing. Then follow `.zzzops/rules/EXECUTION_STRATEGY.md`: capture baseline; implement one smallest falsifiable chunk; run/inspect/record the real probe before continuing; widen only after proof.
 3. Work to a verified checkpoint without silent scope expansion. Classify discoveries as scope, checklist, child, dependency, or root. Apply PROJECT test-bug policy; never hide a failure, weaken the test, or expand authority silently.
 4. Persist evidence and usage at natural checkpoints. Follow preference-limited parallel/worktree rules; coordinator owns ZzzOps state and integration.
@@ -21,7 +21,7 @@
 
 - On a blocker, follow `.zzzops/rules/BLOCKERS.md`: record continuation, ask when useful, do only bounded safe work, then keep active or block/release claim and switch.
 - Before `done`, cite observed before/after evidence for each criterion; verify required children, blockers, and relevant checks; state anything unobserved. Build/lint/types/code review do not prove runtime behavior unless that is the criterion. Run `SELF_REVIEW.md`, fix/reverify in-scope findings, and record even a clean result. Source-changing work then enters the `BRANCH_REVIEW.md` human gate; technical completion alone is not `done`.
-- Follow PROJECT Git/review/commit policy, staging only authorized implementation and pending local ZzzOps state; a GitHub-only state change never causes an empty commit. Recheck parent criteria and unlocked dependents; repeat upward, then select again.
+- Follow PROJECT Git/review/commit policy, staging only authorized implementation and pending local ZzzOps state; a GitHub-only state change never causes an empty commit. Refresh the batch after state mutation, recheck parent/unlocks, then select again.
 
 ## Exhaustion and handoff
 

--- a/.agents/skills/execute-zzzops/references/UNBLOCK.md
+++ b/.agents/skills/execute-zzzops/references/UNBLOCK.md
@@ -1,6 +1,6 @@
 # Unblock goals
 
-1. Read the selected backend's human-input queue, then each referenced goal's open blockers, evidence, continuation choice, dependencies, and recheck trigger. Repair missing derived queue entries before interviewing.
+1. Use the complete BACKENDS portfolio snapshot to derive the human queue; re-read only referenced goals for full blocker evidence, continuation, and triggers. Report derived drift rather than inventing missing state.
 2. Consolidate duplicates and order questions by leverage: safety/access/human action; choices blocking many goals; specifications; technical unknowns. Do not ask questions already answered in project docs, history, or related goals.
 3. Interview according to PROJECT timing/batching policy. For each blocker give: goal(s), category, exact question/action, why it matters, options when applicable, recommended default with consequence, and what safe work can continue. Prefer a few high-leverage questions over a transcript dump.
 4. On each answer, resolve the old blocker without deleting it; record answer, resolver/date, changed assumptions/scope/criteria/next action, and any narrower successor blocker. Update state, dependencies, history, backend-derived human queue/local `needs_human`, and local backlinks atomically.

--- a/.agents/skills/install-zzzops/scripts/test_install_zzzops.py
+++ b/.agents/skills/install-zzzops/scripts/test_install_zzzops.py
@@ -61,6 +61,13 @@ class InstallerInitializationTests(unittest.TestCase):
             self.assertFalse((target / ".zzzops" / "init" / "plan.json").exists())
             self.assertFalse((target / ".zzzops" / "HEALTH_STATE.json").exists())
             self.assertFalse((target / ".zzzops" / "health_preferences.json").exists())
+            portfolio_help = subprocess.run(
+                [sys.executable, str(target / ".agents" / "zzzops.py"), "--repo", str(target), "portfolio", "--help"],
+                text=True, encoding="utf-8", capture_output=True, check=False,
+            )
+            self.assertEqual(0, portfolio_help.returncode, portfolio_help.stderr + portfolio_help.stdout)
+            self.assertIn("--format {summary,json}", portfolio_help.stdout)
+            self.assertIn("--compare", portfolio_help.stdout)
             usage = subprocess.run(
                 [sys.executable, str(target / ".agents" / "zzzops.py"), "--repo", str(target), "usage", "ensure"],
                 text=True, encoding="utf-8", capture_output=True, check=False,

--- a/.agents/skills/migrate-zzzops-todos/SKILL.md
+++ b/.agents/skills/migrate-zzzops-todos/SKILL.md
@@ -11,7 +11,7 @@ Run `.zzzops/rules/INITIALIZATION.md`, then `.zzzops/rules/BACKENDS.md`. Use `.a
 Run applicable `.zzzops/rules/HEALTH.md` hooks from reviewed PROJECT policy; nudges never substitute for migration approval.
 
 1. Run `scripts/inventory.py .`. Inspect candidate files and surrounding project context yourself. The inventory is advisory; do not treat syntax as intent.
-2. Ignore managed/dependency/build/generated areas. Compare candidates with `.zzzops/migration/STATE.json` and goal provenance; investigate only new fingerprints. Ask about ownership/exclusions, project outcome/KPIs/acceptance, and consequential ambiguity according to PROJECT interview policy. Reuse existing charter answers.
+2. Ignore managed/dependency/build/generated areas. Compare candidates with `.zzzops/migration/STATE.json` and the complete BACKENDS portfolio snapshot; re-read only likely matches and investigate only new fingerprints. Ask about ownership/exclusions, project outcome/KPIs/acceptance, and consequential ambiguity according to PROJECT interview policy. Reuse existing charter answers.
 3. Copy the installed plan and summary templates into `.zzzops/migration/`. Fill every proposed goal, charter-based value rationale, source disposition, exclusion, and question. Present `SUMMARY.md` and wait for approval.
 4. Apply the approved plan to the selected backend: native GitHub issues/comments or local goal files/backlinks. Update charter, local ledger/history, and `STATE.json` consistently. Keep inline annotations. Delete a dedicated backlog only after all full-context content is represented. Verify results; remove resolved plan/summary.
 

--- a/.agents/skills/suggest-zzzops-work/SKILL.md
+++ b/.agents/skills/suggest-zzzops-work/SKILL.md
@@ -5,7 +5,7 @@ description: Suggest, discover, or audit valuable ZzzOps work from project code,
 
 # Suggest ZzzOps Work
 
-Run `.zzzops/rules/INITIALIZATION.md`, then `.zzzops/rules/BACKENDS.md`. Read project instructions, charter, local preferences, and canonical goals.
+Run `.zzzops/rules/INITIALIZATION.md`, then `.zzzops/rules/BACKENDS.md`. Read project instructions, charter, preferences, and the complete compact portfolio snapshot; re-read only likely duplicates.
 Run applicable `.zzzops/rules/HEALTH.md` hooks from reviewed PROJECT policy; health never changes dry-run/apply authority.
 
 1. Mode defaults to `dry-run`: no edits to source, Git, goals, index, or preferences. `apply` requires explicit user request or `$execute-zzzops` invocation allowed by both PROJECT refill policy and local preference. Never edit/commit preferences.

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 
@@ -353,8 +354,223 @@ class ManagedGoalTests(unittest.TestCase):
         goal["implementation"]["review"]["status"] = "self_approved"
         self.assertIn("implementation.review.status is invalid", zzzops.validate_managed_goal(goal))
 
+    def test_managed_goal_rejects_invented_lifecycle_enums(self):
+        goal = self.goal()
+        for field, value in (("status", "almost-done"), ("priority", "urgent"), ("value", "priceless"), ("difficulty", "heroic"), ("confidence", "vibes")):
+            candidate = dict(goal)
+            candidate[field] = value
+            self.assertIn(f"{field} is invalid", zzzops.validate_managed_goal(candidate))
+
+
+class PortfolioTests(unittest.TestCase):
+    def goal(self, **overrides):
+        goal = {
+            "schema_version": 1, "status": "ready", "priority": "P2", "value": "medium",
+            "difficulty": "S", "confidence": "high", "parent": None, "depends_on": [],
+            "claim": {"owner": None}, "blockers": [], "evidence": [],
+            "next_action": "Run the next observable probe.", "revision": 1,
+            "implementation": {"branch": None, "base": None, "target": None, "pr": None,
+                               "review": {"status": "not_started", "checkpoint": None}},
+        }
+        goal.update(overrides)
+        return goal
+
+    def issue(self, number, **goal_overrides):
+        goal = self.goal(**goal_overrides)
+        title = f"Goal {number}"
+        body = zzzops.render_managed_goal(goal, "## Outcome / Why\n\nUseful work.\n", number)
+        return {
+            "number": number, "title": title, "body": body, "state": "closed" if goal["status"] == "done" else "open",
+            "updated_at": f"2026-07-{number:02d}T00:00:00Z", "html_url": f"https://example.test/issues/{number}",
+            "labels": [{"name": "zzzops"}, {"name": f"zzzops:status:{goal['status']}"}, {"name": f"zzzops:priority:{goal['priority']}"}],
+        }
+
+    def test_empty_snapshot_is_complete_and_deterministic(self):
+        first = zzzops.build_portfolio_snapshot("local_files", [], reads=1, raw_bytes=0)
+        second = zzzops.build_portfolio_snapshot("local_files", [], reads=1, raw_bytes=0)
+        self.assertTrue(first["complete"])
+        self.assertEqual(first["portfolio_digest"], second["portfolio_digest"])
+        self.assertEqual(0, first["summary"]["total"])
+        self.assertEqual([], first["findings"])
+
+    def test_snapshot_derives_graph_actionability_and_compact_summary(self):
+        records = [
+            zzzops.github_goal_record(self.issue(1, status="done")),
+            zzzops.github_goal_record(self.issue(2, depends_on=[1])),
+            zzzops.github_goal_record(self.issue(3, parent=2, status="blocked", blockers=[{"id": "B-1", "status": "open", "category": "decision"}])),
+        ]
+        snapshot = zzzops.build_portfolio_snapshot(
+            "github_issues", records, reads=1, raw_bytes=20000,
+            as_of=zzzops.datetime(2026, 7, 17, tzinfo=zzzops.timezone.utc),
+        )
+        by_key = {goal["key"]: goal for goal in snapshot["goals"]}
+        self.assertEqual([2], by_key[1]["blocks"])
+        self.assertEqual([3], by_key[2]["children"])
+        self.assertEqual({"total": 3, "actionable": 1, "blocked": 1, "done": 1, "findings": 0, "reads": 1, "raw_bytes": 20000, "ignored": 0}, snapshot["summary"])
+        self.assertTrue(snapshot["valid"])
+        summary = zzzops.render_portfolio_summary(snapshot)
+        self.assertIn("goals=3 actionable=1 blocked=1 done=1", summary)
+        self.assertNotIn("Goal 1", summary)
+        self.assertLess(len(summary.encode("utf-8")), snapshot["summary"]["raw_bytes"] // 10)
+
+    def test_audit_reports_graph_state_claim_review_and_label_drift(self):
+        stale = {"owner": "Codex", "expires_at": "2026-07-16T00:00:00Z"}
+        pending = {"branch": "goal/x", "base": "dev", "target": "dev", "pr": "url", "review": {"status": "pending", "checkpoint": "abc"}}
+        records = [
+            zzzops.github_goal_record(self.issue(1, depends_on=[2], claim=stale, implementation=pending)),
+            zzzops.github_goal_record(self.issue(2, depends_on=[1], status="done")),
+        ]
+        records[0]["depends_on"].append(2)
+        records[0]["implementation"]["review"]["checkpoint"] = None
+        records[1]["claim"] = {"owner": "Codex", "expires_at": "2026-07-16T00:00:00"}
+        records[0]["labels"] = ["zzzops", "zzzops:status:new"]
+        findings = zzzops.audit_portfolio(records, "github_issues", zzzops.datetime(2026, 7, 17, tzinfo=zzzops.timezone.utc))
+        codes = {finding["code"] for finding in findings}
+        self.assertTrue({"duplicate_dependency", "depends_on_cycle", "done_with_unfinished_dependency", "stale_claim", "invalid_claim_expiry", "pending_review_without_checkpoint", "label_drift"}.issubset(codes))
+
+    @mock.patch.object(zzzops.shutil, "which", return_value="gh")
+    @mock.patch.object(zzzops.subprocess, "run")
+    @mock.patch.object(zzzops, "validate_project_state", return_value=[])
+    @mock.patch.object(zzzops, "parse_project_state", return_value={"initialized": True, "backend": "github_issues", "repository": {"identity": "owner/repo"}})
+    def test_github_adapter_uses_one_paginated_read_and_filters_prs(self, _parse, _validate, run, _which):
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            (repo / ".zzzops").mkdir()
+            (repo / ".zzzops" / "PROJECT.md").write_text("state", encoding="utf-8")
+            payload = [[self.issue(1), {**self.issue(2), "pull_request": {}}], [self.issue(3)]]
+            run.return_value = SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+            snapshot = zzzops.portfolio_snapshot(repo, zzzops.datetime(2026, 7, 17, tzinfo=zzzops.timezone.utc))
+        self.assertEqual([1, 3], [goal["key"] for goal in snapshot["goals"]])
+        self.assertEqual(2, snapshot["summary"]["reads"])
+        self.assertEqual(1, snapshot["summary"]["processes"])
+        self.assertEqual(0, snapshot["summary"]["ignored"])
+        command = run.call_args.args[0]
+        self.assertIn("--paginate", command)
+        self.assertIn("--slurp", command)
+        self.assertEqual(1, run.call_count)
+
+    @mock.patch.object(zzzops.shutil, "which", return_value="gh")
+    @mock.patch.object(zzzops.subprocess, "run", return_value=SimpleNamespace(returncode=1, stdout="", stderr="API rate limit exceeded; partial page rejected"))
+    @mock.patch.object(zzzops, "validate_project_state", return_value=[])
+    @mock.patch.object(zzzops, "parse_project_state", return_value={"initialized": True, "backend": "github_issues", "repository": {"identity": "owner/repo"}})
+    def test_github_adapter_reports_partial_or_rate_limit_failure(self, _parse, _validate, _run, _which):
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            (repo / ".zzzops").mkdir()
+            (repo / ".zzzops" / "PROJECT.md").write_text("state", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "rate limit.*partial page"):
+                zzzops.portfolio_snapshot(repo)
+
+    @mock.patch.object(zzzops, "validate_project_state", return_value=[])
+    @mock.patch.object(zzzops, "parse_project_state", return_value={"initialized": True, "backend": "local_files", "repository": None})
+    def test_local_adapter_scans_once_and_retains_malformed_findings(self, _parse, _validate):
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            (repo / ".zzzops").mkdir()
+            (repo / ".zzzops" / "PROJECT.md").write_text("state", encoding="utf-8")
+            items = repo / "goals" / "items"
+            items.mkdir(parents=True)
+            (items / "G-1.md").write_text(
+                "---\nid: G-1\ntitle: First\nstatus: ready\npriority: P1\nvalue: high\ndifficulty: S\nconfidence: high\n"
+                "parent: null\ndepends_on: []\nblocks: []\nneeds_human: false\nclaim: {owner: null}\n---\n\n"
+                "## Approach and next action\n\n**Next action:** Prove it.\n",
+                encoding="utf-8",
+            )
+            (items / "broken.md").write_text("not a goal", encoding="utf-8")
+            (repo / "goals" / "INDEX.md").write_text("[G-1](items/G-1.md)\n[broken](items/broken.md)\n", encoding="utf-8")
+            snapshot = zzzops.portfolio_snapshot(repo)
+        self.assertFalse(snapshot["complete"])
+        self.assertEqual(1, snapshot["summary"]["total"])
+        self.assertEqual(1, snapshot["summary"]["reads"])
+        self.assertEqual("goals/items/G-1.md", snapshot["goals"][0]["path"])
+        self.assertEqual("malformed_record", snapshot["findings"][0]["code"])
+
+    @mock.patch.object(zzzops, "validate_project_state", return_value=[])
+    @mock.patch.object(zzzops, "parse_project_state", return_value={"initialized": True, "backend": "local_files", "repository": None})
+    def test_local_adapter_detects_duplicate_identity_and_cycles(self, _parse, _validate):
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            (repo / ".zzzops").mkdir()
+            (repo / ".zzzops" / "PROJECT.md").write_text("state", encoding="utf-8")
+            items = repo / "goals" / "items"
+            items.mkdir(parents=True)
+            template = (
+                "---\nid: {id}\ntitle: {id}\nstatus: ready\npriority: P2\nvalue: medium\ndifficulty: S\nconfidence: high\n"
+                "parent: null\ndepends_on: [{dependency}]\nblocks: [{block}]\nneeds_human: false\nclaim: {{owner: null}}\n---\n\n"
+                "## Approach and next action\n\n**Next action:** Probe.\n"
+            )
+            (items / "G-A.md").write_text(template.format(id="G-A", dependency="G-B", block="G-B"), encoding="utf-8")
+            (items / "G-B.md").write_text(template.format(id="G-B", dependency="G-A", block="G-A"), encoding="utf-8")
+            (items / "duplicate.md").write_text(template.format(id="G-A", dependency="G-B", block="G-B"), encoding="utf-8")
+            (repo / "goals" / "INDEX.md").write_text(
+                "[A](items/G-A.md)\n[B](items/G-B.md)\n[duplicate](items/duplicate.md)\n", encoding="utf-8",
+            )
+            snapshot = zzzops.portfolio_snapshot(repo)
+        codes = {finding["code"] for finding in snapshot["findings"]}
+        self.assertTrue({"duplicate_identity", "depends_on_cycle", "filename_identity_mismatch"}.issubset(codes))
+
+    def test_large_graph_is_iterative_and_invalid_states_are_not_actionable(self):
+        chain = [{"key": index, "parent": None, "depends_on": [] if index == 0 else [index - 1]} for index in range(1500)]
+        self.assertEqual(set(), zzzops._cycle_nodes(chain, "depends_on"))
+        chain[0]["depends_on"] = [1499]
+        self.assertEqual(1500, len(zzzops._cycle_nodes(chain, "depends_on")))
+        records = [
+            zzzops.github_goal_record(self.issue(1, status="new")),
+            zzzops.github_goal_record(self.issue(2, status="triaged")),
+            zzzops.github_goal_record(self.issue(3, status="cancelled")),
+            zzzops.github_goal_record(self.issue(4, depends_on=[3])),
+        ]
+        snapshot = zzzops.build_portfolio_snapshot("github_issues", records, reads=1, raw_bytes=100)
+        self.assertEqual(0, snapshot["summary"]["actionable"])
+        self.assertFalse(snapshot["valid"])
+        self.assertIn("cancelled_dependency", {finding["code"] for finding in snapshot["findings"]})
+
+    def test_projection_benchmark_fixture_is_repeatable(self):
+        context = ("Observable outcome, acceptance evidence, scope, decisions, and resumable history. " * 18).strip()
+        issues = []
+        for number in range(1, 121):
+            issue = self.issue(number)
+            goal = zzzops.parse_managed_goal(issue["body"], number)
+            issue["body"] = zzzops.render_managed_goal(goal, f"## Outcome / Why\n\n{context}\n", number)
+            issues.append(issue)
+        raw_bytes = sum(len((issue["title"] + issue["body"]).encode("utf-8")) for issue in issues)
+        snapshot = zzzops.build_portfolio_snapshot(
+            "github_issues", [zzzops.github_goal_record(issue) for issue in issues], reads=2, raw_bytes=raw_bytes,
+        )
+        json_bytes = len(json.dumps(snapshot, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        summary_bytes = len(zzzops.render_portfolio_summary(snapshot).encode("utf-8"))
+        self.assertEqual(2, snapshot["summary"]["reads"])
+        self.assertLess(json_bytes, raw_bytes)
+        self.assertLess(summary_bytes, json_bytes)
+
+    def test_compare_reports_added_removed_and_changed_goals(self):
+        current = zzzops.build_portfolio_snapshot("local_files", [
+            {"key": "A", "title": "A", "status": "ready", "priority": "P1", "value": "high", "difficulty": "S", "confidence": "high", "parent": None, "depends_on": [], "claim": None, "needs_human": False, "blocker_categories": [], "next_action": "A", "revision": 2, "digest": "new", "updated_at": None, "implementation": None, "labels": []},
+            {"key": "C", "title": "C", "status": "ready", "priority": "P2", "value": "medium", "difficulty": "S", "confidence": "high", "parent": None, "depends_on": [], "claim": None, "needs_human": False, "blocker_categories": [], "next_action": "C", "revision": 1, "digest": "c", "updated_at": None, "implementation": None, "labels": []},
+        ], reads=1, raw_bytes=10)
+        prior = {"schema_version": 1, "goals": [{"key": "A", "revision": 1, "digest": "old"}, {"key": "B", "revision": 1, "digest": "b"}]}
+        self.assertEqual(["goal_changed", "goal_removed", "goal_added"], [finding["code"] for finding in zzzops.compare_portfolios(current, prior)])
+        with self.assertRaisesRegex(ValueError, "malformed goal"):
+            zzzops.compare_portfolios(current, {"schema_version": 1, "goals": [None]})
+
 
 class WorkflowContractTests(unittest.TestCase):
+    def test_management_workflows_use_one_complete_portfolio_snapshot(self):
+        root = Path(__file__).parent
+        backend = (root.parent / ".zzzops" / "rules" / "BACKENDS.md").read_text(encoding="utf-8")
+        self.assertIn("portfolio --format json", backend)
+        self.assertIn("complete:true", backend)
+        self.assertIn("valid:true", backend)
+        self.assertIn("re-read only the selected canonical goal", backend.casefold())
+        for relative in (
+            "skills/add-zzzops-goal/SKILL.md", "skills/analyze-zzzops-usage/SKILL.md",
+            "skills/migrate-zzzops-todos/SKILL.md", "skills/suggest-zzzops-work/SKILL.md",
+            "skills/execute-zzzops/references/CREATE.md", "skills/execute-zzzops/references/EXECUTE.md",
+            "skills/execute-zzzops/references/UNBLOCK.md",
+        ):
+            text = (root / relative).read_text(encoding="utf-8")
+            self.assertIn("snapshot", text.casefold(), relative)
+
     def test_github_schema_is_issue_native_while_local_ids_remain(self):
         self.assertIn("schema_version", zzzops.GOAL_FIELDS)
         for derived in ("id", "title", "blocks", "needs_human"):

--- a/.agents/zzzops.py
+++ b/.agents/zzzops.py
@@ -23,6 +23,7 @@ PROJECT_SCHEMA_VERSION = 1
 PLAN_SCHEMA_VERSION = 1
 POLICY_SCHEMA_VERSION = 1
 GOAL_SCHEMA_VERSION = 1
+PORTFOLIO_SCHEMA_VERSION = 1
 PROJECT_BLOCK_START = "<!-- zzzops-project-state"
 PROJECT_BLOCK_END = "zzzops-project-state -->"
 GOAL_BLOCK_START = "<!-- zzzops-goal"
@@ -49,6 +50,11 @@ BLOCKER_CATEGORIES = {
     "specification", "decision", "access-approval", "human-action",
     "external-dependency", "technical-unknown", "safety-compliance",
 }
+GOAL_STATUSES = {"new", "triaged", "ready", "in_progress", "blocked", "done", "cancelled"}
+GOAL_PRIORITIES = {"P0", "P1", "P2", "P3"}
+GOAL_VALUES = {"critical", "high", "medium", "low"}
+GOAL_DIFFICULTIES = {"unknown", "XS", "S", "M", "L", "XL"}
+GOAL_CONFIDENCES = {"low", "medium", "high"}
 REDUNDANT_GOAL_TITLE_PREFIX = re.compile(r"^\[G-\d{8}-\d{3}-[^\]]+\]\s*")
 
 PREFERENCE_LABELS = (
@@ -416,6 +422,12 @@ def validate_managed_goal(goal: Any, issue_number: int | None = None) -> list[st
     for field in required_text:
         if not text_present(goal.get(field)):
             errors.append(f"{field} is required")
+    for field, allowed in (
+        ("status", GOAL_STATUSES), ("priority", GOAL_PRIORITIES), ("value", GOAL_VALUES),
+        ("difficulty", GOAL_DIFFICULTIES), ("confidence", GOAL_CONFIDENCES),
+    ):
+        if text_present(goal.get(field)) and goal[field] not in allowed:
+            errors.append(f"{field} is invalid")
     for field in ("depends_on", "blockers", "evidence"):
         if not isinstance(goal.get(field), list):
             errors.append(f"{field} must be a list")
@@ -506,6 +518,375 @@ def validate_github_issue_goal(issue_number: Any, title: Any, body: Any) -> list
         if goal is None:
             errors.append("managed goal block is required")
     return errors
+
+
+def _inline_yaml_value(value: str) -> Any:
+    value = value.strip()
+    if value in {"", "null", "~"}:
+        return None
+    if value.casefold() in {"true", "false"}:
+        return value.casefold() == "true"
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        return [] if not inner else [item.strip().strip('"\'') for item in inner.split(",")]
+    if value.startswith("{") and value.endswith("}"):
+        result = {}
+        for item in value[1:-1].split(","):
+            key, separator, nested = item.partition(":")
+            if not separator:
+                raise ValueError(f"invalid inline mapping: {value}")
+            result[key.strip()] = _inline_yaml_value(nested)
+        return result
+    return value.strip('"\'')
+
+
+def parse_local_goal(path: Path, repo: Path | None = None) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8-sig")
+    match = re.match(r"---\s*\n(.*?)\n---\s*\n", text, re.DOTALL)
+    if not match:
+        raise ValueError("missing YAML frontmatter")
+    frontmatter = match.group(1)
+    fields: dict[str, Any] = {}
+    implementation: dict[str, Any] = {}
+    in_implementation = False
+    for line in frontmatter.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        key, separator, value = line.strip().partition(":")
+        if not separator:
+            raise ValueError(f"invalid frontmatter line: {line}")
+        if indent == 0:
+            in_implementation = key == "implementation"
+            if not in_implementation:
+                fields[key] = _inline_yaml_value(value)
+        elif in_implementation and indent == 2:
+            implementation[key] = _inline_yaml_value(value)
+    if implementation:
+        fields["implementation"] = implementation
+    for required in ("id", "title", "status", "priority", "value", "difficulty", "confidence"):
+        if not text_present(fields.get(required)):
+            raise ValueError(f"{required} is required")
+    for field, allowed in (
+        ("status", GOAL_STATUSES), ("priority", GOAL_PRIORITIES), ("value", GOAL_VALUES),
+        ("difficulty", GOAL_DIFFICULTIES), ("confidence", GOAL_CONFIDENCES),
+    ):
+        if fields[field] not in allowed:
+            raise ValueError(f"{field} is invalid")
+    for relation in ("depends_on", "blocks"):
+        if not isinstance(fields.get(relation, []), list):
+            raise ValueError(f"{relation} must be an inline list")
+    blocker_categories = re.findall(
+        r"Status/category/raised/owner:\s*open\s*/\s*`?([a-z-]+)`?", text[match.end():], re.IGNORECASE,
+    )
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return {
+        "key": fields["id"], "title": fields["title"], "status": fields["status"],
+        "priority": fields["priority"], "value": fields["value"], "difficulty": fields["difficulty"],
+        "confidence": fields["confidence"], "parent": fields.get("parent"),
+        "depends_on": fields.get("depends_on", []), "claim": fields.get("claim"),
+        "needs_human": bool(fields.get("needs_human")) or bool(blocker_categories),
+        "blocker_categories": blocker_categories, "next_action": _extract_next_action(text),
+        "revision": None, "digest": digest, "updated_at": fields.get("updated"),
+        "implementation": fields.get("implementation"), "labels": [],
+        "path": path.relative_to(repo).as_posix() if repo is not None else path.name,
+        "declared_blocks": fields.get("blocks", []), "filename": path.stem,
+    }
+
+
+def _extract_next_action(text: str) -> str:
+    match = re.search(r"\*\*Next action:\*\*\s*(.+)", text)
+    return match.group(1).strip() if match else ""
+
+
+def github_goal_record(issue: dict[str, Any]) -> dict[str, Any]:
+    number = issue.get("number")
+    body = issue.get("body") or ""
+    goal = parse_managed_goal(body, number)
+    if goal is None:
+        raise ValueError("managed goal block is required")
+    errors = validate_github_issue_goal(number, issue.get("title"), body)
+    if errors:
+        raise ValueError("; ".join(errors))
+    digest_source = "\0".join((issue.get("title") or "", body, issue.get("updated_at") or ""))
+    return {
+        "key": number, "title": issue["title"], "status": goal["status"],
+        "priority": goal["priority"], "value": goal["value"], "difficulty": goal["difficulty"],
+        "confidence": goal["confidence"], "parent": goal["parent"],
+        "depends_on": goal["depends_on"], "claim": goal["claim"],
+        "needs_human": goal_needs_human(goal),
+        "blocker_categories": sorted({blocker["category"] for blocker in goal["blockers"] if blocker.get("status") == "open"}),
+        "next_action": goal["next_action"], "revision": goal["revision"],
+        "digest": hashlib.sha256(digest_source.encode("utf-8")).hexdigest(),
+        "updated_at": issue.get("updated_at"), "implementation": goal.get("implementation"),
+        "labels": sorted(label["name"] for label in issue.get("labels", []) if isinstance(label, dict) and text_present(label.get("name"))),
+        "state": issue.get("state"), "url": issue.get("html_url"),
+    }
+
+
+def _cycle_nodes(records: list[dict[str, Any]], relation: str) -> set[Any]:
+    graph = {}
+    for record in records:
+        values = record.get(relation)
+        graph[record["key"]] = ([values] if relation == "parent" and values is not None else values or [])
+    state: dict[Any, int] = {}
+    cycles: set[Any] = set()
+    for start in graph:
+        if state.get(start):
+            continue
+        path: list[Any] = [start]
+        positions = {start: 0}
+        state[start] = 1
+        stack = [(start, iter(graph[start]))]
+        while stack:
+            node, targets = stack[-1]
+            try:
+                target = next(targets)
+            except StopIteration:
+                stack.pop()
+                state[node] = 2
+                positions.pop(node, None)
+                path.pop()
+                continue
+            if target not in graph or state.get(target) == 2:
+                continue
+            if state.get(target) == 1:
+                cycles.update(path[positions[target]:])
+                continue
+            state[target] = 1
+            positions[target] = len(path)
+            path.append(target)
+            stack.append((target, iter(graph[target])))
+    return cycles
+
+
+def _portfolio_key(value: Any) -> tuple[int, Any]:
+    return (0, value) if isinstance(value, int) and not isinstance(value, bool) else (1, str(value))
+
+
+def audit_portfolio(records: list[dict[str, Any]], backend: str, as_of: datetime | None = None) -> list[dict[str, Any]]:
+    as_of = datetime.now(timezone.utc) if as_of is None else as_of
+    findings: list[dict[str, Any]] = []
+    grouped: dict[Any, list[dict[str, Any]]] = {}
+    for record in records:
+        grouped.setdefault(record["key"], []).append(record)
+    for key, matches in grouped.items():
+        if len(matches) > 1:
+            findings.append({"code": "duplicate_identity", "goal": key, "detail": f"{len(matches)} records"})
+    goals = {key: matches[0] for key, matches in grouped.items()}
+    for record in records:
+        key = record["key"]
+        relations = ([record["parent"]] if record.get("parent") is not None else []) + list(record.get("depends_on", []))
+        if len(record.get("depends_on", [])) != len(set(record.get("depends_on", []))):
+            findings.append({"code": "duplicate_dependency", "goal": key, "detail": "dependency repeated"})
+        for target in relations:
+            if target == key:
+                findings.append({"code": "self_relation", "goal": key, "detail": str(target)})
+            elif target not in goals:
+                findings.append({"code": "missing_relation", "goal": key, "detail": str(target)})
+        if record["status"] == "done":
+            unfinished = [str(target) for target in record.get("depends_on", []) if target in goals and goals[target]["status"] != "done"]
+            if unfinished:
+                findings.append({"code": "done_with_unfinished_dependency", "goal": key, "detail": ",".join(unfinished)})
+        cancelled = [str(target) for target in record.get("depends_on", []) if target in goals and goals[target]["status"] == "cancelled"]
+        if cancelled:
+            findings.append({"code": "cancelled_dependency", "goal": key, "detail": ",".join(cancelled)})
+        claim = record.get("claim")
+        if isinstance(claim, dict) and claim.get("owner") and claim.get("expires_at"):
+            try:
+                expires = datetime.fromisoformat(str(claim["expires_at"]).replace("Z", "+00:00"))
+                if expires.tzinfo is None:
+                    raise ValueError("timezone missing")
+                if expires < as_of:
+                    findings.append({"code": "stale_claim", "goal": key, "detail": str(claim["expires_at"])})
+            except ValueError:
+                findings.append({"code": "invalid_claim_expiry", "goal": key, "detail": str(claim["expires_at"])})
+        review = (record.get("implementation") or {}).get("review") if isinstance(record.get("implementation"), dict) else None
+        if isinstance(review, dict) and review.get("status") == "pending" and not review.get("checkpoint"):
+            findings.append({"code": "pending_review_without_checkpoint", "goal": key, "detail": "checkpoint missing"})
+        if backend == "github_issues":
+            if isinstance(review, dict) and review.get("status") == "approved" and not (record.get("implementation") or {}).get("pr"):
+                findings.append({"code": "approved_review_without_pr", "goal": key, "detail": "PR missing"})
+            expected = {"zzzops", f"zzzops:status:{record['status']}", f"zzzops:priority:{record['priority']}"}
+            actual = set(record.get("labels", []))
+            drift = sorted(expected - actual)
+            stale = sorted(label for label in actual if (label.startswith("zzzops:status:") or label.startswith("zzzops:priority:")) and label not in expected)
+            if drift or stale:
+                findings.append({"code": "label_drift", "goal": key, "detail": f"missing={drift}; stale={stale}"})
+            terminal = record["status"] in {"done", "cancelled"}
+            if terminal != (record.get("state") == "closed"):
+                findings.append({"code": "issue_state_drift", "goal": key, "detail": f"goal={record['status']}; issue={record.get('state')}"})
+        elif backend == "local_files":
+            if record.get("filename") != key:
+                findings.append({"code": "filename_identity_mismatch", "goal": key, "detail": str(record.get("filename"))})
+            if set(record.get("declared_blocks", [])) != set(record.get("blocks", [])):
+                findings.append({"code": "local_backlink_drift", "goal": key, "detail": f"declared={record.get('declared_blocks', [])}; derived={record.get('blocks', [])}"})
+    for relation in ("depends_on", "parent"):
+        for key in sorted(_cycle_nodes(records, relation), key=_portfolio_key):
+            findings.append({"code": f"{relation}_cycle", "goal": key, "detail": "cycle member"})
+    return sorted(findings, key=lambda finding: (finding["code"], str(finding["goal"]), finding["detail"]))
+
+
+def build_portfolio_snapshot(
+    backend: str, records: list[dict[str, Any]], *, reads: int, raw_bytes: int,
+    ignored: int = 0, as_of: datetime | None = None,
+) -> dict[str, Any]:
+    for record in records:
+        record["children"] = []
+        record["blocks"] = []
+    by_key = {record["key"]: record for record in records}
+    for record in records:
+        if record.get("parent") in by_key:
+            by_key[record["parent"]]["children"].append(record["key"])
+        for dependency in record.get("depends_on", []):
+            if dependency in by_key:
+                by_key[dependency]["blocks"].append(record["key"])
+    for record in records:
+        record["children"].sort(key=_portfolio_key)
+        record["blocks"].sort(key=_portfolio_key)
+    findings = audit_portfolio(records, backend, as_of)
+    terminal = {"done", "cancelled"}
+    blocked = {record["key"] for record in records if record["status"] == "blocked" or record["needs_human"]}
+    terminal_keys = {record["key"] for record in records if record["status"] in terminal}
+    done = {record["key"] for record in records if record["status"] == "done"}
+    actionable = [
+        record["key"] for record in records
+        if record["status"] in {"ready", "in_progress"} and record["key"] not in blocked
+        and all(dependency in done for dependency in record.get("depends_on", []))
+    ]
+    portfolio_digest = hashlib.sha256(
+        "\n".join(f"{record['key']}:{record['revision']}:{record['digest']}" for record in sorted(records, key=lambda item: _portfolio_key(item["key"]))).encode("utf-8")
+    ).hexdigest()
+    return {
+        "schema_version": PORTFOLIO_SCHEMA_VERSION, "backend": backend, "complete": True,
+        "valid": not findings,
+        "portfolio_digest": portfolio_digest, "goals": sorted(records, key=lambda record: _portfolio_key(record["key"])),
+        "findings": findings, "summary": {
+            "total": len(records), "actionable": len(actionable), "blocked": len(blocked),
+            "done": len(terminal_keys), "findings": len(findings), "reads": reads,
+            "raw_bytes": raw_bytes, "ignored": ignored,
+        },
+    }
+
+
+def portfolio_snapshot(repo: Path, as_of: datetime | None = None) -> dict[str, Any]:
+    project_path = repo / ".zzzops" / "PROJECT.md"
+    if not project_path.is_file():
+        raise ValueError("PROJECT.md is missing; run agent-driven initialization")
+    project = parse_project_state(project_path.read_text(encoding="utf-8-sig"))
+    errors = validate_project_state(project)
+    if errors or not project or not project.get("initialized"):
+        raise ValueError("PROJECT.md is not initialized: " + "; ".join(errors or ["initialization pending"]))
+    backend = project["backend"]
+    if backend == "local_files":
+        item_root = repo / "goals" / "items"
+        paths = sorted(item_root.glob("*.md")) if item_root.is_dir() else []
+        records = []
+        findings = []
+        raw_bytes = 0
+        for path in paths:
+            try:
+                if path.is_symlink():
+                    raise ValueError("symbolic-link goal files are not supported")
+                raw_bytes += path.stat().st_size
+                records.append(parse_local_goal(path, repo))
+            except (OSError, UnicodeError, ValueError) as exc:
+                findings.append({"code": "malformed_record", "goal": path.name, "detail": str(exc)})
+        index_path = repo / "goals" / "INDEX.md"
+        expected_links = {path.name for path in paths}
+        if expected_links and not index_path.is_file():
+            findings.append({"code": "local_index_drift", "goal": "goals/INDEX.md", "detail": "derived index missing"})
+        elif index_path.is_file():
+            try:
+                index_text = index_path.read_text(encoding="utf-8-sig")
+                actual_links = set(re.findall(r"items/([^\s)>]+\.md)", index_text))
+                if actual_links != expected_links:
+                    findings.append({"code": "local_index_drift", "goal": "goals/INDEX.md", "detail": f"missing={sorted(expected_links - actual_links)}; stale={sorted(actual_links - expected_links)}"})
+            except (OSError, UnicodeError) as exc:
+                findings.append({"code": "local_index_drift", "goal": "goals/INDEX.md", "detail": str(exc)})
+        snapshot = build_portfolio_snapshot(backend, records, reads=1, raw_bytes=raw_bytes, as_of=as_of)
+        snapshot["findings"] = sorted(snapshot["findings"] + findings, key=lambda item: (item["code"], str(item["goal"])))
+        snapshot["summary"]["findings"] = len(snapshot["findings"])
+        snapshot["complete"] = not findings
+        snapshot["valid"] = not snapshot["findings"]
+        snapshot["summary"]["processes"] = 0
+        return snapshot
+    identity = ((project.get("repository") or {}).get("identity") if isinstance(project.get("repository"), dict) else None)
+    if not text_present(identity):
+        raise ValueError("PROJECT.md repository.identity is required for GitHub Issues")
+    executable = shutil.which("gh")
+    if not executable:
+        raise ValueError("GitHub CLI is unavailable")
+    command = [executable, "api", "--paginate", "--slurp", f"repos/{identity}/issues?state=all&labels=zzzops&per_page=100"]
+    try:
+        result = subprocess.run(command, cwd=repo, capture_output=True, text=True, encoding="utf-8", timeout=60, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"GitHub portfolio read failed: {type(exc).__name__}") from exc
+    if result.returncode:
+        raise ValueError("GitHub portfolio read failed: " + (result.stderr.strip() or "unknown gh error"))
+    try:
+        pages = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"GitHub portfolio read returned invalid JSON: {exc}") from exc
+    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+        raise ValueError("GitHub portfolio pagination result is incomplete or malformed")
+    issues = [issue for page in pages for issue in page if isinstance(issue, dict) and "pull_request" not in issue]
+    managed = [issue for issue in issues if GOAL_BLOCK_START in (issue.get("body") or "")]
+    records = []
+    findings = []
+    for issue in managed:
+        try:
+            records.append(github_goal_record(issue))
+        except (KeyError, TypeError, ValueError) as exc:
+            findings.append({"code": "malformed_record", "goal": issue.get("number", "unknown"), "detail": str(exc)})
+    snapshot = build_portfolio_snapshot(
+        backend, records, reads=len(pages), raw_bytes=len(result.stdout.encode("utf-8")),
+        ignored=len(issues) - len(managed), as_of=as_of,
+    )
+    snapshot["findings"] = sorted(snapshot["findings"] + findings, key=lambda item: (item["code"], str(item["goal"])))
+    snapshot["summary"]["findings"] = len(snapshot["findings"])
+    snapshot["complete"] = not findings
+    snapshot["valid"] = not snapshot["findings"]
+    snapshot["summary"]["processes"] = 1
+    return snapshot
+
+
+def render_portfolio_summary(snapshot: dict[str, Any], include_done: bool = False) -> str:
+    summary = snapshot["summary"]
+    lines = [
+        f"ZzzOps portfolio: {snapshot['backend']} | goals={summary['total']} actionable={summary['actionable']} "
+        f"blocked={summary['blocked']} done={summary['done']} findings={summary['findings']} reads={summary['reads']} "
+        f"complete={str(snapshot['complete']).lower()} valid={str(snapshot['valid']).lower()}",
+        f"digest={snapshot['portfolio_digest']}",
+    ]
+    for goal in snapshot["goals"]:
+        if not include_done and goal["status"] in {"done", "cancelled"}:
+            continue
+        human = " human" if goal["needs_human"] else ""
+        title = re.sub(r"\s+", " ", str(goal["title"])).strip()[:240]
+        next_action = re.sub(r"\s+", " ", str(goal["next_action"])).strip()[:240]
+        lines.append(f"{goal['key']} [{goal['status']} {goal['priority']}/{goal['value']}/{goal['difficulty']}{human}] {title} — {next_action}")
+    for finding in snapshot["findings"]:
+        lines.append(f"! {finding['code']} {finding['goal']}: {finding['detail']}")
+    return "\n".join(lines)
+
+
+def compare_portfolios(snapshot: dict[str, Any], prior: dict[str, Any]) -> list[dict[str, Any]]:
+    if prior.get("schema_version") != PORTFOLIO_SCHEMA_VERSION or not isinstance(prior.get("goals"), list):
+        raise ValueError("comparison snapshot has an unsupported schema")
+    if any(not isinstance(goal, dict) or "key" not in goal or "digest" not in goal or "revision" not in goal for goal in prior["goals"]):
+        raise ValueError("comparison snapshot contains a malformed goal")
+    current = {goal["key"]: goal for goal in snapshot["goals"]}
+    previous = {goal["key"]: goal for goal in prior["goals"]}
+    findings = []
+    for key in sorted(current.keys() | previous.keys(), key=_portfolio_key):
+        if key not in previous:
+            findings.append({"code": "goal_added", "goal": key, "detail": "absent from comparison snapshot"})
+        elif key not in current:
+            findings.append({"code": "goal_removed", "goal": key, "detail": "absent from current snapshot"})
+        elif current[key].get("digest") != previous[key].get("digest") or current[key].get("revision") != previous[key].get("revision"):
+            findings.append({"code": "goal_changed", "goal": key, "detail": "digest or revision changed"})
+    return findings
 
 
 def command_probe(command: list[str], repo: Path) -> dict[str, Any]:
@@ -1223,6 +1604,11 @@ def main() -> int:
     confirm_command.add_argument("--reviewer", required=True)
     confirm_command.add_argument("--section", action="append", default=[])
     confirm_command.add_argument("--all", action="store_true", help="Approve every current policy section")
+    portfolio_parser = commands.add_parser("portfolio", help="Read and audit the canonical goal portfolio once")
+    portfolio_parser.add_argument("--format", dest="output_format", choices=("summary", "json"), default="summary")
+    portfolio_parser.add_argument("--include-done", action="store_true", help="Include terminal goals in summary output")
+    portfolio_parser.add_argument("--as-of", help="Injected ISO-8601 audit instant for deterministic claim checks")
+    portfolio_parser.add_argument("--compare", type=Path, help="Prior JSON snapshot used only to report digest/revision drift")
     usage_parser = commands.add_parser("usage", help="Operate ignored local usage accounting")
     usage_commands = usage_parser.add_subparsers(dest="usage_command", required=True)
     usage_commands.add_parser("ensure", help="Create the local ledger from its template if absent")
@@ -1264,6 +1650,27 @@ def main() -> int:
             else:
                 result = confirm_project(repo, args.project_digest, args.reviewer, args.section, args.all)
                 print(json.dumps(result, indent=2))
+        elif args.command == "portfolio":
+            try:
+                as_of = None
+                if args.as_of:
+                    as_of = datetime.fromisoformat(args.as_of.replace("Z", "+00:00"))
+                    if as_of.tzinfo is None:
+                        raise ValueError("--as-of must include a timezone")
+                result = portfolio_snapshot(repo, as_of)
+                if args.compare:
+                    prior = json.loads(args.compare.resolve().read_text(encoding="utf-8-sig"))
+                    result["changes"] = compare_portfolios(result, prior)
+                if args.output_format == "json":
+                    print(json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+                else:
+                    print(render_portfolio_summary(result, args.include_done))
+            except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+                if args.output_format == "json":
+                    print(json.dumps({"schema_version": PORTFOLIO_SCHEMA_VERSION, "complete": False, "valid": False, "error": str(exc)}, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+                else:
+                    print(f"ERROR: {exc}")
+                return 2
         elif args.command == "usage":
             result = ensure_usage_ledger(repo)
             print(json.dumps(result, indent=2, ensure_ascii=False))

--- a/.zzzops/rules/BACKENDS.md
+++ b/.zzzops/rules/BACKENDS.md
@@ -2,6 +2,8 @@
 
 `.zzzops/PROJECT.md` selects exactly one authority.
 
+At each decision checkpoint run `python .agents/zzzops.py --repo . portfolio --format json` once. Require `complete:true` and `valid:true`; use its compact inventory/graph/human queue. It omits criteria/history, so re-read only the selected canonical goal before writing and match revision/digest. Refresh after relevant mutation or drift.
+
 When initialization selects GitHub while local goals exist, shared state must set `migration_pending:true`. Until an approved migration clears it, local files remain transitional truth and other ordinary workflows stop; never read/write both as co-authorities.
 
 ## GitHub Issues (`github_issues`)
@@ -12,7 +14,7 @@ Prefer when inspect plus a read-only `gh api repos/{owner}/{repo}` probe confirm
 - Append one compact hidden `<!-- zzzops-goal ... zzzops-goal -->` JSON block using `.agents/zzzops.py`. It stores state only: GitHub supplies identity/title; inverse `blocks`, human-queue membership, labels, and open/closed are derived. Preserve human/unmanaged text.
 - Same-repository parent/dependency relations are positive issue numbers. Derive children/blocking edges portfolio-wide. Put resolutions/history in append-only comments; old comments remain immutable provenance.
 - Use label `zzzops`, one `zzzops:status:*`, and one `zzzops:priority:*` as derived indexes.
-- Before update, re-read issue plus `updated_at`; parse/validate the block and abort/reconcile if the observed digest/revision changed. Paginate portfolio reads.
+- Before update, re-read issue plus `updated_at`; parse/validate the block and abort/reconcile if the snapshot digest/revision changed. The batch command paginates once and reports incomplete reads instead of guessing.
 - Capability/auth/permission/disabled-Issues/label drift is an explicit blocker. Never fall back to local files automatically.
 
 ## Local files (`local_files`)

--- a/README.md
+++ b/README.md
@@ -103,11 +103,14 @@ Use $execute-zzzops to interview me about and unblock blocked goals.
 Use $execute-zzzops to reprioritize all goals against project KPIs.
 Use $analyze-zzzops-usage to analyze value-per-token efficiency and recommend changes.
 Use $suggest-zzzops-work in dry-run mode to audit the project and suggest valuable goals.
+python .agents/zzzops.py --repo . portfolio --format summary  # compact read-only queue/DAG audit
 ```
 
 In Claude Code, replace `$name` with `/name`, for example `/analyze-zzzops-usage`.
 
 Maintainers: see the [skill discovery and mode contract](docs/SKILLS.md).
+
+Portfolio batching benchmarks and the machine contract are documented in [portfolio performance](docs/PERFORMANCE.md).
 
 Usage analysis reports real KPI/outcome efficiency when measurable, plus a clearly labeled heuristic for cross-goal comparison. It also tracks management overhead, because spending 40,000 tokens organizing a 3,000-token fix is not “agentic”—it is a committee.
 
@@ -193,24 +196,24 @@ python .agents/prompt_stats.py --check
 <!-- PROMPT_BUDGET_START -->
 | Prompt | Bytes | Est. tokens |
 | --- | ---: | ---: |
-| `.agents/skills/add-zzzops-goal/SKILL.md` | 1265 | 317 |
-| `.agents/skills/analyze-zzzops-usage/SKILL.md` | 2412 | 603 |
+| `.agents/skills/add-zzzops-goal/SKILL.md` | 1304 | 326 |
+| `.agents/skills/analyze-zzzops-usage/SKILL.md` | 2491 | 623 |
 | `.agents/skills/execute-zzzops/SKILL.md` | 2427 | 607 |
 | `.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md` | 3454 | 864 |
-| `.agents/skills/execute-zzzops/references/CREATE.md` | 2893 | 724 |
-| `.agents/skills/execute-zzzops/references/EXECUTE.md` | 3324 | 831 |
+| `.agents/skills/execute-zzzops/references/CREATE.md` | 2925 | 732 |
+| `.agents/skills/execute-zzzops/references/EXECUTE.md` | 3448 | 862 |
 | `.agents/skills/execute-zzzops/references/SELF_REVIEW.md` | 1345 | 337 |
-| `.agents/skills/execute-zzzops/references/UNBLOCK.md` | 1563 | 391 |
+| `.agents/skills/execute-zzzops/references/UNBLOCK.md` | 1564 | 391 |
 | `.agents/skills/install-zzzops/SKILL.md` | 1471 | 368 |
-| `.agents/skills/migrate-zzzops-todos/SKILL.md` | 2062 | 516 |
-| `.agents/skills/suggest-zzzops-work/SKILL.md` | 2743 | 686 |
+| `.agents/skills/migrate-zzzops-todos/SKILL.md` | 2119 | 530 |
+| `.agents/skills/suggest-zzzops-work/SKILL.md` | 2793 | 699 |
 | `.agents/templates/project-goals/GOAL.md` | 1992 | 498 |
 | `.agents/templates/project-goals/INDEX.md` | 1135 | 284 |
 | `.agents/templates/project-goals/MIGRATION_SUMMARY.md` | 194 | 49 |
 | `.agents/templates/project-goals/PROJECT.md` | 2416 | 604 |
 | `.agents/templates/project-goals/USAGE_LEDGER.md` | 1105 | 277 |
 | `.claude/skills/install-zzzops/SKILL.md` | 382 | 96 |
-| `.zzzops/rules/BACKENDS.md` | 2389 | 598 |
+| `.zzzops/rules/BACKENDS.md` | 2787 | 697 |
 | `.zzzops/rules/BLOCKERS.md` | 2238 | 560 |
 | `.zzzops/rules/CONTINUATION.md` | 1505 | 377 |
 | `.zzzops/rules/EXECUTION_STRATEGY.md` | 3663 | 916 |
@@ -220,7 +223,7 @@ python .agents/prompt_stats.py --check
 | `.zzzops/rules/USAGE_ACCOUNTING.md` | 2505 | 627 |
 | `AGENTS.md` | 2963 | 741 |
 | `CLAUDE.md` | 217 | 55 |
-| **Total** | **55151** | **13800** |
+| **Total** | **55931** | **13994** |
 <!-- PROMPT_BUDGET_END -->
 
 </details>

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,23 @@
+# Portfolio performance
+
+ZzzOps reads canonical goals once per decision checkpoint:
+
+```powershell
+python .agents/zzzops.py --repo . portfolio --format summary
+python .agents/zzzops.py --repo . portfolio --format json
+```
+
+The stable JSON projection contains selection, graph, blocker, claim, review, revision, and digest fields—not full criteria, evidence, comments, or history. Agents re-read only the selected goal before mutation. `complete:false`, `valid:false`, or a nonzero exit forbids selection from partial or structurally unsafe state. `--compare prior.json` reports added, removed, or changed digests/revisions without repairing state.
+
+## First-release baseline
+
+Observed on 2026-07-17 on the maintainer's Windows machine; elapsed time is illustrative, bytes/call counts are the repeatable cross-harness measures. Token usage remains unavailable unless a harness reports it, so byte reductions are not presented as billing tokens.
+
+| Backend fixture | Goals | Canonical/API bytes | Compact JSON | Human summary | Backend reads | Observed elapsed |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Live GitHub repository | 28 | 329,199 | 20,793 (-93.7%) | 1,035 (-99.7%) | 1 page / 1 process | 1.282 s |
+| Representative full local goals | 250 | 340,530 | 124,816 (-63.3%) | 13,944 (-95.9%) | 1 bounded scan | 1.145 s |
+
+The previous agent-driven GitHub pattern commonly required one list read plus selected or per-goal detail reads and agent-authored graph summaries. The new command performs one paginated CLI process over `zzzops`-labelled issues, reports the real page count, and still requires one targeted concurrency re-read before mutation. Local files use one sorted `goals/items/*.md` scan plus derived-index comparison.
+
+The utility reports malformed records, duplicate/self/missing/cyclic relations, status/dependency conflicts, stale claims, review checkpoint errors, GitHub label/state drift, and snapshot changes. It never prioritizes, repairs, mutates, caches, or replaces agent judgment.


### PR DESCRIPTION
## Summary
- add one deterministic, read-only portfolio command for GitHub Issues and local-file backends
- emit compact stable JSON or human summaries with DAG, claim, blocker, review, label/state, index, and digest validation
- make management workflows consume one complete/valid snapshot and re-read only selected goals before mutation
- document repeatable byte/call benchmarks and install/CLI behavior

## Measured result
- live GitHub: 28 goals, 1 page/process, 329,199 fetched bytes -> 20,793 JSON bytes (-93.7%) or 1,035 summary bytes (-99.7%)
- representative local: 250 goals, one bounded scan, 340,530 source bytes -> 124,816 JSON bytes (-63.3%)

## Verification
- 50 core workflow/portfolio tests
- 13 health policy tests
- 13 health CLI tests
- real app-data storage test
- 3 installer tests
- 6 semantic-release tests
- prompt accounting/check: 27 prompts, 55,931 bytes, ~13,994 estimated tokens
- compileall and git diff --check

Closes #31