### PR TITLE
docs(readme): explain GitHub goal visibility

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -614,6 +614,14 @@ class WorkflowContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, rule)
 
+    def test_readme_exposes_github_goal_visibility_boundary(self):
+        readme = (Path(__file__).parent.parent / "README.md").read_text(encoding="utf-8")
+        migration = readme.index("### 4. Migrate existing work")
+        warning = readme.index("GitHub-backed goals inherit the repository's visibility")
+        self.assertLess(warning, migration)
+        self.assertIn("Never put secrets or raw sensitive data", readme)
+        self.assertIn("local-files backend", readme)
+
     def test_completion_review_policy_covers_scoped_cleanup_scenarios(self):
         root = Path(__file__).parent
         plan = json.loads((root / "templates" / "project-goals" / "INIT_PLAN.json").read_text(encoding="utf-8"))

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Once reviewed, these policies let the agent make routine decisions without wakin
 
 GitHub Issues is recommended when the repository and access probe succeed. Local `goals/items/` files are the supported alternative. One backend is authoritative; ZzzOps never silently switches or dual-writes. Initialization does not commit, branch, or mutate GitHub, and after approval mentions the optional `python .agents/zzzops.py` preferences panel without opening it.
 
+**Visibility:** GitHub-backed goals inherit the repository's visibility. Never put secrets or raw sensitive data in a goal; redact it, link to an approved private system, or select the local-files backend before capture or migration.
+
 Maintainers: see the [initialization and policy contract](docs/INITIALIZATION.md).
 
 ### 4. Migrate existing work


### PR DESCRIPTION
Closes #41\n\nAdds a concise GitHub Issue visibility warning before migration and a focused documentation contract test.\n\nChecks: .agents/test_zzzops.py; prompt budget check.