### PR TITLE
ci(acceptance): verify plan coverage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,10 @@ jobs:
         run: python -m unittest discover -s .agents/skills/install-zzzops/scripts -p 'test_*.py'
       - name: Test TODO migration inventory
         run: python -m unittest discover -s .agents/skills/migrate-zzzops-todos/scripts -p 'test_*.py'
+      - name: Test manual acceptance plan coverage
+        run: |
+          python .agents/test_manual_acceptance.py
+          python .agents/manual_acceptance.py coverage
       - name: Test semantic releases
         run: python -m unittest discover -s .github/scripts -p 'test_*.py'
       - name: Verify prompt budget
@@ -57,3 +61,7 @@ jobs:
         run: python -m unittest discover -s .agents/skills/install-zzzops/scripts -p 'test_*.py'
       - name: Test TODO migration inventory
         run: python -m unittest discover -s .agents/skills/migrate-zzzops-todos/scripts -p 'test_*.py'
+      - name: Test manual acceptance plan coverage
+        run: |
+          python .agents/test_manual_acceptance.py
+          python .agents/manual_acceptance.py coverage


### PR DESCRIPTION
Closes #57\n\nRuns the read-only acceptance-plan tests and coverage audit in PR validation without mutating human checkmarks.\n\nChecks: .agents/test_manual_acceptance.py; coverage audit.