### PR TITLE
test(acceptance): focus plan on user surfaces

### DIFF
--- a/.agents/manual_acceptance.py
+++ b/.agents/manual_acceptance.py
@@ -45,10 +45,9 @@ def main() -> int:
     items = data["items"]
     if args.command == "coverage":
         required = [
-            "install.ps1", "install.sh", ".agents/zzzops/zzzops.py", ".zzzops/rules/BACKENDS.md",
+            "install.ps1", "install.sh",
             ".agents/skills/add-zzzops-goal", ".agents/skills/migrate-to-zzzops",
             ".agents/skills/suggest-zzzops-work", ".agents/skills/execute-zzzops",
-            ".github/workflows", ".agents/prompt_stats.py",
         ]
         mapped = {path for item in items for path in item["paths"]}
         missing = [path for path in required if not any(entry == path or entry.startswith(path + "/") for entry in mapped)]

--- a/.agents/test_manual_acceptance.py
+++ b/.agents/test_manual_acceptance.py
@@ -38,8 +38,34 @@ class ManualAcceptanceTests(unittest.TestCase):
             result = subprocess.run([sys.executable, str(SCRIPT), "coverage", "--repo", str(repo)], text=True, capture_output=True)
             self.assertEqual(1, result.returncode)
             self.assertIn("install.sh", json.loads(result.stdout)["unmapped_required_surfaces"])
-            self.assertIn(".agents/zzzops/zzzops.py", json.loads(result.stdout)["unmapped_required_surfaces"])
+            self.assertIn(".agents/skills/add-zzzops-goal", json.loads(result.stdout)["unmapped_required_surfaces"])
             self.assertEqual(path.read_text(encoding="utf-8"), "<!-- zzzops-acceptance-plan\n" + json.dumps(plan) + "\nzzzops-acceptance-plan -->\n")
