### PR TITLE
feat(acceptance): guide manual plan runs

### DIFF
--- a/.agents/skills/run-zzzops-acceptance/SKILL.md
+++ b/.agents/skills/run-zzzops-acceptance/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: run-zzzops-acceptance
+description: Run/guide/resume/check tests: "manual test", "acceptance test", "run the test plan", "next test", "check".
+---
+
+# Acceptance
+
+`audit`, `next`; present exactly one active item: ID, prerequisites, human action, expected result.
+
+Only explicit same task `check ID` checks it. Never infer an ID. Failures/skips/blockers unchecked; separate tasks `next`.

--- a/.agents/skills/run-zzzops-acceptance/agents/openai.yaml
+++ b/.agents/skills/run-zzzops-acceptance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Run ZzzOps Acceptance"
+  short_description: "Guide one human acceptance test at a time"
+  default_prompt: "Use $run-zzzops-acceptance to guide me through the next manual acceptance test."

--- a/.agents/test_acceptance_skill_contract.py
+++ b/.agents/test_acceptance_skill_contract.py
@@ -1,0 +1,23 @@
+import unittest
+from pathlib import Path
+
+
+REFERENCE = Path(__file__).parent / "skills" / "run-zzzops-acceptance" / "SKILL.md"
+
+
+class AcceptanceSkillContractTests(unittest.TestCase):
+    def test_requires_explicit_same_task_check(self):
+        text = REFERENCE.read_text(encoding="utf-8")
+        self.assertIn("manual test", text)
+        self.assertIn("acceptance test", text)
+        self.assertIn("`check ID`", text)
+        self.assertIn("same task", text)
+        self.assertIn("Never infer an ID", text)
+        self.assertIn("exactly one active item", text)
+        self.assertIn("prerequisites", text)
+        self.assertIn("human action", text)
+        self.assertIn("expected result", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/test_continuation_contract.py
+++ b/.agents/test_continuation_contract.py
@@ -1,0 +1,13 @@
+import unittest
+from pathlib import Path
+
+
+class ContinuationContractTests(unittest.TestCase):
+    def test_scoped_user_refinement_does_not_stop_execution(self):
+        text = (Path(__file__).parent.parent / ".zzzops" / "rules" / "CONTINUATION.md").read_text(encoding="utf-8")
+        self.assertIn("design refinement", text)
+        self.assertIn("they are not replacements", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -650,6 +650,7 @@ class WorkflowContractTests(unittest.TestCase):
             "install-zzzops": ("install", "set up", "copy", "refresh", "update", '"preview"', '"dry run"', '"apply"', '"setup"'),
             "migrate-to-zzzops": ("discover", "plan", "migrate", "import", "todos/backlogs", '"dry run"', '"preview"', '"apply"', "default builds review artifacts"),
             "suggest-zzzops-work": ("suggest", "discover", "audit", '"dry run"', '"preview"', '"plan"', '"apply"', '"refill"'),
+            "run-zzzops-acceptance": ("run", "guide", "check", "resume", "manual test", "acceptance test", "run the test plan", "next test"),
         }
         self.assertEqual(set(contracts), {path.name for path in root.iterdir() if (path / "SKILL.md").is_file()})
         for name, phrases in contracts.items():

--- a/.zzzops/rules/CONTINUATION.md
+++ b/.zzzops/rules/CONTINUATION.md
@@ -1,11 +1,11 @@
 # Execute-intent continuation
 
-Apply reviewed PROJECT `execution_continuation` settings. Continuation is task-local intent, not elapsed-time inference or repository state.
+Apply PROJECT `execution_continuation`. Continuation is task-local intent, not elapsed-time inference or repository state.
 
-1. Enter active execute intent when the user requests the execute-all loop. Preserve it in same-task handoff/compaction context when policy says `same_task_until_superseded`; queue exhaustion/yield alone may retain it.
-2. Clear intent on policy stop reasons: explicit stop/pause/replacement/capture-only, required-authority or blocking boundary, repository/task change, or loss of a trustworthy continuation signal.
-3. During an active loop, an additive capture or a user answer that resolves a surfaced blocker updates the queue at the next safe checkpoint; never nest/duplicate execute or repeat capture. After recording a blocker resolution, rebuild the actionable set and resume once when same-task intent remains; an explicit stop/replacement still wins.
-4. For a standalone adjacent capture, snapshot active intent before capture, finish duplicate checks/questions/canonical write, then—only if intent remains active and policy says `resume_once_and_reprioritize`—re-enter `$execute-zzzops` once through normal inventory. The new goal receives no priority shortcut.
-5. A steer and ordinary follow-up behave the same when the harness exposes the same task context. Compacted context is sufficient only when it explicitly preserves execute intent and stop reason. Separate tasks/threads or unsupported harnesses never share/guess intent; report the limitation when relevant.
+1. Enter active intent for execute-all. Preserve it in same-task handoff/compaction under `same_task_until_superseded`; queue exhaustion/yield does not clear it.
+2. Clear only for explicit stop/pause/replacement/capture-only, required-authority or blocking boundary, repository/task change, or lost continuation. Scoped corrections, design refinements, and requirement changes update the goal and continue; they are not replacements.
+3. During an active loop, an additive capture or a user answer that resolves a surfaced blocker updates the queue at the next safe checkpoint; never nest/duplicate execute or capture. After resolution, rebuild the actionable set and resume once when same-task intent remains; explicit stop/replacement wins.
+4. For a standalone adjacent capture, snapshot intent, finish duplicate checks/questions/canonical write, then—if intent remains active and policy says `resume_once_and_reprioritize`—re-enter `$execute-zzzops` once. The new goal gets no priority shortcut.
+5. A steer and ordinary follow-up are the same when the harness exposes the same task context. Compacted context must preserve execute intent and stop reason. Separate tasks/threads or unsupported harnesses never share/guess intent; report that limitation when relevant.
 
 Capture itself remains Git-free. Resumed source work begins afterward under normal authority, branch, review, claim, blocker, and verification policy.


### PR DESCRIPTION
Tracks #71&#10;&#10;Adds a discoverable repo-local acceptance workflow, explicit same-task check safety, and focused contract coverage.&#10;&#10;Verification: prompt-budget check (12,999 estimated tokens); acceptance/manual ledger/continuation/workflow contract suites; acceptance coverage audit.