### PR TITLE
feat(execute): inspect PR review feedback

### DIFF
--- a/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
+++ b/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
@@ -15,10 +15,14 @@ When PROJECT `pull_request_unit` is `per_goal`, each source-changing goal owns o
 
 ## Review gate
 
-After implementation, automated checks, and required self-review pass, apply PROJECT `review_gate`. `human_after_checks` creates a `human-action` blocker containing branch/commit/PR links, checks, material risks, and the exact approval/change request needed; do not merge or mark done and surface it through the normal human queue.
+At each review checkpoint for a recorded PR, make one bounded provider read of review state, unresolved inline threads, and relevant top-level comments. Prefer thread-aware data; classify each as actionable, resolved/outdated, discussion-only, automated, ambiguous, or unauthorized. Record concise actionable file/line context on the canonical goal. Do not poll.
+
+Address authorized actionable feedback only on the recorded branch/PR. Re-read the PR head and threads before mutation; after each small verified change, repeat self-review and required checks, record the new exact head/checkpoint, and invalidate prior approval. Ambiguous, scope-expanding, policy-conflicting, or unauthorized feedback is a categorized blocker; code changes never imply a provider thread was resolved.
+
+After implementation, automated checks, comment handling, and required self-review pass, apply PROJECT `review_gate`. `human_after_checks` creates a `human-action` blocker containing branch/commit/PR links, checks, material risks, and the exact approval/change request needed; do not merge or mark done and surface it through the normal human queue.
 
 - Apply PROJECT `pr_approval` and `conversational_approval`: where PR UI approval is required, open/update the correct PR and accept only valid approval with required checks; never self-approve or bypass policy. Otherwise explicit conversational approval may resolve the gate when policy permits it.
 - Changes requested: keep the branch, implement/reverify, and create a new review checkpoint.
-- Approved: retain the blocker resolution and apply PROJECT `merge_after_approval`; merge only when authorized, verify target/checks, then mark done and cycle. Missing merge authority becomes `access-approval`.
+- Approved: retain the blocker resolution and apply PROJECT `merge_after_approval`; before merging, re-read the exact PR head, actionable feedback, checks, target, mergeability, and permission. Merge only when every policy gate and authority is present; `mergeable` is not authorization. Verify the target contains the reviewed head and required post-merge checks, then record merge evidence and cycle. Missing approval, clean checks, conflict resolution, or merge authority becomes the precise categorized blocker; Missing merge authority is an `access-approval` blocker.
 
 The parent receives its own review gate only after required children are integrated, combined regression passes, parent criteria pass, and parent self-review completes.

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -594,6 +594,9 @@ class WorkflowContractTests(unittest.TestCase):
             "each source-changing goal owns one branch and one PR", "Related/small goals",
             "explicit user instruction", "record the override/rationale", "Parent and child goals keep distinct PRs",
             "commit/squash policy is separate", "Capture stays Git-free", "without PR capability",
+            "bounded provider read", "thread-aware data", "resolved/outdated", "discussion-only", "automated",
+            "Re-read the PR head and threads", "invalidate prior approval", "mergeable` is not authorization",
+            "Verify the target contains the reviewed head",
         ):
             self.assertIn(phrase, workflow)
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ python .agents/prompt_stats.py --check
 | --- | ---: | ---: |
 | `.agents/skills/add-zzzops-goal/SKILL.md` | 1304 | 326 |
 | `.agents/skills/execute-zzzops/SKILL.md` | 2342 | 586 |
-| `.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md` | 3454 | 864 |
+| `.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md` | 4618 | 1155 |
 | `.agents/skills/execute-zzzops/references/CREATE.md` | 2921 | 731 |
 | `.agents/skills/execute-zzzops/references/EXECUTE.md` | 3344 | 836 |
 | `.agents/skills/execute-zzzops/references/SELF_REVIEW.md` | 1345 | 337 |
@@ -220,7 +220,7 @@ python .agents/prompt_stats.py --check
 | `.zzzops/rules/INITIALIZATION.md` | 1930 | 483 |
 | `AGENTS.md` | 2896 | 724 |
 | `CLAUDE.md` | 217 | 55 |
-| **Total** | **49629** | **12416** |
+| **Total** | **50793** | **12707** |
 <!-- PROMPT_BUDGET_END -->
 
 </details>


### PR DESCRIPTION
Closes #47\n\nMakes PR review checkpoints thread-aware and bounded, requires same-branch remediation and exact-head rechecks, and explicitly distinguishes mergeability from authorization.\n\nChecks: focused workflow-contract test; prompt-budget check.