+
+    def test_coverage_accepts_only_native_installers_and_installed_skills(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            (repo / "docs").mkdir()
+            surfaces = [
+                "install.ps1", "install.sh",
+                ".agents/skills/add-zzzops-goal", ".agents/skills/migrate-to-zzzops",
+                ".agents/skills/suggest-zzzops-work", ".agents/skills/execute-zzzops",
+            ]
+            plan = {
+                "version": 1,
+                "items": [{"id": "A-1", "status": "unchecked", "paths": surfaces, "fingerprint": None, "notes": ""}],
+            }
+            path = repo / "docs" / "ACCEPTANCE_TEST_PLAN.md"
+            path.write_text(
+                "<!-- zzzops-acceptance-plan\n" + json.dumps(plan) + "\nzzzops-acceptance-plan -->\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "coverage", "--repo", str(repo)],
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            self.assertEqual([], json.loads(result.stdout)["unmapped_required_surfaces"])
 
 
 if __name__ == "__main__":

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -2,10 +2,10 @@
 
 Run this plan conversationally: ask for the next item, perform its human action, then explicitly say `check A-001`. A checked item becomes stale when one of its mapped paths changes.
 
-Maintainers must map each new shipped user-facing functional surface to a human item. Documentation and individual test cases are not functional surfaces and need no item solely to test their prose or test code; inspect documentation and run changed tests instead. Reusable test/acceptance harness behavior needs focused regression coverage, and needs a human item only when that harness itself exposes a shipped user-facing workflow. If a scenario cannot safely be manually tested, add an evidence-backed exemption in the item notes explaining the safety boundary and automated coverage; do not silently omit it. Run `<python> .agents/manual_acceptance.py coverage` with one resolved Python 3 interpreter to report required unmapped surfaces without changing the plan.
+Maintainers must map each shipped user-facing surface to a human item. For ZzzOps that means only the native installer CLI modes and installed skills. Internal control commands, backend mechanics, policy plumbing, reservations, prompt accounting, CI, documentation, and individual test cases are not separate human acceptance surfaces; inspect or automate them proportionately instead. Reusable acceptance-harness behavior needs focused regression coverage, but no human item unless the harness itself ships to users. Run `<python> .agents/manual_acceptance.py coverage` with one resolved Python 3 interpreter to report required unmapped user surfaces without changing the plan.
 
 <!-- zzzops-acceptance-plan
-{"version":1,"items":[{"id":"A-001","title":"Native install preview is non-mutating","status":"unchecked","paths":["install.ps1","install.sh"],"fingerprint":null,"notes":""},{"id":"A-002","title":"Native installer confirms and applies once","status":"unchecked","paths":["install.ps1","install.sh"],"fingerprint":null,"notes":""},{"id":"A-003","title":"Agent-led project initialization","status":"unchecked","paths":[".zzzops/rules/INITIALIZATION.md",".agents/zzzops/zzzops.py"],"fingerprint":null,"notes":""},{"id":"A-004","title":"Reviewed execution defaults","status":"unchecked","paths":[".agents/zzzops/zzzops.py",".agents/zzzops/templates/project-goals/INIT_PLAN.json",".zzzops/rules/EXECUTION_STRATEGY.md",".zzzops/rules/GOAL_SYSTEM.md"],"fingerprint":null,"notes":""},{"id":"A-005","title":"GitHub Issues backend","status":"unchecked","paths":[".zzzops/rules/BACKENDS.md"],"fingerprint":null,"notes":""},{"id":"A-006","title":"Migrate TODOs with approval","status":"unchecked","paths":[".agents/skills/migrate-to-zzzops/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-007","title":"Execute workflow is discoverable","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-008","title":"Capture a durable goal","status":"unchecked","paths":[".agents/skills/add-zzzops-goal/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-009","title":"Suggest work in dry-run mode","status":"unchecked","paths":[".agents/skills/suggest-zzzops-work/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-010","title":"Execute, unblock, watch, and resume","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md",".agents/skills/execute-zzzops/references/EXECUTE.md",".agents/skills/execute-zzzops/references/UNBLOCK.md",".zzzops/rules/BLOCKERS.md",".zzzops/rules/CONTINUATION.md",".zzzops/rules/EXECUTION_STRATEGY.md"],"fingerprint":null,"notes":""},{"id":"A-011","title":"Branch review and merge gate","status":"unchecked","paths":[".agents/skills/execute-zzzops/references/BRANCH_REVIEW.md"],"fingerprint":null,"notes":""},{"id":"A-012","title":"Concurrent goal reservation","status":"unchecked","paths":[".agents/zzzops/zzzops.py",".zzzops/rules/GOAL_SYSTEM.md",".zzzops/rules/BACKENDS.md"],"fingerprint":null,"notes":""},{"id":"A-013","title":"Prompt budget is current","status":"unchecked","paths":[".agents/prompt_stats.py"],"fingerprint":null,"notes":""},{"id":"A-014","title":"PR validation and release boundaries","status":"unchecked","paths":[".github/workflows"],"fingerprint":null,"notes":""}]}
+{"version":1,"items":[{"id":"A-001","title":"Native install preview is non-mutating","status":"unchecked","paths":["install.ps1","install.sh"],"fingerprint":null,"notes":""},{"id":"A-002","title":"Native installer confirms and applies once","status":"unchecked","paths":["install.ps1","install.sh"],"fingerprint":null,"notes":""},{"id":"A-003","title":"Initialize through an installed skill","status":"unchecked","paths":[".agents/skills/add-zzzops-goal/SKILL.md",".zzzops/rules/INITIALIZATION.md"],"fingerprint":null,"notes":""},{"id":"A-006","title":"Migrate TODOs with approval","status":"unchecked","paths":[".agents/skills/migrate-to-zzzops/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-008","title":"Capture a durable goal","status":"unchecked","paths":[".agents/skills/add-zzzops-goal/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-009","title":"Suggest work in dry-run mode","status":"unchecked","paths":[".agents/skills/suggest-zzzops-work/SKILL.md"],"fingerprint":null,"notes":""},{"id":"A-010","title":"Execute goals through review and resume","status":"unchecked","paths":[".agents/skills/execute-zzzops/SKILL.md",".agents/skills/execute-zzzops/references/EXECUTE.md",".agents/skills/execute-zzzops/references/UNBLOCK.md",".agents/skills/execute-zzzops/references/BRANCH_REVIEW.md"],"fingerprint":null,"notes":""}]}
 zzzops-acceptance-plan -->
 
 ## A-001 - Native install preview is non-mutating
@@ -24,7 +24,7 @@ Human action: run the platform installer without its dry-run option, inspect its
 
 Expected: the same invocation rechecks and applies the preview; installation succeeds concisely; `.agents/skills/` and `.claude/skills/` contain the discoverable skills, all other harness support is grouped under `.agents/zzzops/`, shared rules stay under `.zzzops/`, and no ZzzOps file sits directly under `.agents/` or `.claude/`. Git shows only the previewed mechanics, project state is not initialized, and the repeated preview reports that ZzzOps is already up to date.
 
-## A-003 - Agent-led project initialization
+## A-003 - Initialize through an installed skill
 
 Prerequisite: A-002 completed in the disposable repository.
 
@@ -32,27 +32,13 @@ Human action: open a fresh Codex or Claude Code session, start a non-install Zzz
 
 Expected: the installed skill is discovered; the agent proposes overridable project defaults, including outcome-first communication, and waits for explicit policy review before continuing.
 
-## A-004 - Reviewed execution defaults
-
-Prerequisite: initialized disposable repository with ZzzOps mechanics installed.
-
-Human action: run `<python> .agents/zzzops/zzzops.py --repo . init inspect`, then inspect the proposed execution settings in the initialization plan and reviewed `PROJECT.md`.
-
-Expected: the size report uses existing Git-tracked file bytes; refill is enabled for documentation, test coverage, and non-behavioral code quality with a three-goal cap; the small disposable repository selects at most three worktree workers; writable dependent goals wait for completed dependencies while read-only investigation remains allowed; completed worktrees must be removed or deliberately retained clean for safe reuse. These are visible reviewed defaults rather than hidden local state.
-
-## A-005 to A-014 - Core ZzzOps workflow coverage
+## Installed skill workflows
 
 Run each in a disposable repository and record the result in the matching ledger item.
 
 | ID | Human action | Expected observable result |
 | --- | --- | --- |
-| A-005 | Initialize with GitHub Issues selected. | A human-first issue is the canonical goal; repository visibility is explained. |
 | A-006 | Preview a TODO migration, approve it, and inspect the resulting queue. | Existing TODOs are summarized before approval, then become durable GitHub goals with nothing silently omitted. |
-| A-007 | In a fresh session, invoke `execute-zzzops` in dry-run mode against the migrated queue. | It discovers and reports the durable queue without source or Git changes. |
 | A-008 | Capture a small additional goal. | It is durable but creates no branch, commit, or PR. |
 | A-009 | Run work suggestion in dry-run mode. | Evidence-backed suggestions are shown without changing the backlog. |
-| A-010 | Exhaust the queue on one merge-ready PR, merge it during the announced watch, and repeat once without a wait-capable surface. | The agent asks for one clear action without narrating polling mechanics, observes and resumes once; unsupported waiting hands off plainly with the blocker intact. |
-| A-011 | Complete a source-changing test goal. | The agent says the change is ready, provides the review action/link, and does not expose internal hashes or merge without authority. |
-| A-012 | Have two runs contend for one goal, then two different goals contend for one declared resource; repeat with distinct resources and after expiry. | Each overlap has one bundle winner, losers reselect, distinct work proceeds, only owners renew/release, and expiry cannot delete a replacement. |
-| A-013 | Run prompt statistics and its check mode. | The byte/token estimate is deterministic and check mode succeeds. |
-| A-014 | Open a PR and inspect its validation/release behavior. | PR checks are read-only; `main` release behavior remains restricted. |
+| A-010 | Invoke `execute-zzzops` in dry-run mode, then run one small source-changing goal through a human blocker, review, merge, and resume. | Dry run changes nothing; normal execution gives clear actions, preserves blockers, presents a review link without merging early, and resumes after the authorized merge. |


### PR DESCRIPTION
## Outcome
- limits human acceptance to the native installer CLI and installed skills
- consolidates execute behavior into one end-to-end user workflow
- removes internal backend, reservation, prompt-accounting, CI, and harness mechanics as standalone human tests
- makes coverage require only the installer and the four currently installed skills

## Verification
- 73 agent tests pass
- manual acceptance coverage reports no missing user surfaces
- next-item selection returns A-001
- git diff --check passes

Tracks #123