### PR TITLE
feat(acceptance): add mapped human test plan

### DIFF
--- a/.agents/manual_acceptance.py
+++ b/.agents/manual_acceptance.py
@@ -1,0 +1,72 @@
+"""Small cross-platform shim for the tracked human acceptance plan."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+START = "<!-- zzzops-acceptance-plan\n"
+END = "\nzzzops-acceptance-plan -->"
+
+
+def digest(repo: Path, paths: list[str]) -> str:
+    value = hashlib.sha256()
+    for relative in sorted(paths):
+        path = repo / relative
+        value.update(relative.encode())
+        value.update(b"\0")
+        value.update(path.read_bytes() if path.is_file() else b"<missing>")
+        value.update(b"\0")
+    return value.hexdigest()
+
+
+def load(plan_path: Path) -> tuple[str, dict, int, int]:
+    text = plan_path.read_text(encoding="utf-8")
+    start = text.index(START) + len(START)
+    end = text.index(END, start)
+    return text, json.loads(text[start:end]), start, end
+
+
+def save(plan_path: Path, text: str, data: dict, start: int, end: int) -> None:
+    plan_path.write_text(text[:start] + json.dumps(data, separators=(",", ":")) + text[end:], encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("next", "check", "audit"))
+    parser.add_argument("item", nargs="?")
+    parser.add_argument("--repo", type=Path, default=Path("."))
+    parser.add_argument("--plan", type=Path, default=Path("docs/ACCEPTANCE_TEST_PLAN.md"))
+    args = parser.parse_args()
+    repo = args.repo.resolve()
+    plan = (repo / args.plan).resolve()
+    text, data, start, end = load(plan)
+    items = data["items"]
+    if args.command == "audit":
+        changed = []
+        for item in items:
+            current = digest(repo, item["paths"])
+            if item["status"] == "checked" and item["fingerprint"] != current:
+                item["status"], item["fingerprint"] = "unchecked", None
+                changed.append(item["id"])
+        save(plan, text, data, start, end)
+        print(json.dumps({"stale": changed}))
+        return 0
+    if args.command == "next":
+        item = next((entry for entry in items if entry["status"] != "checked"), None)
+        print(json.dumps(item))
+        return 0 if item else 1
+    item = next((entry for entry in items if entry["id"] == args.item), None)
+    if not item:
+        raise SystemExit("unknown item")
+    item["status"], item["fingerprint"] = "checked", digest(repo, item["paths"])
+    save(plan, text, data, start, end)
+    print(json.dumps({"checked": item["id"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/test_manual_acceptance.py
+++ b/.agents/test_manual_acceptance.py
@@ -1,0 +1,33 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+SCRIPT = ROOT / ".agents" / "manual_acceptance.py"
+
+
+class ManualAcceptanceTests(unittest.TestCase):
+    def test_check_and_audit_only_affect_mapped_item(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            (repo / "docs").mkdir()
+            (repo / "a.txt").write_text("one")
+            (repo / "b.txt").write_text("two")
+            plan = {"version": 1, "items": [{"id":"A-1","status":"unchecked","paths":["a.txt"],"fingerprint":None,"notes":""},{"id":"A-2","status":"unchecked","paths":["b.txt"],"fingerprint":None,"notes":""}]}
+            (repo / "docs" / "ACCEPTANCE_TEST_PLAN.md").write_text("# Plan\n\n<!-- zzzops-acceptance-plan\n" + json.dumps(plan) + "\nzzzops-acceptance-plan -->\n")
+            def run(*args):
+                return subprocess.run([sys.executable, str(SCRIPT), *args, "--repo", str(repo)], text=True, capture_output=True, check=True)
+            self.assertEqual("A-1", json.loads(run("next").stdout)["id"])
+            run("check", "A-1")
+            (repo / "b.txt").write_text("changed")
+            self.assertEqual([], json.loads(run("audit").stdout)["stale"])
+            (repo / "a.txt").write_text("changed")
+            self.assertEqual(["A-1"], json.loads(run("audit").stdout)["stale"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -3,7 +3,7 @@
 Run this plan conversationally: ask for the next item, perform its human action, then explicitly say `check A-001`. A checked item becomes stale when one of its mapped paths changes.
 
 <!-- zzzops-acceptance-plan
-{"version":1,"items":[{"id":"A-001","title":"Install preview is non-mutating","status":"unchecked","paths":[".agents/skills/install-zzzops/scripts/install_zzzops.py"],"fingerprint":null,"notes":""},{"id":"A-002","title":"Execute workflow is discoverable","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md"],"fingerprint":null,"notes":""}]}
+{"version":1,"items":[{"id":"A-001","title":"Install preview is non-mutating","status":"unchecked","paths":[".agents/skills/install-zzzops/scripts/install_zzzops.py"],"fingerprint":null,"notes":""},{"id":"A-002","title":"Execute workflow is discoverable","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-003","title":"Preferences CLI preserves local choices","status":"unchecked","paths":[".agents/zzzops.py",".agents/templates/project-goals/PREFERENCES.json"],"fingerprint":null,"notes":""}]}
 zzzops-acceptance-plan -->
 
 ## A-001 — Install preview is non-mutating
@@ -21,3 +21,11 @@ Prerequisite: mechanics installed in a disposable repository.
 Human action: open a fresh Codex or Claude Code session and invoke `execute-zzzops` in dry-run mode.
 
 Expected: it reports the durable queue without source or Git changes.
+
+## A-003 — Preferences CLI preserves local choices
+
+Prerequisite: initialized disposable repository with ZzzOps mechanics installed.
+
+Human action: run `python .agents/zzzops.py`, change one refill preference, exit, then reopen the panel.
+
+Expected: the selected preference remains user-local in `.zzzops/PREFERENCES.json`; it is not staged or committed.

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -1,0 +1,23 @@
+# Human acceptance plan
+
+Run this plan conversationally: ask for the next item, perform its human action, then explicitly say `check A-001`. A checked item becomes stale when one of its mapped paths changes.
+
+<!-- zzzops-acceptance-plan
+{"version":1,"items":[{"id":"A-001","title":"Install preview is non-mutating","status":"unchecked","paths":[".agents/skills/install-zzzops/scripts/install_zzzops.py"],"fingerprint":null,"notes":""},{"id":"A-002","title":"Execute workflow is discoverable","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md"],"fingerprint":null,"notes":""}]}
+zzzops-acceptance-plan -->
+
+## A-001 — Install preview is non-mutating
+
+Prerequisite: use a disposable Git repository.
+
+Human action: ask the installed `install-zzzops` skill for a dry run, then inspect Git status.
+
+Expected: it reports a plan and does not create mechanics or alter project state.
+
+## A-002 — Execute workflow is discoverable
+
+Prerequisite: mechanics installed in a disposable repository.
+
+Human action: open a fresh Codex or Claude Code session and invoke `execute-zzzops` in dry-run mode.
+
+Expected: it reports the durable queue without source or Git changes.

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -3,7 +3,7 @@
 Run this plan conversationally: ask for the next item, perform its human action, then explicitly say `check A-001`. A checked item becomes stale when one of its mapped paths changes.
 
 <!-- zzzops-acceptance-plan
-{"version":1,"items":[{"id":"A-001","title":"Install preview is non-mutating","status":"unchecked","paths":[".agents/skills/install-zzzops/scripts/install_zzzops.py"],"fingerprint":null,"notes":""},{"id":"A-002","title":"Execute workflow is discoverable","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-003","title":"Preferences CLI preserves local choices","status":"unchecked","paths":[".agents/zzzops.py",".agents/templates/project-goals/PREFERENCES.json"],"fingerprint":null,"notes":""}]}
+{"version":1,"items":[{"id":"A-001","title":"Install preview is non-mutating","status":"unchecked","paths":[".agents/skills/install-zzzops/scripts/install_zzzops.py"],"fingerprint":null,"notes":""},{"id":"A-002","title":"Execute workflow is discoverable","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-003","title":"Preferences CLI preserves local choices","status":"unchecked","paths":[".agents/zzzops.py",".agents/templates/project-goals/PREFERENCES.json"],"fingerprint":null,"notes":""},{"id":"A-004","title":"Agent-led project initialization","status":"unchecked","paths":[".zzzops/rules/INITIALIZATION.md",".agents/zzzops.py"],"fingerprint":null,"notes":""},{"id":"A-005","title":"GitHub Issues backend","status":"unchecked","paths":[".zzzops/rules/BACKENDS.md"],"fingerprint":null,"notes":""},{"id":"A-006","title":"Local-files backend","status":"unchecked","paths":[".zzzops/rules/BACKENDS.md"],"fingerprint":null,"notes":""},{"id":"A-007","title":"Capture a durable goal","status":"unchecked","paths":[".agents/skills/add-zzzops-goal/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-008","title":"Migrate TODOs with approval","status":"unchecked","paths":[".agents/skills/migrate-zzzops-todos/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-009","title":"Suggest work in dry-run mode","status":"unchecked","paths":[".agents/skills/suggest-zzzops-work/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-010","title":"Execute, unblock, and resume","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md",".zzzops/rules/CONTINUATION.md"],"fingerprint":null,"notes":""},{"id":"A-011","title":"Branch review and merge gate","status":"unchecked","paths":[".agents/skills/execute-zzzops/references/BRANCH_REVIEW.md"],"fingerprint":null,"notes":""},{"id":"A-012","title":"Health nudges remain private and opt-in","status":"unchecked","paths":[".zzzops/rules/HEALTH.md",".agents/zzzops_health.py"],"fingerprint":null,"notes":""},{"id":"A-013","title":"Prompt budget is current","status":"unchecked","paths":[".agents/prompt_stats.py","README.md"],"fingerprint":null,"notes":""},{"id":"A-014","title":"PR validation and release boundaries","status":"unchecked","paths":[".github/workflows"],"fingerprint":null,"notes":""}]}
 zzzops-acceptance-plan -->
 
 ## A-001 — Install preview is non-mutating
@@ -29,3 +29,21 @@ Prerequisite: initialized disposable repository with ZzzOps mechanics installed.
 Human action: run `python .agents/zzzops.py`, change one refill preference, exit, then reopen the panel.
 
 Expected: the selected preference remains user-local in `.zzzops/PREFERENCES.json`; it is not staged or committed.
+
+## A-004 to A-014 — Core ZzzOps workflow coverage
+
+Run each in a disposable repository and record the result in the matching ledger item.
+
+| ID | Human action | Expected observable result |
+| --- | --- | --- |
+| A-004 | Start a non-install workflow and review the generated `PROJECT.md`. | The agent interviews consequential unknowns; ordinary work waits for explicit policy review. |
+| A-005 | Initialize with GitHub Issues selected. | A human-first issue is the canonical goal; repository visibility is explained. |
+| A-006 | Initialize with local files selected. | Canonical goal files and derived index are used without GitHub writes. |
+| A-007 | Capture a small goal. | It is durable but creates no branch, commit, or PR. |
+| A-008 | Preview a TODO migration, then inspect the plan. | Existing TODOs are summarized; no goal is created before approval. |
+| A-009 | Run work suggestion in dry-run mode. | Evidence-backed suggestions are shown without changing the backlog. |
+| A-010 | Execute a simple goal, answer one blocker, and resume. | The loop preserves state and resumes only safe same-task work. |
+| A-011 | Complete a source-changing test goal. | A branch/PR/check/review gate is presented; no merge occurs without authority. |
+| A-012 | Inspect disabled health status, then opt in locally. | Nudges remain nonblocking; repository state contains no personal timing data. |
+| A-013 | Run prompt statistics and its check mode. | README counts regenerate deterministically and check succeeds. |
+| A-014 | Open a PR and inspect its validation/release behavior. | PR checks are read-only; `main` release behavior remains restricted. |


### PR DESCRIPTION
Closes #53\n\nAdds a tracked human acceptance ledger and cross-platform next/check/audit shim with fingerprint-based invalidation.\n\nChecks: .agents/test_manual_acceptance.py; live next-item probe.