### PR TITLE
Fix canonical issue closure after dev merges

### DIFF
--- a/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
+++ b/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
@@ -15,9 +15,7 @@ When PROJECT `pull_request_unit` is `per_goal`, each source-changing goal owns o
 
 ## Canonical issue links
 
-Every implementation PR names its canonical GitHub goal. A PR whose base is the configured integration branch uses GitHub closing syntax in its body: `Closes #N`. Before merge, re-read that exact issue and later verify it closed.
-
-A stacked PR whose base is another goal branch must not close its issue early. Its body uses a visible non-closing link such as `Tracks #N`; the eventual PR into the configured integration branch uses `Closes #N`. Record the issue/PR pairing in the goal history and preserve explicit repository-policy exemptions.
+Every implementation PR uses `Tracks #N`. Do not rely on closing keywords: GitHub applies them only on default-branch merges. After verifying the exact head is in the integration target, re-read the issue, record `done`/merge evidence, run `gh issue close N --reason completed`, and verify closure. Stacked or incomplete PRs never close an issue.
 
 ## Review gate
 

--- a/.agents/test_branch_review_contract.py
+++ b/.agents/test_branch_review_contract.py
@@ -8,10 +8,10 @@ REFERENCE = Path(__file__).parent / "skills" / "execute-zzzops" / "references" /
 class CanonicalIssueLinkContractTests(unittest.TestCase):
     def test_direct_and_stacked_prs_have_distinct_issue_link_semantics(self):
         text = REFERENCE.read_text(encoding="utf-8")
-        self.assertIn("`Closes #N`", text)
         self.assertIn("`Tracks #N`", text)
-        self.assertIn("must not close its issue early", text)
-        self.assertIn("later verify it closed", text)
+        self.assertIn("default-branch merges", text)
+        self.assertIn("gh issue close N --reason completed", text)
+        self.assertIn("Stacked or incomplete PRs never close an issue", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace default-branch closing keywords with Tracks #N`n- require verified integration-head evidence followed by an explicit, verified issue close
- cover the direct and stacked closure contract

## Verification
- python .agents/test_branch_review_contract.py
- python .agents/test_zzzops.py
- python .agents/prompt_stats.py --check

Tracks #69