### PR TITLE
fix(installer): explain dry-run outcomes

### DIFF
--- a/.agents/skills/install-zzzops/SKILL.md
+++ b/.agents/skills/install-zzzops/SKILL.md
@@ -7,9 +7,9 @@ description: Install, set up, copy, refresh, or update ZzzOps mechanics in anoth
 
 Mode: `preview` or `dry run` stops after step 1 with no writes. `apply`, `install`, `setup`, or `update` follows the full preview-confirm-apply workflow; this is the default when no mode is stated.
 
-1. Inspect target instructions and preview with `scripts/install_zzzops.py TARGET`.
-2. Review conflicts. Apply the identical plan with `--apply --confirm-plan APPROVAL_CODE`; use `--overwrite-mechanical` only after explicit conflict review.
-3. Inspect the target diff. Verify project state, goals, local preferences, and project instruction files were untouched. Skills are installed for Codex under `.agents/skills/` and Claude Code under `.claude/skills/`; installation never edits target `AGENTS.md` or `CLAUDE.md`.
-4. Stop. Lead with whether installation succeeded and the next useful action: invoke any non-install workflow so its agent initializes the project, then `$migrate-to-zzzops` to discover/import existing TODOs. Keep file counts, fingerprints, and conflict details out of the default summary unless they require action or the user asks. Never initialize state, discover/import work, or delete TODOs during installation.
+1. Inspect target instructions and preview with `scripts/install_zzzops.py TARGET`. For dry run, explain the capabilities and major surfaces that would be installed plus any conflict requiring action; the approval code only binds apply to that exact preview.
+2. For apply, use the identical plan with `--apply --confirm-plan APPROVAL_CODE`; use `--overwrite-mechanical` only after explicit conflict review. Do not replay preview detail.
+3. Inspect the target diff. Verify project state, goals, local preferences, and project instructions were untouched.
+4. Stop. Report installation success and the next useful action: invoke a non-install workflow to initialize, then `$migrate-to-zzzops` for existing TODOs. Never initialize, migrate, or delete TODOs during installation.
 
 The main agent runs the installer because it writes files. Never install this installer into the target, create/copy project state, overwrite target state, or replace unmarked target instructions.

--- a/.agents/skills/install-zzzops/scripts/install_zzzops.py
+++ b/.agents/skills/install-zzzops/scripts/install_zzzops.py
@@ -135,22 +135,28 @@ def main() -> int:
     counts: dict[str, int] = {}
     for _path, action, _data, _expected in actions:
         counts[action] = counts.get(action, 0) + 1
-    print("ZzzOps installation")
-    print("Applying the approved preview." if args.apply else "Preview only; no files changed.")
-    print(f"Target: {target}")
-    print(
-        f"Files: {counts.get('create', 0)} to add, {counts.get('overwrite', 0)} to update, "
-        f"{counts.get('unchanged', 0)} unchanged."
-    )
+    if not args.apply:
+        print("ZzzOps installation preview")
+        print(f"Target: {target}")
+        print("This will install:")
+        print("- goal-management skills for Codex and Claude Code")
+        print("- shared workflow rules and the ZzzOps control CLI")
+        print("- blank templates for project setup, preferences, and TODO migration")
+        if counts.get("create", 0) or counts.get("overwrite", 0):
+            print(f"Planned changes: {counts.get('create', 0)} new, {counts.get('overwrite', 0)} updated.")
+        else:
+            print("Planned changes: ZzzOps is already up to date.")
     for error in errors:
-        print(f"Action needed: {error}")
+        print(f"Cannot install yet: {error}")
     if errors:
         return 2
-    print(f"Approval code: {fingerprint}")
     if not args.apply:
+        print("No files were changed.")
+        print("Use this code to apply exactly what was previewed:")
+        print(f"Approval code: {fingerprint}")
         return 0
     if args.confirm_plan != fingerprint:
-        print("The approval code does not match this preview. No files were changed.")
+        print("The target changed or this approval is for another preview. Run the preview again; no files were changed.")
         return 2
     backups: dict[Path, bytes | None] = {}
     writes: list[tuple[Path, bytes, str | None]] = []
