### PR TITLE
fix(feedback): normalize stdin byte-order marks

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -1,4 +1,5 @@
 import importlib.util
+import io
 import json
 import re
 import subprocess
@@ -437,6 +438,16 @@ class ExecutionReportTests(unittest.TestCase):
         }
         values.update(overrides)
         return zzzops.record_execution_report(self.repo, self.project, **values)
+
+    def test_feedback_cli_text_normalizes_utf8_bom_for_file_and_stdin(self):
+        prompt = self.repo / "prompt.txt"
+        for text in ("", "Feedback"):
+            prompt.write_bytes(b"\xef\xbb\xbf" + text.encode("utf-8"))
+            from_file = zzzops.read_cli_text(str(prompt))
+            with mock.patch.object(sys, "stdin", io.StringIO("\ufeff" + text)):
+                from_stdin = zzzops.read_cli_text("-")
+            self.assertEqual(text, from_file)
+            self.assertEqual(from_file, from_stdin)
 
     def test_record_is_constrained_local_and_policy_can_disable_it(self):
         result = self.record()

--- a/.agents/zzzops/zzzops.py
+++ b/.agents/zzzops/zzzops.py
@@ -895,7 +895,8 @@ def reviewed_project_state(repo: Path) -> dict[str, Any]:
 
 def read_cli_text(value: str) -> str:
     if value == "-":
-        return sys.stdin.read()
+        text = sys.stdin.read()
+        return text[1:] if text.startswith("\ufeff") else text
     try:
         return Path(value).resolve().read_text(encoding="utf-8-sig")
     except (OSError, UnicodeError) as exc:


### PR DESCRIPTION
## Summary

- normalize one leading Unicode BOM from feedback supplied through standard input
- preserve ordinary input and match existing `utf-8-sig` prompt-file behavior
- cover empty, BOM-only, and non-empty BOM-prefixed transport equivalence

## Verification

- focused regression failed before the fix and passes afterward
- all 7 feedback/report tests pass, including confirmation and report cleanup/retention paths
- all 87 `.agents` tests pass
- both changed Python files compile with bytecode output redirected to a temporary directory
- `git diff --check` passes

Tracks #140
