### PR TITLE
fix(installer): skip no-op confirmation

### DIFF
--- a/.agents/test_install_zzzops.py
+++ b/.agents/test_install_zzzops.py
@@ -86,6 +86,9 @@ class NativeInstallerTests(unittest.TestCase):
                 applied = self.run_installer(installer, target, answer="y\n")
                 self.assertEqual(0, applied.returncode, applied.stderr + applied.stdout)
                 self.assertIn("ZzzOps is installed.", applied.stdout)
+                self.assertIn("Codex or Claude Code", applied.stdout)
+                self.assertIn("restart or reopen", applied.stdout)
+                self.assertIn("review-zzzops-policy", applied.stdout)
                 self.assertTrue((target / ".zzzops" / "rules" / "INITIALIZATION.md").is_file())
                 self.assertTrue((target / ".agents" / "zzzops" / "templates" / "project-goals" / "INIT_PLAN.json").is_file())
                 self.assertTrue((target / ".agents" / "zzzops" / ".gitignore").is_file())
@@ -112,6 +115,11 @@ class NativeInstallerTests(unittest.TestCase):
                 repeated = self.run_installer(installer, target, "--dry-run")
                 self.assertEqual(0, repeated.returncode, repeated.stderr + repeated.stdout)
                 self.assertIn("already up to date", repeated.stdout)
+                current = self.run_installer(installer, target)
+                self.assertEqual(0, current.returncode, current.stderr + current.stdout)
+                self.assertIn("No further action is necessary", current.stdout)
+                self.assertNotIn("Install these changes?", current.stdout)
+                self.assertNotIn("cancelled", current.stdout)
 
     def test_ignore_warning_and_local_state_preservation(self):
         for name, installer in self.installers.items():

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On macOS or Linux:
 /path/to/zzzops/install.sh /path/to/your-project
 ```
 
-The installer previews the tracked project mechanics, warns if Git ignores required `.agents/` or `.claude/` content, and asks once before writing. The default answer is no. Use `-DryRun` on Windows or `--dry-run` on macOS/Linux for a non-interactive preview.
+The installer previews the tracked project mechanics, warns if Git ignores required `.agents/` or `.claude/` content, and asks once before real writes. The default answer is no. If everything is current, it exits without prompting and says no further action is necessary. Use `-DryRun` on Windows or `--dry-run` on macOS/Linux for a non-interactive preview.
 
 The CLI copies discoverable skills, mechanics, and blank templates—never itself, project state, another project’s goals, or the target’s `AGENTS.md`/`CLAUDE.md`.
 

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -20,9 +20,9 @@ Expected: it explains the tracked project skills, rules/control CLI, and blank s
 
 Prerequisite: complete A-001, then remove the `.agents/` and `.claude/` ignore rules.
 
-Human action: run the platform installer without its dry-run option, inspect its preview, answer yes at the default-no prompt, inspect the installed files and target Git status, then repeat a dry run.
+Human action: run the platform installer without its dry-run option, inspect its preview, answer yes at the default-no prompt, inspect the installed files and target Git status, then run the normal installer again.
 
-Expected: the same invocation rechecks and applies the preview; installation succeeds concisely; `.agents/skills/` and `.claude/skills/` contain the discoverable skills, all other harness support is grouped under `.agents/zzzops/`, shared rules stay under `.zzzops/`, and no ZzzOps file sits directly under `.agents/` or `.claude/`. Git shows only the previewed mechanics, project state is not initialized, and the repeated preview reports that ZzzOps is already up to date.
+Expected: the same invocation rechecks and applies the preview; installation succeeds concisely and directs you to open the target in Codex or Claude Code, restart/reopen the harness if skills are not discovered, and begin with `review-zzzops-policy`. `.agents/skills/` and `.claude/skills/` contain the discoverable skills, all other harness support is grouped under `.agents/zzzops/`, shared rules stay under `.zzzops/`, and no ZzzOps file sits directly under `.agents/` or `.claude/`. Git shows only the previewed mechanics and project state is not initialized. A repeated normal install reports that ZzzOps is already up to date, says no further action is necessary, and exits without asking for confirmation.
 
 ## A-003 - Review and initialize project policy
 

--- a/install.ps1
+++ b/install.ps1
@@ -219,6 +219,11 @@ if ($DryRun) {
     Write-Host 'No files were changed.'
     exit 0
 }
+$pendingChanges = @($plan.Actions | Where-Object { $_.Action -in @('create', 'overwrite') }).Count
+if (-not $pendingChanges) {
+    Write-Host 'ZzzOps is already up to date. No further action is necessary.'
+    exit 0
+}
 $answer = Read-Host 'Install these changes? [y/N]'
 if ($answer -notmatch '^(?i:y|yes)$') {
     Write-Host 'Installation cancelled; no files were changed.'
@@ -230,5 +235,5 @@ if ($confirmedPlan.Errors.Count -or $confirmedPlan.Signature -ne $plan.Signature
     exit 2
 }
 if (-not (Apply-Plan $confirmedPlan)) { exit 2 }
-Write-Host 'ZzzOps is installed. Start any ZzzOps workflow to set up the project.'
+Write-Host 'ZzzOps is installed. Open the target repository in Codex or Claude Code; restart or reopen the harness if the new skills are not discovered. Begin with review-zzzops-policy.'
 exit 0

--- a/install.sh
+++ b/install.sh
@@ -207,6 +207,14 @@ build_plan
 show_preview
 [[ ${#PLAN_ERRORS[@]} -eq 0 ]] || exit 2
 if [[ $DRY_RUN -eq 1 ]]; then printf 'No files were changed.\n'; exit 0; fi
+pending_changes=0
+for action in "${PLAN_ACTION[@]}"; do
+    [[ "$action" == create || "$action" == overwrite ]] && ((pending_changes+=1))
+done
+if [[ $pending_changes -eq 0 ]]; then
+    printf 'ZzzOps is already up to date. No further action is necessary.\n'
+    exit 0
+fi
 printf 'Install these changes? [y/N] '
 IFS= read -r answer || answer=''
 answer=${answer%$'\r'}
@@ -218,4 +226,4 @@ if [[ ${#PLAN_ERRORS[@]} -gt 0 || "$PLAN_SIGNATURE" != "$preview_signature" ]]; 
     exit 2
 fi
 if ! apply_plan; then printf 'Installation failed and was rolled back.\n'; exit 2; fi
-printf 'ZzzOps is installed. Start any ZzzOps workflow to set up the project.\n'
+printf 'ZzzOps is installed. Open the target repository in Codex or Claude Code; restart or reopen the harness if the new skills are not discovered. Begin with review-zzzops-policy.\n'


### PR DESCRIPTION
Stops both native installers before confirmation when ZzzOps is already current, with a clear no-action-needed result. Successful installs now direct users to open the target in Codex or Claude Code, restart or reopen the harness if needed, and begin with review-zzzops-policy. Tests: 75 agent tests, native PowerShell and Bash install-to-rerun probes, installer syntax, and acceptance coverage.