### PR TITLE
fix(reservations): release all owned resources

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -1267,8 +1267,10 @@ class FakeReservationAdapter:
         self.next_id = 1
         self.lock = threading.Lock()
         self.delete_error = None
+        self.delete_error_node_ids = set()
         self.update_error = None
         self.create_error = None
+        self.list_error = None
 
     @property
     def label(self):
@@ -1289,6 +1291,15 @@ class FakeReservationAdapter:
         with self.lock:
             return dict(self.labels[name]) if name in self.labels else None
 
+    def list_resource_labels(self):
+        if self.list_error:
+            raise zzzops.ReservationProviderError(self.list_error)
+        with self.lock:
+            return [
+                dict(label) for name, label in self.labels.items()
+                if name.startswith("zzzops:resource:")
+            ]
+
     def create_label(self, name, description):
         if self.barrier and (self.barrier_prefix is None or name.startswith(self.barrier_prefix)):
             self.barrier.wait(timeout=2)
@@ -1303,7 +1314,7 @@ class FakeReservationAdapter:
 
     def delete_label(self, node_id):
         with self.lock:
-            if self.delete_error == "before":
+            if self.delete_error == "before" or node_id in self.delete_error_node_ids:
                 raise zzzops.ReservationProviderError("delete failed")
             match = next((name for name, label in self.labels.items() if label["node_id"] == node_id), None)
             if match:
@@ -1443,6 +1454,28 @@ class ReservationTests(unittest.TestCase):
         with self.assertRaisesRegex(zzzops.ReservationProviderError, "not available"):
             adapter.goal_revision(12, require_actionable=True)
 
