### PR TITLE
feat(execute): allow stacked dependent PRs

### DIFF
--- a/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
+++ b/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
@@ -5,7 +5,7 @@ Use this only for source-changing goals and apply reviewed PROJECT Git/review po
 ## Resolve topology
 
 1. Record one stable `implementation` identity per goal: branch, base, integration target, PR, and review status/checkpoint. Reuse it on resume.
-2. Resolve root base from PROJECT `branch_base`; dependent ancestry from `dependency_base` and `multiple_dependency_base`. For the installed fallback values, use the nearest authorized trunk, dependency branch, or a reviewed base containing every required ancestor. Block rather than omit an ancestor or guess order.
+2. Resolve root base from PROJECT `branch_base`; dependent ancestry from `dependency_base` and `multiple_dependency_base`. For the installed fallback values, use the nearest authorized trunk, dependency branch, or a reviewed base containing every required ancestor. A technically ready dependency awaiting review may be its child’s recorded base: stack the child branch/PR on it and preserve ancestry/review order. Do not bypass an unresolved technical dependency, merge gate, or conflicting parent change; rebase and retest as its parent advances. Block rather than omit an ancestor or guess order.
 3. Apply PROJECT `parent_pseudo_trunk` and `child_target` recursively. Under the installed fallback, a goal with children owns their pseudo-trunk even without a direct commit; a child targets the nearest parent pseudo-trunk and may base on a sibling dependency branch.
 4. Follow policy integration order. Under the installed fallback, integrate reviewed children into their parent pseudo-trunk in dependency order and run combined checks/parent criteria before presenting the parent upstream.
 

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -596,7 +596,8 @@ class WorkflowContractTests(unittest.TestCase):
             "commit/squash policy is separate", "Capture stays Git-free", "without PR capability",
             "bounded provider read", "thread-aware data", "resolved/outdated", "discussion-only", "automated",
             "Re-read the PR head and threads", "invalidate prior approval", "mergeable` is not authorization",
-            "Verify the target contains the reviewed head",
+            "Verify the target contains the reviewed head", "technically ready dependency awaiting review",
+            "stack the child branch/PR on it", "rebase and retest as its parent advances",
         ):
             self.assertIn(phrase, workflow)
 


### PR DESCRIPTION
Closes #59\n\nAllows technically ready dependent goals to branch and PR from a parent awaiting human review, while retaining ancestry, review ordering, rebasing, and retest safeguards.\n\nChecks: focused branch workflow contract; prompt budget check.