### PR TITLE
docs(workflows): avoid command retry loops

### DIFF
--- a/.zzzops/rules/BACKENDS.md
+++ b/.zzzops/rules/BACKENDS.md
@@ -1,16 +1,16 @@
 # GitHub goal backend
 
-The reviewed canonical `.zzzops/POLICY.json` records GitHub Issues as the goal authority; `.zzzops/PROJECT.md` summarizes that choice for humans.
+Canonical `.zzzops/POLICY.json` makes GitHub Issues the goal authority; `.zzzops/PROJECT.md` summarizes it.
 
-Use the portfolio embedded by `INITIALIZATION.md`'s single checkpoint; never run a second portfolio command there. Require `complete:true` and `valid:true`; use its compact inventory/graph/human queue. It omits criteria/history, so re-read only the selected goal before writing and match revision/digest. Refresh the checkpoint once after mutation/drift. Standalone `portfolio` is for explicit CLI inspection/comparison.
+Use `INITIALIZATION.md`'s checkpoint portfolio; never rerun `portfolio` there. Require `complete:true` and `valid:true`; use its inventory/graph/human queue. It omits criteria/history, so re-read only the selected goal and match revision/digest. Refresh once after mutation/drift. Standalone `portfolio` is only for explicit inspection/comparison.
 
-Closed goals are fully validated, then emitted as minimal archived projections. Re-read only likely duplicates, selection-critical relations, or explicit user targets.
+Closed goals become validated minimal projections. Re-read only likely duplicates, selection-critical relations, or explicit targets.
 
 Managed issues labeled `zzzops-feedback` are omitted from ordinary portfolio checkpoints. Include them with `--include-feedback` only after one explicit approval for the current execution session; the choice covers the whole feedback queue, is not persisted, and never causes per-issue approval prompts.
 
 ## GitHub Issues (`github_issues`)
 
-The checkpoint's single paginated GitHub process must confirm identity, authentication, Issues, and management permission while fetching managed issues. Agents use native `gh issue`/`gh api` only for targeted reads/writes; the CLI validates managed structures.
+The checkpoint's one paginated GitHub process confirms identity, authentication, Issues, and management permission. Use native `gh issue`/`gh api` only for targeted reads/writes; the CLI validates structures. If direct `gh` auth works but a sandboxed CLI child fails authentication, rerun the same bounded command once in an approved authenticated context; never reauthenticate or vary commands.
 
 - Repository plus issue number/URL is identity. Use a plain human title: never add a ZzzOps/date ID. Begin the body with concise human sections; no rendered metadata/frontmatter or duplicated title.
 - When introducing this backend, explain that goals inherit the repository's visibility and must not contain secrets or raw sensitive data.

--- a/.zzzops/rules/EXECUTION_STRATEGY.md
+++ b/.zzzops/rules/EXECUTION_STRATEGY.md
@@ -45,6 +45,6 @@ Do not use writable worktrees for coupled work, broad shared-file changes, gener
 
 ## Waits, commits, resources
 
-Delegate wait-dominated commands and human-unblock watches at the PROJECT threshold before launch; keep the main thread on independent lightweight work. If an unexpected command runs long, poll boundedly and delegate comparable future waits rather than duplicate it. A wait monitor remains read-only and must stop on user input or state drift.
+Delegate waits and human watches at the PROJECT threshold. Resume yielded session/cell handles; poll boundedly, never relaunch because output was deferred. For quote-heavy/multiline cross-shell payloads, use secure UTF-8 temp files or byte-preserving stdin; verify bytes before external writes. Read-only monitors stop on input/drift.
 
 Follow PROJECT Git/commit policy and never absorb unrelated changes. Note fan-out, latency benefit, resource evidence, and contention; revert work types to sequential when parallel cost lacks value.


### PR DESCRIPTION
Tracks #137

## Summary
- resume yielded command handles instead of relaunching equivalent work
- use byte-preserving transport for quote-heavy cross-shell payloads
- retry established-auth child-process failures once in the approved authenticated context
- distill existing wording so prompt usage remains below the current ceiling

## Verification
- 10 workflow-contract tests pass
- prompt budget check passes at approximately 14,394 tokens
- focused diff inspection and git diff --check pass