+    def test_github_adapter_lists_only_complete_resource_labels_across_pages(self):
+        adapter = object.__new__(zzzops.GitHubReservationAdapter)
+        adapter.repository = "owner/repo"
+        resource = {
+            "name": zzzops.resource_label_name("branch:topic"), "node_id": "L1", "description": "metadata",
+        }
+        adapter._run = mock.Mock(return_value=SimpleNamespace(
+            returncode=0, stdout=json.dumps([[resource, {"name": "ordinary", "node_id": "L2"}], []]), stderr="",
+        ))
+        self.assertEqual([resource], adapter.list_resource_labels())
+        adapter._run.assert_called_once_with([
+            "api", "--paginate", "--slurp", "repos/owner/repo/labels?per_page=100",
+        ])
+
+        adapter._run.return_value = SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps([[{"name": zzzops.resource_label_name("branch:topic"), "description": "metadata"}]]),
+            stderr="",
+        )
+        with self.assertRaisesRegex(zzzops.ReservationProviderError, "incomplete resource"):
+            adapter.list_resource_labels()
+
     def test_reservation_ttl_uses_reviewed_claim_policy(self):
         project = {"policy": {"sections": [{
             "id": "autonomy_approval_parallelism", "settings": {"claim_ttl_hours": 4},
@@ -1525,6 +1558,138 @@ class ReservationTests(unittest.TestCase):
         self.assertTrue(released["released"])
         self.assertIsNone(adapter.get_label(zzzops.resource_label_name("generated:dist/a")))
         self.assertIsNotNone(adapter.get_label(zzzops.resource_label_name("generated:dist/b")))
+
+    def test_release_discovers_owned_resources_when_arguments_are_omitted(self):
+        adapter = FakeReservationAdapter()
+        resources = ["branch:topic", "generated:dist/a"]
+        acquired = zzzops.acquire_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", resources, 120, self.now,
+        )
+        self.assertTrue(acquired["acquired"])
+
+        released = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+
+        self.assertEqual({"released": True, "outcome": "released", "goal": 12}, released)
+        self.assertIsNone(adapter.label)
+        for resource in resources:
+            self.assertIsNone(adapter.get_label(zzzops.resource_label_name(resource)))
+
+    def test_release_preserves_foreign_and_replacement_resource_owners(self):
+        adapter = FakeReservationAdapter()
+        self.acquire(adapter)
+        cases = {
+            "branch:other-owner": ("owner/repo", 12, 4, "agent-b", "run-a"),
+            "branch:other-run": ("owner/repo", 12, 4, "agent-a", "run-b"),
+            "branch:other-goal": ("owner/repo", 13, 4, "agent-a", "run-a"),
+            "branch:other-repo": ("other/repo", 12, 4, "agent-a", "run-a"),
+            "branch:replacement": ("owner/repo", 12, 5, "agent-a", "run-a"),
+        }
+        for resource, (repository, goal, revision, owner, run_id) in cases.items():
+            adapter.create_label(
+                zzzops.resource_label_name(resource),
+                zzzops.reservation_description(
+                    repository, goal, revision, owner, run_id, int(self.now.timestamp()) + 120,
+                ),
+            )
+
+        released = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+
+        self.assertEqual("released", released["outcome"])
+        self.assertIsNone(adapter.label)
+        for resource in cases:
+            self.assertIsNotNone(adapter.get_label(zzzops.resource_label_name(resource)))
+
+    def test_release_fails_safely_on_malformed_or_unavailable_discovery(self):
+        adapter = FakeReservationAdapter()
+        self.acquire(adapter)
+        adapter.create_label(zzzops.resource_label_name("branch:ambiguous"), "malformed")
+        malformed = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+        self.assertEqual("failed", malformed["outcome"])
+        self.assertFalse(malformed["released"])
+        self.assertIsNotNone(adapter.label)
+
+        adapter.labels.pop(zzzops.resource_label_name("branch:ambiguous"))
+        adapter.list_error = "list failed"
+        unavailable = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+        self.assertEqual("failed", unavailable["outcome"])
+        self.assertIsNotNone(adapter.label)
+
+    def test_release_reports_partial_cleanup_and_preserves_goal_for_retry(self):
+        adapter = FakeReservationAdapter()
+        resources = ["branch:first", "branch:second"]
+        zzzops.acquire_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", resources, 120, self.now,
+        )
+        first = adapter.get_label(zzzops.resource_label_name("branch:first"))
+        adapter.delete_error_node_ids.add(first["node_id"])
+
+        released = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+
+        self.assertEqual("partial", released["outcome"])
+        self.assertEqual(1, released["released_resources"])
+        self.assertIsNotNone(adapter.label)
+        self.assertIsNotNone(adapter.get_label(zzzops.resource_label_name("branch:first")))
+        self.assertIsNone(adapter.get_label(zzzops.resource_label_name("branch:second")))
+
+        adapter.delete_error_node_ids.clear()
+        retried = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+        self.assertEqual("released", retried["outcome"])
+        self.assertIsNone(adapter.label)
+        self.assertIsNone(adapter.get_label(zzzops.resource_label_name("branch:first")))
+
+    def test_release_recovers_resources_after_goal_label_was_already_removed(self):
+        adapter = FakeReservationAdapter()
+        resource = "branch:orphaned"
+        zzzops.acquire_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [resource], 120, self.now,
+        )
+        adapter.label = None
+
+        released = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+
+        self.assertEqual("released", released["outcome"])
+        self.assertIsNone(adapter.get_label(zzzops.resource_label_name(resource)))
+
+    def test_release_reports_stale_goal_revision_as_failed_without_writing(self):
+        adapter = FakeReservationAdapter(revision=5)
+        adapter.create_label(
+            zzzops.resource_label_name("branch:owned"),
+            zzzops.reservation_description(
+                "owner/repo", 12, 4, "agent-a", "run-a", int(self.now.timestamp()) + 120,
+            ),
+        )
+        released = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+        self.assertEqual("failed", released["outcome"])
+        self.assertIsNotNone(adapter.get_label(zzzops.resource_label_name("branch:owned")))
+
+    def test_release_is_idempotent_when_goal_and_resources_are_already_absent(self):
+        adapter = FakeReservationAdapter()
+        released = zzzops.release_reservation_bundle(
+            adapter, "owner/repo", 12, 4, "agent-a", "run-a", [],
+        )
+        self.assertEqual({"released": True, "outcome": "already_released", "goal": 12}, released)
+
+    def test_release_cli_messages_distinguish_all_terminal_outcomes(self):
+        self.assertIn("all owned resources", zzzops.reservation_cli_message({"outcome": "released"}, 12))
+        self.assertIn("already released", zzzops.reservation_cli_message({"outcome": "already_released"}, 12))
+        self.assertIn("Partially released", zzzops.reservation_cli_message({"outcome": "partial"}, 12))
+        self.assertIn("no complete release", zzzops.reservation_cli_message({"outcome": "failed"}, 12))
 
     def test_release_cleans_advisory_labels_owned_under_an_earlier_strict_policy(self):
         adapter = FakeReservationAdapter()

--- a/.agents/zzzops/zzzops.py
+++ b/.agents/zzzops/zzzops.py
@@ -90,6 +90,7 @@ GITHUB_MANAGEMENT_PERMISSIONS = {"TRIAGE", "WRITE", "MAINTAIN", "ADMIN"}
 RESERVATION_COLOR = "5319E7"
 RESERVATION_ID = re.compile(r"^[A-Za-z0-9._-]+$")
 RESERVATION_EXPIRY_GRACE_SECONDS = 60
+RESOURCE_LABEL_PREFIX = "zzzops:resource:"
 EXECUTION_REPORT_SCHEMA_VERSION = 3
 LEGACY_EXECUTION_REPORT_SCHEMA_VERSION = 2
 EXECUTION_REPORT_TARGET = "david-rzepa/zzzops"
@@ -272,7 +273,7 @@ def exclusive_resources(resources: Any, policy: Any = None) -> list[str]:
 
 def resource_label_name(resource: str) -> str:
     normalized = normalize_resources([resource])[0]
-    return "zzzops:resource:" + hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:32]
+    return RESOURCE_LABEL_PREFIX + hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:32]
 
 
 def reservation_description(
@@ -382,6 +383,36 @@ class GitHubReservationAdapter:
         if not isinstance(label, dict) or not label.get("node_id"):
             raise ReservationProviderError("GitHub returned incomplete reservation metadata; no ownership assumed.")
         return label
+
+    def list_resource_labels(self) -> list[dict[str, Any]]:
+        result = self._run([
+            "api", "--paginate", "--slurp", f"repos/{self.repository}/labels?per_page=100",
+        ])
+        if result.returncode:
+            raise self._provider_error(result)
+        try:
+            pages = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise ReservationProviderError(
+                "GitHub returned invalid resource reservation metadata; no release was assumed."
+            ) from exc
+        if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+            raise ReservationProviderError(
+                "GitHub returned incomplete resource reservation metadata; no release was assumed."
+            )
+        labels = []
+        for label in (item for page in pages for item in page):
+            if not isinstance(label, dict):
+                raise ReservationProviderError(
+                    "GitHub returned incomplete resource reservation metadata; no release was assumed."
+                )
+            if str(label.get("name", "")).startswith(RESOURCE_LABEL_PREFIX):
+                if not label.get("node_id"):
+                    raise ReservationProviderError(
+                        "GitHub returned incomplete resource reservation metadata; no release was assumed."
+                    )
+                labels.append(label)
+        return labels
 
     def create_label(self, name: str, description: str) -> dict[str, Any] | None:
         result = self._run([
@@ -687,6 +718,31 @@ def _release_resource(
             raise ReservationProviderError("GitHub did not confirm resource release; it will expire safely.")
 
 
+def _owned_resource_labels(
+    adapter: Any, repository: str, goal: int, revision: int, owner: str, run_id: str,
+) -> list[dict[str, Any]]:
+    owned = []
+    for label in adapter.list_resource_labels():
+        metadata = parse_reservation_description(label.get("description"))
+        if metadata["repository_key"] != reservation_repository_key(repository):
+            continue
+        if (
+            metadata["goal"] == goal and metadata["owner"] == owner and metadata["run_id"] == run_id
+            and metadata["revision"] <= revision
+        ):
+            owned.append(label)
+    return owned
+
+
+def _delete_discovered_resource(adapter: Any, label: dict[str, Any]) -> None:
+    try:
+        adapter.delete_label(label["node_id"])
+    except ReservationProviderError:
+        confirmed = adapter.get_label(label["name"])
+        if confirmed is not None and confirmed.get("node_id") == label["node_id"]:
+            raise ReservationProviderError("GitHub did not confirm resource release; it will expire safely.")
+
+
 def acquire_reservation_bundle(
     adapter: Any, repository: str, goal: int, revision: int, owner: str, run_id: str,
     resources: list[str], ttl_seconds: int = 900, now: datetime | None = None, resource_policy: Any = None,
@@ -736,16 +792,67 @@ def release_reservation_bundle(
     adapter: Any, repository: str, goal: int, revision: int, owner: str, run_id: str, resources: list[str],
     resource_policy: Any = None,
 ) -> dict[str, Any]:
-    resources = normalize_resources(resources)
-    reserved_resources = exclusive_resources(resources, resource_policy)
-    _validate_reservation_goal(adapter, repository, goal, revision)
-    for resource in reversed(reserved_resources):
-        _release_resource(adapter, repository, resource, goal, revision, owner, run_id)
-    for resource in reversed(sorted(set(resources) - set(reserved_resources))):
-        _release_resource(
-            adapter, repository, resource, goal, revision, owner, run_id, ignore_not_owned=True,
-        )
-    return release_reservation(adapter, repository, goal, revision, owner, run_id, _validated=True)
+    exclusive_resources(resources, resource_policy)  # Validate retained CLI arguments and reviewed policy.
+    try:
+        _validate_reservation_goal(adapter, repository, goal, revision)
+    except ReservationProviderError as exc:
+        return {"released": False, "outcome": "failed", "goal": goal, "detail": str(exc)}
+    removed = 0
+    try:
+        owned = _owned_resource_labels(adapter, repository, goal, revision, owner, run_id)
+    except ReservationProviderError as exc:
+        return {"released": False, "outcome": "failed", "goal": goal, "detail": str(exc)}
+    for label in reversed(owned):
+        try:
+            _delete_discovered_resource(adapter, label)
+            removed += 1
+        except ReservationProviderError as exc:
+            outcome = "partial" if removed else "failed"
+            return {
+                "released": False, "outcome": outcome, "goal": goal,
+                "released_resources": removed, "detail": str(exc),
+            }
+    try:
+        remaining = _owned_resource_labels(adapter, repository, goal, revision, owner, run_id)
+    except ReservationProviderError as exc:
+        outcome = "partial" if removed else "failed"
+        return {
+            "released": False, "outcome": outcome, "goal": goal,
+            "released_resources": removed, "detail": str(exc),
+        }
+    if remaining:
+        return {
+            "released": False, "outcome": "partial", "goal": goal,
+            "released_resources": removed, "detail": "Owned resource reservations remain after release.",
+        }
+    try:
+        goal_result = release_reservation(adapter, repository, goal, revision, owner, run_id, _validated=True)
+    except ReservationProviderError as exc:
+        outcome = "partial" if removed else "failed"
+        return {
+            "released": False, "outcome": outcome, "goal": goal,
+            "released_resources": removed, "detail": str(exc),
+        }
+    if goal_result["outcome"] == "already_released" and not removed:
+        return goal_result
+    return {"released": True, "outcome": "released", "goal": goal}
+
+
+def reservation_cli_message(result: dict[str, Any], goal: int) -> str:
+    outcome = result.get("outcome")
+    if result.get("acquired") is True:
+        return f"Reserved goal #{goal}."
+    if outcome == "released":
+        return f"Released goal #{goal} and all owned resources."
+    if outcome == "already_released":
+        return f"Goal #{goal} and its owned resources were already released."
+    if outcome == "partial":
+        return f"Partially released goal #{goal}; owned reservations remain. Retry after refreshing."
+    if outcome == "failed":
+        return f"Could not safely release goal #{goal}; no complete release was assumed."
+    if outcome in {"contended", "resource_contended"}:
+        return f"Another agent is handling overlapping work for goal #{goal}. Refresh and choose different work."
+    return f"Goal #{goal} is not reserved by this run. Refresh before continuing."
 
 
 def project_claim_ttl_seconds(project: dict[str, Any]) -> int:
@@ -2861,14 +2968,8 @@ def main() -> int:
                 )
             if args.output_format == "json":
                 print(json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
-            elif result.get("acquired") is True:
-                print(f"Reserved goal #{args.goal}.")
-            elif result.get("released") is True:
-                print(f"Released goal #{args.goal}.")
-            elif result.get("outcome") in {"contended", "resource_contended"}:
-                print(f"Another agent is handling overlapping work for goal #{args.goal}. Refresh and choose different work.")
             else:
-                print(f"Goal #{args.goal} is not reserved by this run. Refresh before continuing.")
+                print(reservation_cli_message(result, args.goal))
             return 0 if result.get("acquired") is True or result.get("released") is True else 3
         elif args.command == "report":
             if args.report_command == "record":


### PR DESCRIPTION
## Summary
- discover every owned resource reservation during bundle release instead of relying on repeated CLI arguments
- preserve foreign and replacement ownership and fail safely on ambiguous metadata
- report released, already released, partial, and failed outcomes distinctly for JSON and human output

## Verification
- 24 focused reservation tests
- 97 full core ZzzOps tests
- Python compilation and git diff --check
- live GitHub pagination shape verified

Closes #170