### PR TITLE
ci(installer): validate native Windows behavior

### DIFF
--- a/.agents/test_install_zzzops.py
+++ b/.agents/test_install_zzzops.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_VALIDATION = ROOT / ".github" / "scripts" / "require_validation.py"
 
 
 def available_installers() -> dict[str, tuple[str, Path]]:
@@ -34,6 +35,10 @@ class NativeInstallerTests(unittest.TestCase):
         cls.installers = available_installers()
         if not cls.installers:
             raise unittest.SkipTest("PowerShell and Bash are unavailable")
+        expected = {name for name in os.environ.get("ZZZOPS_EXPECT_INSTALLERS", "").split(",") if name}
+        missing = expected - set(cls.installers)
+        if missing:
+            raise AssertionError("Required native installers are unavailable: " + ", ".join(sorted(missing)))
 
     def make_repo(self, directory: str) -> Path:
         target = Path(directory)
@@ -332,6 +337,41 @@ class NativeInstallerTests(unittest.TestCase):
                 self.assertIn("rolled back", result.stdout)
                 self.assertFalse((target / ".zzzops" / "rules" / "BACKENDS.md").exists())
                 self.assertFalse((target / ".zzzops" / "rules" / "BLOCKERS.md").exists())
+
+
+class ValidationAggregateTests(unittest.TestCase):
+    def run_required_validation(self, *results: str):
+        return subprocess.run(
+            [sys.executable, str(REQUIRED_VALIDATION), *results],
+            text=True, encoding="utf-8", capture_output=True, check=False,
+        )
+
+    def test_required_validation_accepts_only_complete_success(self):
+        success = self.run_required_validation("linux=success", "windows=success")
+        self.assertEqual(0, success.returncode, success.stderr + success.stdout)
+
+        for results in (
+            ("linux=success", "windows=failure"),
+            ("linux=failure", "windows=success"),
+            ("linux=success", "windows=cancelled"),
+            ("linux=success", "windows="),
+            (),
+        ):
+            with self.subTest(results=results):
+                failure = self.run_required_validation(*results)
+                self.assertNotEqual(0, failure.returncode, failure.stderr + failure.stdout)
+
+    def test_workflow_preserves_stable_check_and_requires_native_installers(self):
+        workflow = (ROOT / ".github" / "workflows" / "validate.yml").read_text(encoding="utf-8")
+        self.assertIn("validate-linux:", workflow)
+        self.assertIn("runs-on: ubuntu-latest", workflow)
+        self.assertIn("validate-windows:", workflow)
+        self.assertIn("runs-on: windows-latest", workflow)
+        self.assertEqual(2, workflow.count("ZZZOPS_EXPECT_INSTALLERS: PowerShell,Bash"))
+        self.assertIn("name: dev-required-tests", workflow)
+        self.assertIn("needs: [validate-linux, validate-windows]", workflow)
+        self.assertIn("linux=${{ needs.validate-linux.result }}", workflow)
+        self.assertIn("windows=${{ needs.validate-windows.result }}", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/require_validation.py
+++ b/.github/scripts/require_validation.py
@@ -1,0 +1,31 @@
+"""Fail a required-check aggregate unless every named validation leg succeeded."""
+
+from __future__ import annotations
+
+import sys
+
+
+def failed_results(arguments: list[str]) -> list[str]:
+    """Return named results that are absent, malformed, or not successful."""
+    failures = []
+    for argument in arguments:
+        name, separator, result = argument.partition("=")
+        if not separator or not name or result != "success":
+            failures.append(argument)
+    return failures
+
+
+def main(arguments: list[str]) -> int:
+    failures = failed_results(arguments)
+    if not arguments:
+        print("No validation results were supplied.", file=sys.stderr)
+        return 1
+    if failures:
+        print("Required validation did not succeed: " + ", ".join(failures), file=sys.stderr)
+        return 1
+    print("All required validation legs succeeded: " + ", ".join(arguments))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,9 +12,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: dev-required-tests
+  validate-linux:
+    name: Linux validation
     runs-on: ubuntu-latest
+    env:
+      ZZZOPS_EXPECT_INSTALLERS: PowerShell,Bash
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -42,3 +44,29 @@ jobs:
           python -m compileall -q .agents .github/scripts
           bash -n install.sh
           [void][scriptblock]::Create((Get-Content -Raw ./install.ps1))
+
+  validate-windows:
+    name: Windows installer validation
+    runs-on: windows-latest
+    env:
+      ZZZOPS_EXPECT_INSTALLERS: PowerShell,Bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Test native Windows installer behavior
+        run: python -m unittest discover -s .agents -p 'test_install_zzzops.py'
+
+  required:
+    name: dev-required-tests
+    if: ${{ always() }}
+    needs: [validate-linux, validate-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require every native validation leg
+        run: >-
+          python .github/scripts/require_validation.py
+          linux=${{ needs.validate-linux.result }}
+          windows=${{ needs.validate-windows.result }}

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,6 +1,6 @@
 # Branch protection
 
-ZzzOps currently uses a private repository on GitHub Free. GitHub returns `403` for both classic branch protection and repository rulesets until the repository becomes public or the owner upgrades to GitHub Pro. The CI workflow is already usable: every PR targeting `dev` runs the read-only required-check candidate `dev-required-tests`.
+ZzzOps currently uses a private repository on GitHub Free. GitHub returns `403` for both classic branch protection and repository rulesets until the repository becomes public or the owner upgrades to GitHub Pro. The CI workflow is already usable: every PR targeting `dev` runs Linux validation and native Windows installer validation behind the stable, read-only required-check candidate `dev-required-tests`. The aggregate fails unless both platform jobs succeed.
 
 ## Enable protection after Pro/public access
 


### PR DESCRIPTION
## Summary
- split PR validation into Linux and native Windows jobs
- preserve dev-required-tests as an always-running aggregate that fails unless both legs succeed
- require PowerShell and Git Bash explicitly and test aggregate failure semantics

## Verification
- py -3 .agents/test_install_zzzops.py (8 tests, both runtimes required)
- 88 core ZzzOps tests
- 4 migration tests
- acceptance coverage and prompt budget checks
- semantic-release tests, Python/script syntax, YAML parse, and git diff --check

Closes #160