### PR TITLE
fix(release): keep dry-run preview read-only

### DIFF
--- a/.github/scripts/preview_semantic_release.mjs
+++ b/.github/scripts/preview_semantic_release.mjs
@@ -1,0 +1,124 @@
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import semanticRelease from "semantic-release";
+
+const require = createRequire(import.meta.url);
+const releaseConfig = require("../../release.config.cjs");
+const repository = process.cwd();
+const branch = execFileSync("git", ["branch", "--show-current"], {
+  cwd: repository,
+  encoding: "utf8"
+}).trim();
+const canonicalRemote = execFileSync("git", ["remote", "get-url", "origin"], {
+  cwd: repository,
+  encoding: "utf8"
+}).trim();
+const remoteUrl = new URL(canonicalRemote);
+if (!remoteUrl.protocol.startsWith("http")) {
+  throw new Error("Semantic release preview requires an HTTP(S) origin URL.");
+}
+const remotePath = remoteUrl.pathname.replace(/^\/+/, "");
+const remotePrefix = `${remoteUrl.protocol}//${remoteUrl.host}/`;
+
+if (!branch) {
+  throw new Error("Semantic release preview requires a checked-out branch.");
+}
+
+const isolatedEnv = { ...process.env };
+for (const name of [
+    "CI",
+    "BB_TOKEN",
+    "BB_TOKEN_BASIC_AUTH",
+    "BITBUCKET_TOKEN",
+    "GIT_CREDENTIALS",
+    "GITHUB_ACTION",
+    "GITHUB_ACTIONS",
+  "GITHUB_EVENT_NAME",
+  "GITHUB_EVENT_PATH",
+  "GITHUB_REF",
+  "GITHUB_REPOSITORY",
+  "GITHUB_RUN_ID",
+  "GITHUB_SERVER_URL",
+    "GITHUB_SHA",
+    "GITHUB_TOKEN",
+    "GITHUB_WORKSPACE",
+    "GH_TOKEN",
+    "GITLAB_TOKEN",
+    "GL_TOKEN"
+]) {
+  delete isolatedEnv[name];
+}
+
+const previewRoot = mkdtempSync(join(tmpdir(), "zzzops-release-preview-"));
+const localRemote = join(previewRoot, ...remotePath.split("/"));
+let processGitConfig;
+
+try {
+  mkdirSync(dirname(localRemote), { recursive: true });
+  execFileSync("git", [
+    "-c",
+    `safe.directory=${join(repository, ".git")}`,
+    "clone",
+    "--bare",
+    repository,
+    localRemote
+  ], {
+    stdio: ["ignore", "ignore", "inherit"]
+  });
+  const configuredCount = Number.parseInt(isolatedEnv.GIT_CONFIG_COUNT || "0", 10);
+  const gitConfigIndex = Number.isNaN(configuredCount) ? 0 : configuredCount;
+  isolatedEnv.GIT_CONFIG_COUNT = String(gitConfigIndex + 1);
+  isolatedEnv[`GIT_CONFIG_KEY_${gitConfigIndex}`] = `url.${pathToFileURL(`${previewRoot}${sep}`).href}.insteadOf`;
+  isolatedEnv[`GIT_CONFIG_VALUE_${gitConfigIndex}`] = remotePrefix;
+  processGitConfig = {
+    GIT_CONFIG_COUNT: process.env.GIT_CONFIG_COUNT,
+    [`GIT_CONFIG_KEY_${gitConfigIndex}`]: process.env[`GIT_CONFIG_KEY_${gitConfigIndex}`],
+    [`GIT_CONFIG_VALUE_${gitConfigIndex}`]: process.env[`GIT_CONFIG_VALUE_${gitConfigIndex}`]
+  };
+  process.env.GIT_CONFIG_COUNT = isolatedEnv.GIT_CONFIG_COUNT;
+  process.env[`GIT_CONFIG_KEY_${gitConfigIndex}`] = isolatedEnv[`GIT_CONFIG_KEY_${gitConfigIndex}`];
+  process.env[`GIT_CONFIG_VALUE_${gitConfigIndex}`] = isolatedEnv[`GIT_CONFIG_VALUE_${gitConfigIndex}`];
+  const mirroredHeads = execFileSync("git", ["ls-remote", "--heads", canonicalRemote], {
+    encoding: "utf8",
+    env: isolatedEnv
+  });
+  if (!mirroredHeads.includes(`refs/heads/${branch}`)) {
+    throw new Error(`Local semantic release mirror is missing branch ${branch}.`);
+  }
+  const result = await semanticRelease(
+    {
+      ...releaseConfig,
+      branches: [branch],
+      ci: false,
+      dryRun: true,
+      plugins: releaseConfig.plugins.slice(0, 2),
+      repositoryUrl: canonicalRemote
+    },
+    {
+      cwd: repository,
+      env: isolatedEnv,
+      stderr: process.stderr,
+      stdout: process.stdout
+    }
+  );
+
+  if (!result) {
+    console.log("No semantic release is currently required.");
+  }
+} finally {
+  if (processGitConfig) {
+    for (const [name, value] of Object.entries(processGitConfig)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+  rmSync(previewRoot, { recursive: true, force: true });
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,7 @@ jobs:
       - name: Test semantic release configuration
         run: npm run test:release
       - name: Preview semantic release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: npx semantic-release --dry-run --branches dev
+        run: node .github/scripts/preview_semantic_release.mjs
 
   release:
     if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ bash -n install.sh
 powershell -NoProfile -Command "[void][scriptblock]::Create((Get-Content -Raw ./install.ps1))"
 ```
 
-`npx semantic-release --dry-run --branches dev` previews the next version and release notes without creating a tag or GitHub Release.
+`node .github/scripts/preview_semantic_release.mjs` previews the next version and release notes against a temporary local bare remote. It uses only semantic-release's analysis and note-generation plugins, so it neither needs GitHub write permission nor can create a repository tag or GitHub Release.
 
 Maintainers: see [branch protection](docs/BRANCH_PROTECTION.md) for the required `dev` check, current GitHub Free limitation, closest enforceable `main` policy, and recovery procedure.
 


### PR DESCRIPTION
## Summary

- keep the `dev` semantic-release preview under read-only GitHub permissions
- invoke semantic-release against a temporary local bare mirror with only analysis and note-generation plugins
- strip inherited CI credentials and temporarily redirect GitHub Git transport locally while retaining canonical GitHub links in generated notes
- document the credential-free preview command

## Root cause

The merged `semantic-release --dry-run` command still ran a remote `git push --dry-run` authorization check. The read-only Actions token correctly returned 403 in run 29868000146.

## Verification

- simulated GitHub Actions environment: v1.1.0 notes generated with canonical GitHub links and `Skip v1.1.0 tag creation in dry-run mode`
- `npm run test:release` (3 tests)
- Node 24.14.0 syntax check
- prompt budget (`~14396 / 14400` tokens)
- `git diff --check`

Tracks #146
