### PR TITLE
fix(cli): emit deterministic UTF-8 output

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -1,6 +1,7 @@
 import importlib.util
 import io
 import json
+import os
 import re
 import subprocess
 import sys
@@ -459,6 +460,27 @@ class ExecutionReportTests(unittest.TestCase):
                 from_stdin = zzzops.read_cli_text("-")
             self.assertEqual(text, from_file)
             self.assertEqual(from_file, from_stdin)
+
+    def test_feedback_prepare_emits_utf8_bytes_under_non_utf8_inherited_encoding(self):
+        prompt = self.repo / "prompt.txt"
+        feedback = "Please preserve this em dash — exactly."
+        prompt.write_bytes(b"\xef\xbb\xbf" + feedback.encode("utf-8"))
+        environment = dict(os.environ)
+        environment["PYTHONIOENCODING"] = "cp1252"
+        command = [
+            sys.executable, str(MODULE_PATH), "--repo", str(MODULE_PATH.parents[2]),
+            "feedback", "prepare", "--prompt-file", str(prompt),
+        ]
+
+        first = subprocess.run(command, capture_output=True, check=False, env=environment)
+        self.assertEqual(0, first.returncode, first.stderr.decode("utf-8", errors="replace"))
+        decoded = first.stdout.decode("utf-8")
+        prepared = json.loads(decoded)
+        self.assertIn(feedback, prepared["body"])
+
+        second = subprocess.run(command, capture_output=True, check=False, env=environment)
+        self.assertEqual(first.stdout, second.stdout)
+        self.assertEqual(prepared["digest"], json.loads(second.stdout.decode("utf-8"))["digest"])
 
     def test_record_is_constrained_local_and_policy_can_disable_it(self):
         result = self.record()

--- a/.agents/zzzops/zzzops.py
+++ b/.agents/zzzops/zzzops.py
@@ -1134,6 +1134,14 @@ def read_cli_text(value: str) -> str:
     except (OSError, UnicodeError) as exc:
         raise ValueError(f"Could not read feedback prompt: {type(exc).__name__}") from exc
 
+
+def configure_cli_stdout() -> None:
+    """Use readable, byte-stable UTF-8 whenever stdout owns an encoding layer."""
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding="utf-8", errors="strict")
+
+
 def project_digest(text: str) -> str:
     return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
 
@@ -2724,6 +2732,7 @@ def confirm_project(repo: Path, digest: str, reviewer: str, section_ids: list[st
 
 
 def main() -> int:
+    configure_cli_stdout()
     parser = argparse.ArgumentParser(description="ZzzOps project control CLI")
     parser.add_argument("--repo", type=Path, default=Path.cwd(), help="Project root (default: current directory)")
     commands = parser.add_subparsers(dest="command")


### PR DESCRIPTION
## Summary
- configure CLI stdout as strict UTF-8 before parsing or command output
- preserve readable Unicode while overriding inherited non-UTF-8 console encodings
- add a raw-byte feedback subprocess regression with BOM input and digest-stability checks

## Verification
- failing pre-fix reproduction emitted cp1252 byte 