### PR TITLE
docs(acceptance): clarify maintainer-only infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The CLI copies discoverable skills, mechanics, and blank templates—never itsel
 
 Discoverable skills stay in `.agents/skills/` and `.claude/skills/`. Other harness support is grouped under `.agents/zzzops/`, while shared project rules and state use the root `.zzzops/` folder.
 
+Target projects receive exactly six skills: `add-zzzops-goal`, `execute-zzzops`, `migrate-to-zzzops`, `review-zzzops-policy`, `send-zzzops-feedback`, and `suggest-zzzops-work`. The `run-zzzops-acceptance` skill, [human acceptance plan](docs/ACCEPTANCE_TEST_PLAN.md), and `.agents/manual_acceptance.py` harness are maintenance and release infrastructure for this base repository; installers exclude them because target users exercise the six shipped workflows rather than maintain ZzzOps itself.
+
 Open a new Codex task or Claude Code session in the target project so its ZzzOps skills are discovered, then start the policy review workflow.
 
 ### 3. Initialize the project

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -2,6 +2,8 @@
 
 Run this plan conversationally: ask for the next item, perform its human action, then explicitly say `check A-001`. A checked item becomes stale when one of its mapped paths changes.
 
+This plan, the `run-zzzops-acceptance` skill, and `.agents/manual_acceptance.py` belong only to the ZzzOps base repository's maintenance and release process. Neither native installer copies them into target projects; both install exactly `add-zzzops-goal`, `execute-zzzops`, `migrate-to-zzzops`, `review-zzzops-policy`, `send-zzzops-feedback`, and `suggest-zzzops-work`.
+
 Maintainers must map each shipped user-facing surface to a human item. For ZzzOps that means only the native installer CLI modes and installed skills. Internal control commands, backend mechanics, policy plumbing, reservations, prompt accounting, CI, documentation, and individual test cases are not separate human acceptance surfaces; inspect or automate them proportionately instead. Reusable acceptance-harness behavior needs focused regression coverage, but no human item unless the harness itself ships to users. Run `<python> .agents/manual_acceptance.py coverage` with one resolved Python 3 interpreter to report required unmapped user surfaces without changing the plan.
 
 <!-- zzzops-acceptance-plan

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -2,6 +2,8 @@
 
 ZzzOps uses the portable skill contract shared by Codex and Claude Code: the `name` and `description` frontmatter in each `SKILL.md`. Put likely user verbs, nouns, boundaries, and exact mode phrases in `description`; do not invent alias or keyword metadata. Codex's optional `agents/openai.yaml` supplies UI text, while Claude Code may support additional metadata, but neither replaces the common description.
 
+The table below is the exact six-skill target installation shared by `install.ps1` and `install.sh`. `run-zzzops-acceptance` is deliberately absent: that skill, `docs/ACCEPTANCE_TEST_PLAN.md`, and `.agents/manual_acceptance.py` are base-repository maintenance and release infrastructure used to validate the shipped workflows, not features copied into target projects.
+
 | Skill | Discovery terms | Default | Explicit modes |
 | --- | --- | --- | --- |
 | `add-zzzops-goal` | add, create, capture, record; goal, TODO, backlog item | Write one canonical goal | None |


### PR DESCRIPTION
## Summary
- name the exact six skills installed into target projects
- identify the acceptance skill, plan, and harness as base-repository maintenance/release infrastructure
- explain why installers deliberately exclude that workflow

## Verification
- both native installer skill lists match the documented six skills
- acceptance coverage reports no unmapped required surfaces
- prompt budget remains within the unchanged ceiling
- git diff --check

Closes #161