### PR TITLE
fix(migration): preserve completion evidence for agent triage

### DIFF
--- a/.agents/skills/migrate-zzzops-todos/SKILL.md
+++ b/.agents/skills/migrate-zzzops-todos/SKILL.md
@@ -10,9 +10,9 @@ Mode: `dry run`, `preview`, or `plan` reports candidates and a proposed plan in 
 Run `.zzzops/rules/INITIALIZATION.md`, then `.zzzops/rules/BACKENDS.md`. Use `.agents/templates/project-goals/` for artifact shapes.
 Run applicable `.zzzops/rules/HEALTH.md` hooks from reviewed PROJECT policy; nudges never substitute for migration approval.
 
-1. Run `scripts/inventory.py .`. Inspect candidate files and surrounding project context yourself. The inventory is advisory; do not treat syntax as intent.
+1. Run `scripts/inventory.py .`. Inspect candidate files and surrounding project context yourself. The inventory preserves source text; it is advisory, so do not treat syntax as intent or hard-code a universal completion vocabulary.
 2. Ignore managed/dependency/build/generated areas. Compare candidates with `.zzzops/migration/STATE.json` and the complete BACKENDS portfolio snapshot; re-read only likely matches and investigate only new fingerprints. Ask about ownership/exclusions, project outcome/KPIs/acceptance, and consequential ambiguity according to PROJECT interview policy. Reuse existing charter answers.
-3. Copy the installed plan and summary templates into `.zzzops/migration/`. Fill every proposed goal, charter-based value rationale, source disposition, exclusion, and question. Present `SUMMARY.md` and wait for approval.
+3. Copy the installed plan and summary templates into `.zzzops/migration/`. Classify completion evidence (for example `[x]`, `DONE`, or local conventions) from full context; summarize skipped completed items with reasons and propose only open work. Fill every proposed goal, charter-based value rationale, source disposition, exclusion, and question. Ask when intent is ambiguous. Present `SUMMARY.md` and wait for approval.
 4. Apply the approved plan to the selected backend: native GitHub issues/comments or local goal files/backlinks. Update charter, history, and `STATE.json` consistently. Keep inline annotations. Delete a dedicated backlog only after all full-context content is represented. Verify results; remove resolved plan/summary.
 
 Only the main agent writes. Repeat runs act only on new fingerprints. Never expose secrets or infer ownership from paths.

--- a/.agents/skills/migrate-zzzops-todos/scripts/test_inventory.py
+++ b/.agents/skills/migrate-zzzops-todos/scripts/test_inventory.py
@@ -40,7 +40,11 @@ class InventoryTests(unittest.TestCase):
                 'print("ready")\n# TODO: Parse quoted values\n# TODO: Parse quoted values\n',
             )
             self.write(root, "README.md", "# Guide\n- [ ] Document setup\n- ordinary bullet\n")
-            self.write(root, "TODO.md", "# Backlog\n- Ship CLI help\n- [ ] Add smoke probe\n")
+            self.write(
+                root,
+                "TODO.md",
+                "# Backlog\n- Ship CLI help\n- [ ] Add smoke probe\n- [x] Already shipped\n- [X] Also shipped\n- DONE Legacy completion marker\n",
+            )
             self.write(root, "notes.md", "- ordinary note\n")
             self.write(root, ".zzzops/rules/private.md", "# TODO: machinery must be excluded\n")
             self.write(root, "goals/items/old.md", "# TODO: canonical goals must be excluded\n")
@@ -48,8 +52,8 @@ class InventoryTests(unittest.TestCase):
             (root / "image.png").write_bytes(b"TODO: binary-ish bytes")
 
             first = self.run_inventory(root)
-            self.assertEqual(first["candidate_count"], 5)
-            self.assertEqual(first["new_count"], 5)
+            self.assertEqual(first["candidate_count"], 8)
+            self.assertEqual(first["new_count"], 8)
             candidates = {(item["path"], item["line"]): item for item in first["candidates"]}
             expected = {
                 ("src/app.py", 2): ("Parse quoted values", False),
@@ -57,6 +61,9 @@ class InventoryTests(unittest.TestCase):
                 ("README.md", 2): ("Document setup", False),
                 ("TODO.md", 2): ("Ship CLI help", True),
                 ("TODO.md", 3): ("Add smoke probe", True),
+                ("TODO.md", 4): ("[x] Already shipped", True),
+                ("TODO.md", 5): ("[X] Also shipped", True),
+                ("TODO.md", 6): ("DONE Legacy completion marker", True),
             }
             self.assertEqual(
                 {key: (item["text"], item["dedicated_backlog"]) for key, item in candidates.items()},
@@ -75,7 +82,7 @@ class InventoryTests(unittest.TestCase):
                 encoding="utf-8",
             )
             second = self.run_inventory(root)
-            self.assertEqual(second["candidate_count"], 5)
+            self.assertEqual(second["candidate_count"], 8)
             self.assertEqual(second["new_count"], 0)
             self.assertEqual(
                 [

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ python .agents/prompt_stats.py --check
 | `.agents/skills/execute-zzzops/references/SELF_REVIEW.md` | 1345 | 337 |
 | `.agents/skills/execute-zzzops/references/UNBLOCK.md` | 1564 | 391 |
 | `.agents/skills/install-zzzops/SKILL.md` | 1464 | 366 |
-| `.agents/skills/migrate-zzzops-todos/SKILL.md` | 2106 | 527 |
+| `.agents/skills/migrate-zzzops-todos/SKILL.md` | 2385 | 597 |
 | `.agents/skills/suggest-zzzops-work/SKILL.md` | 2793 | 699 |
 | `.agents/templates/project-goals/GOAL.md` | 1992 | 498 |
 | `.agents/templates/project-goals/INDEX.md` | 1135 | 284 |
@@ -220,7 +220,7 @@ python .agents/prompt_stats.py --check
 | `.zzzops/rules/INITIALIZATION.md` | 1930 | 483 |
 | `AGENTS.md` | 2896 | 724 |
 | `CLAUDE.md` | 217 | 55 |
-| **Total** | **49350** | **12346** |
+| **Total** | **49629** | **12416** |
 <!-- PROMPT_BUDGET_END -->
 
 </details>


### PR DESCRIPTION
Closes #44\n\nKeeps the inventory mechanical and lossless while requiring migration planning to classify completion evidence from repository context. Adds coverage for checked and DONE-style dedicated-backlog entries.\n\nChecks: focused inventory regression; prompt-budget test.