### PR TITLE
feat(goals): add file-backed transitions

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -683,6 +683,146 @@ class ManagedGoalTests(unittest.TestCase):
             self.assertIn(f"{field} is invalid", zzzops.validate_managed_goal(candidate))
 
 
+class FakeGoalTransitionAdapter:
+    def __init__(self, issue):
+        self.repository = "owner/repo"
+        self.issue = json.loads(json.dumps(issue))
+        self.updates = []
+        self.failure = None
+        self.response_mutation = None
+
+    def get_issue(self, number):
+        self.assert_number(number)
+        return json.loads(json.dumps(self.issue))
+
+    def update_issue(self, number, payload):
+        self.assert_number(number)
+        self.updates.append(json.loads(json.dumps(payload)))
+        if self.failure:
+            raise zzzops.GoalTransitionProviderError(self.failure)
+        updated = json.loads(json.dumps(self.issue))
+        updated.update({"body": payload["body"], "state": payload["state"], "updated_at": "2026-07-21T21:00:00Z"})
+        updated["labels"] = [{"name": label} for label in payload["labels"]]
+        if self.response_mutation:
+            self.response_mutation(updated)
+        self.issue = updated
+        return json.loads(json.dumps(updated))
+
+    @staticmethod
+    def assert_number(number):
+        if number != 42:
+            raise AssertionError(number)
+
+
+class GoalTransitionTests(unittest.TestCase):
+    def goal(self):
+        return {
+            "schema_version": 1, "status": "ready", "priority": "P2", "value": "high",
+            "difficulty": "S", "confidence": "high", "parent": None, "depends_on": [],
+            "claim": None, "blockers": [], "evidence": ["Baseline."],
+            "next_action": "Run the probe.", "revision": 1,
+            "implementation": {"branch": None, "base": None, "target": None, "pr": None,
+                               "review": {"status": "not_started", "checkpoint": None}},
+            "resources": [],
+        }
+
+    def issue(self):
+        body = zzzops.render_managed_goal(self.goal(), "## Outcome / Why\n\nPreserve this human text.\n", 42)
+        return {
+            "number": 42, "title": "Transition safely", "body": body, "state": "open",
+            "updated_at": "2026-07-21T20:00:00Z", "html_url": "https://github.com/owner/repo/issues/42",
+            "labels": [{"name": "zzzops"}, {"name": "zzzops-feedback"},
+                       {"name": "zzzops:status:ready"}, {"name": "zzzops:priority:P2"}],
+        }
+
+    def transition(self, issue=None):
+        issue = issue or self.issue()
+        desired = json.loads(json.dumps(self.goal()))
+        desired.update({"status": "blocked", "priority": "P1", "revision": 2,
+                        "next_action": "Wait for review."})
+        desired["blockers"] = [{"id": "B-001", "status": "open", "category": "human-action"}]
+        return {
+            "schema_version": 1,
+            "expected_revision": 1,
+            "expected_digest": zzzops.github_goal_record(issue)["digest"],
+            "goal": desired,
+        }
+
+    def test_transition_preserves_human_text_and_derives_provider_state(self):
+        issue = self.issue()
+        adapter = FakeGoalTransitionAdapter(issue)
+        result = zzzops.apply_goal_transition(adapter, "owner/repo", 42, self.transition(issue))
+        self.assertEqual(1, len(adapter.updates))
+        payload = adapter.updates[0]
+        self.assertTrue(payload["body"].startswith("## Outcome / Why\n\nPreserve this human text."))
+        self.assertEqual("open", payload["state"])
+        self.assertEqual(
+            {"zzzops", "zzzops-feedback", "zzzops:status:blocked", "zzzops:priority:P1"},
+            set(payload["labels"]),
+        )
+        self.assertEqual({"number": 42, "revision": 2, "state": "open", "status": "blocked",
+                          "url": "https://github.com/owner/repo/issues/42"}, result)
+
+        adapter = FakeGoalTransitionAdapter(issue)
+        transition = self.transition(issue)
+        transition["goal"].update({"status": "done", "blockers": [], "next_action": "No further action."})
+        result = zzzops.apply_goal_transition(adapter, "owner/repo", 42, transition)
+        self.assertEqual("closed", result["state"])
+        self.assertIn("zzzops:status:done", adapter.updates[0]["labels"])
+
+    def test_transition_rejects_stale_or_malformed_input_before_write(self):
+        issue = self.issue()
+        for change in ("revision", "digest", "schema", "revision_jump"):
+            adapter = FakeGoalTransitionAdapter(issue)
+            transition = self.transition(issue)
+            if change == "revision":
+                transition["expected_revision"] = 9
+            elif change == "digest":
+                transition["expected_digest"] = "0" * 64
+            elif change == "schema":
+                transition["surprise"] = True
+            else:
+                transition["goal"]["revision"] = 3
+            with self.assertRaises(ValueError, msg=change):
+                zzzops.apply_goal_transition(adapter, "owner/repo", 42, transition)
+            self.assertEqual([], adapter.updates)
+
+    def test_transition_never_implies_success_on_provider_failure_or_bad_response(self):
+        issue = self.issue()
+        adapter = FakeGoalTransitionAdapter(issue)
+        adapter.failure = "provider failed"
+        with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "provider failed"):
+            zzzops.apply_goal_transition(adapter, "owner/repo", 42, self.transition(issue))
+        self.assertEqual(issue, adapter.issue)
+
+        adapter = FakeGoalTransitionAdapter(issue)
+        adapter.response_mutation = lambda updated: updated.update({"body": "unexpected"})
+        with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "unexpected"):
+            zzzops.apply_goal_transition(adapter, "owner/repo", 42, self.transition(issue))
+        self.assertEqual(1, len(adapter.updates))
+
+    def test_transition_file_is_bom_tolerant(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "transition.json"
+            transition = self.transition()
+            path.write_bytes(b"\xef\xbb\xbf" + json.dumps(transition).encode("utf-8"))
+            self.assertEqual(transition, zzzops.load_goal_transition(path))
+
+    @mock.patch.object(zzzops.shutil, "which", return_value="gh")
+    @mock.patch.object(zzzops.subprocess, "run")
+    def test_github_transition_adapter_uses_one_json_stdin_patch(self, run, _which):
+        issue = self.issue()
+        run.return_value = SimpleNamespace(returncode=0, stdout=json.dumps(issue), stderr="")
+        adapter = zzzops.GitHubGoalTransitionAdapter(Path.cwd(), "owner/repo")
+        payload = {"body": issue["body"], "labels": ["zzzops"], "state": "open"}
+        self.assertEqual(issue, adapter.update_issue(42, payload))
+        self.assertEqual(
+            ["gh", "api", "--method", "PATCH", "repos/owner/repo/issues/42", "--input", "-"],
+            run.call_args.args[0],
+        )
+        self.assertEqual(payload, json.loads(run.call_args.kwargs["input"]))
+
+
 class PortfolioTests(unittest.TestCase):
     def goal(self, **overrides):
         goal = {

--- a/.agents/zzzops/zzzops.py
+++ b/.agents/zzzops/zzzops.py
@@ -22,6 +22,7 @@ PROJECT_SCHEMA_VERSION = 1
 PLAN_SCHEMA_VERSION = 1
 POLICY_SCHEMA_VERSION = 1
 GOAL_SCHEMA_VERSION = 1
+GOAL_TRANSITION_SCHEMA_VERSION = 1
 PORTFOLIO_SCHEMA_VERSION = 1
 PROJECT_POLICY_RELATIVE = ".zzzops/POLICY.json"
 PROJECT_AUDIT_RELATIVE = ".zzzops/PROJECT_AUDIT.md"
@@ -45,6 +46,7 @@ GOAL_FIELDS = {
     "parent", "depends_on", "claim", "blockers",
     "evidence", "next_action", "revision", "implementation", "resources",
 }
+GOAL_TRANSITION_FIELDS = {"schema_version", "expected_revision", "expected_digest", "goal"}
 BLOCKER_CATEGORIES = {
     "specification", "decision", "access-approval", "human-action",
     "external-dependency", "technical-unknown", "safety-compliance",
@@ -185,6 +187,10 @@ EXECUTION_REPORT_ID = re.compile(r"^report-[0-9a-f]{64}$")
 
 class ReservationProviderError(ValueError):
     """The provider did not produce a safe, confirmed reservation result."""
+
+
+class GoalTransitionProviderError(ValueError):
+    """The provider did not produce a safe, confirmed goal transition result."""
 
 
 def _reservation_actor(value: str, field: str, limit: int) -> str:
@@ -367,6 +373,82 @@ class GitHubReservationAdapter:
         ])
         if result.returncode:
             raise self._provider_error(result)
+
+
+class GitHubGoalTransitionAdapter:
+    def __init__(self, repo: Path, repository: str):
+        self.repo = repo
+        self.repository = repository
+        self.executable = shutil.which("gh")
+        if not self.executable:
+            raise GoalTransitionProviderError("GitHub CLI is unavailable; no goal update was made.")
+        self._identity_checked = False
+
+    def _run(
+        self, arguments: list[str], *, input_text: str | None = None, timeout: int = 30,
+    ) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                [self.executable, *arguments], cwd=self.repo, capture_output=True, text=True,
+                encoding="utf-8", input=input_text, timeout=timeout, check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise GoalTransitionProviderError(
+                f"GitHub did not confirm the goal transition ({type(exc).__name__}); success was not assumed."
+            ) from exc
+
+    @staticmethod
+    def _provider_error(result: subprocess.CompletedProcess[str]) -> GoalTransitionProviderError:
+        detail = sanitize_output((result.stderr.strip() or result.stdout.strip() or "unknown GitHub error").splitlines()[0][:300])
+        return GoalTransitionProviderError(f"GitHub did not confirm the goal transition: {detail}")
+
+    def ensure_identity(self) -> None:
+        if self._identity_checked:
+            return
+        result = self._run(["repo", "view", self.repository, "--json", "nameWithOwner,hasIssuesEnabled,viewerPermission"])
+        if result.returncode:
+            raise self._provider_error(result)
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise GoalTransitionProviderError("GitHub returned invalid repository metadata; no goal update was made.") from exc
+        if data.get("nameWithOwner", "").casefold() != self.repository.casefold():
+            raise GoalTransitionProviderError("GitHub repository identity changed; no goal update was made.")
+        if not data.get("hasIssuesEnabled") or data.get("viewerPermission") not in GITHUB_MANAGEMENT_PERMISSIONS:
+            raise GoalTransitionProviderError("GitHub Issues management permission is required; no goal update was made.")
+        self._identity_checked = True
+
+    def get_issue(self, number: int) -> dict[str, Any]:
+        self.ensure_identity()
+        result = self._run(["api", f"repos/{self.repository}/issues/{number}"])
+        if result.returncode:
+            raise self._provider_error(result)
+        try:
+            issue = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise GoalTransitionProviderError("GitHub returned invalid goal data; no goal update was made.") from exc
+        if not isinstance(issue, dict):
+            raise GoalTransitionProviderError("GitHub returned incomplete goal data; no goal update was made.")
+        return issue
+
+    def update_issue(self, number: int, payload: dict[str, Any]) -> dict[str, Any]:
+        result = self._run(
+            ["api", "--method", "PATCH", f"repos/{self.repository}/issues/{number}", "--input", "-"],
+            input_text=json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        )
+        if result.returncode:
+            raise self._provider_error(result)
+        try:
+            issue = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise GoalTransitionProviderError(
+                "GitHub returned an invalid goal-transition response; success was not assumed."
+            ) from exc
+        if not isinstance(issue, dict):
+            raise GoalTransitionProviderError(
+                "GitHub returned an incomplete goal-transition response; success was not assumed."
+            )
+        return issue
 
 
 def _validate_reservation_goal(
@@ -1291,6 +1373,104 @@ def github_goal_record(issue: dict[str, Any]) -> dict[str, Any]:
         "updated_at": issue.get("updated_at"), "implementation": goal.get("implementation"),
         "labels": sorted(label["name"] for label in issue.get("labels", []) if isinstance(label, dict) and text_present(label.get("name"))),
         "state": issue.get("state"), "url": issue.get("html_url"),
+    }
+
+
+def validate_goal_transition(transition: Any, issue_number: int) -> list[str]:
+    if not isinstance(transition, dict):
+        return ["transition must be an object"]
+    errors = []
+    unknown = sorted(set(transition) - GOAL_TRANSITION_FIELDS)
+    missing = sorted(GOAL_TRANSITION_FIELDS - set(transition))
+    if unknown:
+        errors.append("unknown transition fields: " + ", ".join(unknown))
+    if missing:
+        errors.append("missing transition fields: " + ", ".join(missing))
+    if transition.get("schema_version") != GOAL_TRANSITION_SCHEMA_VERSION:
+        errors.append(f"transition schema_version must be {GOAL_TRANSITION_SCHEMA_VERSION}")
+    expected_revision = transition.get("expected_revision")
+    if not isinstance(expected_revision, int) or isinstance(expected_revision, bool) or expected_revision < 1:
+        errors.append("expected_revision must be a positive integer")
+    digest = transition.get("expected_digest")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        errors.append("expected_digest must be the 64-character checkpoint goal digest")
+    goal = transition.get("goal")
+    errors.extend(validate_managed_goal(goal, issue_number))
+    if (
+        isinstance(goal, dict) and isinstance(expected_revision, int)
+        and not isinstance(expected_revision, bool) and goal.get("revision") != expected_revision + 1
+    ):
+        errors.append("goal revision must increment expected_revision by exactly one")
+    return errors
+
+
+def load_goal_transition(path: Path) -> dict[str, Any]:
+    try:
+        transition = json.loads(path.resolve().read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Could not read goal transition: {type(exc).__name__}") from exc
+    return transition
+
+
+def apply_goal_transition(
+    adapter: Any, repository: str, issue_number: int, transition: dict[str, Any],
+) -> dict[str, Any]:
+    errors = validate_goal_transition(transition, issue_number)
+    if errors:
+        raise ValueError("Invalid goal transition: " + "; ".join(errors))
+    if adapter.repository.casefold() != repository.casefold():
+        raise GoalTransitionProviderError("Repository identity changed; no goal update was made.")
+    issue = adapter.get_issue(issue_number)
+    try:
+        record = github_goal_record(issue)
+    except ValueError as exc:
+        raise GoalTransitionProviderError("The current goal could not be validated; no goal update was made.") from exc
+    if record["revision"] != transition["expected_revision"]:
+        raise ValueError(
+            f"Goal #{issue_number} changed from revision {transition['expected_revision']} to {record['revision']}; no update was made."
+        )
+    if not hmac.compare_digest(record["digest"], transition["expected_digest"]):
+        raise ValueError(f"Goal #{issue_number} digest changed; no update was made.")
+
+    desired = transition["goal"]
+    body = render_managed_goal(desired, issue["body"], issue_number)
+    retained_labels = sorted({
+        label["name"] for label in issue.get("labels", [])
+        if isinstance(label, dict) and text_present(label.get("name"))
+        and label["name"] != "zzzops"
+        and not label["name"].startswith("zzzops:status:")
+        and not label["name"].startswith("zzzops:priority:")
+    })
+    labels = ["zzzops", *retained_labels, f"zzzops:status:{desired['status']}", f"zzzops:priority:{desired['priority']}"]
+    state = "closed" if desired["status"] in {"done", "cancelled"} else "open"
+    updated = adapter.update_issue(issue_number, {"body": body, "labels": labels, "state": state})
+
+    expected_url = f"https://github.com/{repository}/issues/{issue_number}"
+    returned_labels = {
+        label["name"] for label in updated.get("labels", [])
+        if isinstance(label, dict) and text_present(label.get("name"))
+    }
+    try:
+        returned_goal = parse_managed_goal(updated.get("body"), issue_number)
+    except ValueError as exc:
+        raise GoalTransitionProviderError(
+            "GitHub returned an unexpected goal-transition response; success was not assumed."
+        ) from exc
+    if (
+        updated.get("number") != issue_number
+        or updated.get("title") != issue.get("title")
+        or updated.get("body") != body
+        or str(updated.get("state", "")).casefold() != state
+        or returned_labels != set(labels)
+        or updated.get("html_url") != expected_url
+        or returned_goal != desired
+    ):
+        raise GoalTransitionProviderError(
+            "GitHub returned an unexpected goal-transition response; success was not assumed."
+        )
+    return {
+        "number": issue_number, "revision": desired["revision"], "state": state,
+        "status": desired["status"], "url": expected_url,
     }
 
 
@@ -2409,6 +2589,11 @@ def main() -> int:
     portfolio_parser.add_argument("--include-done", action="store_true", help="Include terminal goals in summary output")
     portfolio_parser.add_argument("--compare", type=Path, help="Prior JSON snapshot used only to report digest/revision drift")
     portfolio_parser.add_argument("--include-feedback", action="store_true", help="Include specially tagged feedback goals")
+    goal_command = commands.add_parser("goal", help="Apply validated GitHub-backed goal transitions")
+    goal_commands = goal_command.add_subparsers(dest="goal_command", required=True)
+    transition_command = goal_commands.add_parser("transition", help="Apply one file-backed managed-goal transition")
+    transition_command.add_argument("--goal", type=int, required=True)
+    transition_command.add_argument("--input", type=Path, required=True, help="UTF-8 transition JSON file")
     reserve = commands.add_parser("reserve", help="Atomically reserve a GitHub-backed goal")
     reserve_commands = reserve.add_subparsers(dest="reserve_command", required=True)
     for name in ("acquire", "renew", "release"):
@@ -2487,6 +2672,13 @@ def main() -> int:
                 else:
                     print(f"Could not load goals: {exc}")
                 return 2
+        elif args.command == "goal":
+            project = reviewed_project_state(repo)
+            repository = _project_repository_identity(project)
+            transition = load_goal_transition(args.input)
+            adapter = GitHubGoalTransitionAdapter(repo, repository)
+            result = apply_goal_transition(adapter, repository, args.goal, transition)
+            print(json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
         elif args.command == "reserve":
             project = reviewed_project_state(repo)
             repository = _project_repository_identity(project)

--- a/.zzzops/rules/BACKENDS.md
+++ b/.zzzops/rules/BACKENDS.md
@@ -18,7 +18,7 @@ The checkpoint's one paginated GitHub process confirms identity, authentication,
 - Same-repository parent/dependency relations are positive issue numbers. Derive children/blocking edges portfolio-wide. Put resolutions/history in append-only comments; old comments remain immutable provenance.
 - Use label `zzzops`, one `zzzops:status:*`, and one `zzzops:priority:*` as derived indexes.
 - Reservations use transient `zzzops:reserve:<issue>` and `zzzops:resource:<hash>` labels. GitHub name uniqueness chooses one winner with Issues permission; metadata binds repository, goal/revision, owner/run, and expiry. Renew/recover by immutable node ID and exact readback, so delayed cleanup cannot delete a replacement. Drift, conflict, malformed state, provider failure, or uncertainty denies ownership; no alternate lock or advisory fallback.
-- Before update, re-read issue plus `updated_at`; parse/validate the block and abort/reconcile if the snapshot digest/revision changed. The batch command paginates once and reports incomplete reads instead of guessing.
+- Apply updates via `<python> .agents/zzzops/zzzops.py goal transition --goal N --input FILE`. UTF-8 input binds expected revision/digest to the next goal, preserves human text, derives labels/state, and validates the write.
 - Capability/auth/permission/disabled-Issues/label drift is an explicit blocker. Never invent a fallback authority.
 
 ## Git boundary


### PR DESCRIPTION
## Summary

- add a validated `goal transition` CLI command driven by a UTF-8 JSON file
- bind each update to the expected issue revision and checkpoint digest
- preserve human content/custom labels while deriving managed labels and open/closed state
- perform one stdin-backed provider PATCH and validate its complete returned issue
- document the deterministic update path within the unchanged prompt ceiling

## Verification

- all 92 `.agents` tests pass
- 13 focused managed-goal/transition tests pass
- changed Python files compile with bytecode output redirected to a temporary directory
- prompt enforcement passes at approximately 14,398 / 14,400 tokens
- `git diff --check` passes
- live transition of #144 from revision 4 to 5 succeeded and preserved its feedback envelope

Tracks #144
