### PR TITLE
fix(execute): resume after blocker resolution

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -614,6 +614,7 @@ class WorkflowContractTests(unittest.TestCase):
             "required-authority or blocking boundary", "never nest/duplicate execute", "standalone adjacent capture",
             "re-enter `$execute-zzzops` once", "no priority shortcut", "steer and ordinary follow-up",
             "Compacted context", "Separate tasks/threads", "Capture itself remains Git-free",
+            "user answer that resolves a surfaced blocker", "rebuild the actionable set and resume once",
         ):
             self.assertIn(phrase, rule)
 

--- a/.zzzops/rules/CONTINUATION.md
+++ b/.zzzops/rules/CONTINUATION.md
@@ -4,7 +4,7 @@ Apply reviewed PROJECT `execution_continuation` settings. Continuation is task-l
 
 1. Enter active execute intent when the user requests the execute-all loop. Preserve it in same-task handoff/compaction context when policy says `same_task_until_superseded`; queue exhaustion/yield alone may retain it.
 2. Clear intent on policy stop reasons: explicit stop/pause/replacement/capture-only, required-authority or blocking boundary, repository/task change, or loss of a trustworthy continuation signal.
-3. During an active loop, an additive capture updates the queue at the next safe checkpoint; never nest/duplicate execute or repeat capture.
+3. During an active loop, an additive capture or a user answer that resolves a surfaced blocker updates the queue at the next safe checkpoint; never nest/duplicate execute or repeat capture. After recording a blocker resolution, rebuild the actionable set and resume once when same-task intent remains; an explicit stop/replacement still wins.
 4. For a standalone adjacent capture, snapshot active intent before capture, finish duplicate checks/questions/canonical write, then—only if intent remains active and policy says `resume_once_and_reprioritize`—re-enter `$execute-zzzops` once through normal inventory. The new goal receives no priority shortcut.
 5. A steer and ordinary follow-up behave the same when the harness exposes the same task context. Compacted context is sufficient only when it explicitly preserves execute intent and stop reason. Separate tasks/threads or unsupported harnesses never share/guess intent; report the limitation when relevant.
 

--- a/README.md
+++ b/README.md
@@ -215,14 +215,14 @@ python .agents/prompt_stats.py --check
 | `.claude/skills/install-zzzops/SKILL.md` | 382 | 96 |
 | `.zzzops/rules/BACKENDS.md` | 2787 | 697 |
 | `.zzzops/rules/BLOCKERS.md` | 2238 | 560 |
-| `.zzzops/rules/CONTINUATION.md` | 1505 | 377 |
+| `.zzzops/rules/CONTINUATION.md` | 1708 | 427 |
 | `.zzzops/rules/EXECUTION_STRATEGY.md` | 3552 | 888 |
 | `.zzzops/rules/GOAL_SYSTEM.md` | 4040 | 1010 |
 | `.zzzops/rules/HEALTH.md` | 1429 | 358 |
 | `.zzzops/rules/INITIALIZATION.md` | 1930 | 483 |
 | `AGENTS.md` | 2896 | 724 |
 | `CLAUDE.md` | 217 | 55 |
-| **Total** | **50793** | **12707** |
+| **Total** | **50996** | **12757** |
 <!-- PROMPT_BUDGET_END -->
 
 </details>


### PR DESCRIPTION
Closes #49\n\nMakes a user answer that resolves a surfaced blocker rebuild the actionable queue and resume once when same-task execute intent remains.\n\nChecks: focused continuation contract; prompt budget check.