@@ -170,7 +176,7 @@ def main() -> int:
             elif data is not None:
                 atomic_write(path, data)
         raise
-    print("ZzzOps is installed. Next: start any non-install ZzzOps workflow to initialize the project.")
+    print("ZzzOps is installed. Start any ZzzOps workflow to set up the project.")
     return 0
 
 

--- a/.agents/skills/install-zzzops/scripts/test_install_zzzops.py
+++ b/.agents/skills/install-zzzops/scripts/test_install_zzzops.py
@@ -30,12 +30,17 @@ class InstallerInitializationTests(unittest.TestCase):
             (target / ".git").mkdir()
             preview = self.run_installer(target)
             self.assertEqual(0, preview.returncode, preview.stderr + preview.stdout)
-            self.assertIn("Preview only; no files changed.", preview.stdout)
-            self.assertNotIn("Mechanical files", preview.stdout)
+            self.assertIn("installation preview", preview.stdout)
+            self.assertIn("goal-management skills", preview.stdout)
+            self.assertIn("workflow rules", preview.stdout)
+            self.assertIn("blank templates", preview.stdout)
+            self.assertIn("No files were changed.", preview.stdout)
             fingerprint = re.search(r"Approval code: ([0-9a-f]+)", preview.stdout).group(1)
             applied = self.run_installer(target, "--apply", "--confirm-plan", fingerprint)
             self.assertEqual(0, applied.returncode, applied.stderr + applied.stdout)
             self.assertIn("ZzzOps is installed.", applied.stdout)
+            self.assertNotIn("installation preview", applied.stdout)
+            self.assertNotIn("Approval code", applied.stdout)
             self.assertTrue((target / ".zzzops" / "rules" / "INITIALIZATION.md").is_file())
             self.assertTrue((target / ".zzzops" / "rules" / "BACKENDS.md").is_file())
             self.assertTrue((target / ".zzzops" / "rules" / "CONTINUATION.md").is_file())
@@ -66,7 +71,7 @@ class InstallerInitializationTests(unittest.TestCase):
             self.assertFalse(json.loads(checkpoint.stdout)["ready"])
             rerun = self.run_installer(target)
             self.assertEqual(0, rerun.returncode, rerun.stderr + rerun.stdout)
-            self.assertIn("unchanged.", rerun.stdout)
+            self.assertIn("already up to date", rerun.stdout)
 
     def test_update_preserves_local_preferences(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -142,6 +147,10 @@ class InstallerInitializationTests(unittest.TestCase):
             self.assertIn("already manages", applied.stdout)
             self.assertEqual(b"changed after preview\n", changed.read_bytes())
             self.assertFalse((target / ".zzzops" / "rules" / "INITIALIZATION.md").exists())
+            refreshed = self.run_installer(target)
+            self.assertNotEqual(0, refreshed.returncode)
+            self.assertIn("Cannot install yet", refreshed.stdout)
+            self.assertIn(".agents/zzzops.py", refreshed.stdout)
 
 
 if __name__ == "__main__":

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -14,7 +14,7 @@ Prerequisite: use a disposable Git repository.
 
 Human action: ask the installed `install-zzzops` skill for a dry run, then inspect Git status.
 
-Expected: it plainly says this is a preview, gives the approval code needed to apply, and does not create mechanics or alter project state.
+Expected: it explains the skills, workflow rules/control CLI, and blank setup templates it would install; identifies any conflict requiring action; binds apply to that exact preview; and changes nothing.
 
 ## A-002 — Execute workflow is discoverable
 


### PR DESCRIPTION
Tracks #110. Dry runs now explain the installed skills, workflow/control surfaces, and blank setup templates before presenting the apply-binding code. Apply mode reports only its outcome. Preview safety, stale-plan rejection, rollback, conflict reporting, the full test matrix, prompt budget, and a real clean-target probe pass. A-001 remains unchecked until the user explicitly reruns/checks it.