### PR TITLE
docs(workflows): separate refill provenance labels

### DIFF
--- a/.agents/skills/suggest-zzzops-work/SKILL.md
+++ b/.agents/skills/suggest-zzzops-work/SKILL.md
@@ -11,7 +11,7 @@ Run `.zzzops/rules/INITIALIZATION.md`, then `.zzzops/rules/BACKENDS.md`. Read pr
 2. Inspect actual architecture/entry points and relevant active code, tests/coverage evidence, user/developer/operations docs, CI/build/config, errors/observability/security/performance/accessibility, and stale/dead paths. Use focused native commands; do not run expensive suites merely for ideas.
 3. Compare charter, goals, blockers/history, and trackers. Reject duplicates, generated/dependency work, speculative rewrites, cosmetic churn, and ideas without evidenced beneficiary/observable result.
 4. Rank a short high-confidence list by value, risk, unlocks, confidence, difficulty, and feedback speed. Record full evidence/criteria/dependencies/probe internally; present outcome, why it matters, and the next useful decision. No observation surface means no suggestion without a concrete harness plan.
-5. Dry-run: report the ranked outcomes and say that nothing changed. Apply: create only approved/authorized canonical goals using `$add-zzzops-goal` semantics and record evidence/source. Never implement while suggesting; never automate Git for capture.
+5. Dry-run: report the ranked outcomes and say that nothing changed. Apply: create only approved/authorized canonical goals using `$add-zzzops-goal` semantics and record evidence/source. During exhausted-queue refill, tag every goal `zzzops-refill`; never copy source labels such as `zzzops-feedback`, reserved for explicit feedback submissions. Never implement while suggesting; never automate Git for capture.
 
 Exhausted-queue apply honors independent opt-ins:
 

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -1386,5 +1386,17 @@ class WorkflowContractTests(unittest.TestCase):
         for phrase in ("zzzops-feedback", "current execution session", "Never ask per issue", "--include-feedback"):
             self.assertIn(phrase, execute)
 
+    def test_refill_and_feedback_provenance_labels_stay_distinct(self):
+        skills = Path(__file__).parent / "skills"
+        refill = (skills / "suggest-zzzops-work" / "SKILL.md").read_text(encoding="utf-8").lower()
+        feedback = (skills / "send-zzzops-feedback" / "SKILL.md").read_text(encoding="utf-8")
+        for phrase in ("during exhausted-queue refill", "zzzops-refill", "never copy source labels", "zzzops-feedback"):
+            self.assertIn(phrase, refill)
+        self.assertIn("`zzzops-feedback` label", feedback)
+        self.assertEqual(
+            ["zzzops", "zzzops-feedback", "zzzops:status:new", "zzzops:priority:P2"],
+            zzzops.EXECUTION_REPORT_LABELS,
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- tag exhausted-queue refill goals with `zzzops-refill`
- forbid propagation of source labels such as `zzzops-feedback`
- add contract coverage for the refill/feedback label boundary

## Verification

- 86-test `.agents` suite passed
- 11 focused workflow-contract tests passed after self-review correction
- prompt budget check passed at approximately 14,396 / 14,400 tokens
- `git diff --check` passed

Closes #141
