### PR TITLE
test(installer): cover rollback and stale plans

### DIFF
--- a/.agents/skills/install-zzzops/scripts/test_install_zzzops.py
+++ b/.agents/skills/install-zzzops/scripts/test_install_zzzops.py
@@ -5,10 +5,17 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from unittest import mock
 from pathlib import Path
+import importlib.util
 
 
 SCRIPT = Path(__file__).with_name("install_zzzops.py")
+SPEC = importlib.util.spec_from_file_location("install_zzzops_under_test", SCRIPT)
+INSTALLER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(INSTALLER)
 
 
 class InstallerInitializationTests(unittest.TestCase):
@@ -123,6 +130,51 @@ class InstallerInitializationTests(unittest.TestCase):
             self.assertEqual(0, applied.returncode, applied.stderr + applied.stdout)
             for path, data in state.items():
                 self.assertEqual(data, path.read_bytes())
+
+    def test_mid_apply_failure_rolls_back_created_and_overwritten_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            (target / ".git").mkdir()
+            existing = target / ".agents" / "zzzops.py"
+            existing.parent.mkdir()
+            original = b"user mechanical override\n"
+            existing.write_bytes(original)
+            unrelated = target / "keep.txt"
+            unrelated.write_bytes(b"untouched\n")
+            preview = self.run_installer(target, "--overwrite-mechanical")
+            fingerprint = re.search(r"Plan fingerprint: ([0-9a-f]+)", preview.stdout).group(1)
+            real_write = INSTALLER.atomic_write
+            calls = 0
+
+            def fail_second(path, data):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise OSError("injected write failure")
+                real_write(path, data)
+
+            arguments = [str(SCRIPT), str(target), "--apply", "--overwrite-mechanical", "--confirm-plan", fingerprint]
+            with mock.patch.object(INSTALLER, "atomic_write", side_effect=fail_second), mock.patch.object(sys, "argv", arguments), redirect_stdout(StringIO()):
+                with self.assertRaisesRegex(OSError, "injected write failure"):
+                    INSTALLER.main()
+            self.assertEqual(original, existing.read_bytes())
+            self.assertEqual(b"untouched\n", unrelated.read_bytes())
+            self.assertFalse((target / ".agents" / "zzzops_health.py").exists())
+
+    def test_stale_apply_rejects_without_writing_any_planned_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory)
+            (target / ".git").mkdir()
+            preview = self.run_installer(target)
+            fingerprint = re.search(r"Plan fingerprint: ([0-9a-f]+)", preview.stdout).group(1)
+            changed = target / ".agents" / "zzzops.py"
+            changed.parent.mkdir()
+            changed.write_bytes(b"changed after preview\n")
+            applied = self.run_installer(target, "--apply", "--confirm-plan", fingerprint)
+            self.assertNotEqual(0, applied.returncode)
+            self.assertIn("Mechanical file differs", applied.stdout)
+            self.assertEqual(b"changed after preview\n", changed.read_bytes())
+            self.assertFalse((target / ".zzzops" / "rules" / "INITIALIZATION.md").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #43\n\nAdds deterministic rollback coverage after an injected mid-apply write failure and proves changed mechanics are rejected before any planned write.\n\nChecks: focused installer tests.