### PR TITLE
docs(execution): make prioritization evidence-led

### DIFF
--- a/.agents/prompt_stats.py
+++ b/.agents/prompt_stats.py
@@ -59,7 +59,7 @@ WORKFLOW_PROMPTS = {
 
 WORKFLOW_SIGNALS = {
     "capture": ("duplicate/relationship checks", "consequential ambiguity", "active same-task execute intent"),
-    "execution": ("complete:true", "smallest falsifiable chunk", "human_after_checks", "continue while policy permits safe useful work"),
+    "execution": ("complete:true", "smallest falsifiable chunk", "difficulty is cost, not value", "human_after_checks", "continue while policy permits safe useful work"),
     "policy-review": ("only this workflow changes or confirms policy", "explicit approval of the current digest", "execution-report recording"),
     "migration": ("explicit completeness review", "preserve every source location", "apply only after explicit approval"),
     "suggestion": ("no-write default", "zzzops-refill", "never copy source labels"),

--- a/.agents/skills/execute-zzzops/references/EXECUTE.md
+++ b/.agents/skills/execute-zzzops/references/EXECUTE.md
@@ -8,7 +8,7 @@
    Specially tagged `zzzops-feedback` goals are absent unless the user approved them for this execution session. One session approval includes the whole feedback queue; never request approval per issue, and retain `--include-feedback` on every checkpoint refresh in that session.
 2. Route `new` goals through `CREATE.md` according to PROJECT triage/continuation policy.
 3. Use the portfolio's PROJECT-derived `actionable` field. The installed default waits for every dependency to be `done` before writable implementation; a reviewed PROJECT override such as `stack_from_reviewed_checkpoint` may make a child actionable earlier. Read-only investigation may prepare waiting work when policy permits, but never claims, edits, branches, or marks it started. Recheck blocked work only on its trigger.
-4. Rank by evidenced charter/KPI movement and unlock value, then apply PROJECT priority, easy-win, tie-break, and resume policy.
+4. Obey authority and explicit PROJECT priority first. Within the same effective priority, prefer evidenced charter/KPI value, safety/risk reduction, and unlocks: choose high-value, risk-reducing or unlocking work over low-value easy or fast work. Then prefer confidence, faster observable feedback, and lower difficulty; difficulty is cost, not value and never a reason to maximize item count. Unmeasured KPIs may support qualitative rationale, but never invent a baseline, score, or precision. On an exact tie use PROJECT resume policy, then the lowest goal key.
 
 ## Execute
 

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -1708,6 +1708,21 @@ class WorkflowContractTests(unittest.TestCase):
         for phrase in ("zzzops-feedback", "current execution session", "Never ask per issue", "--include-feedback"):
             self.assertIn(phrase, execute)
 
+    def test_execute_prioritization_contract_handles_adversarial_cases(self):
+        execute = (
+            Path(__file__).parent / "skills" / "execute-zzzops" / "references" / "EXECUTE.md"
+        ).read_text(encoding="utf-8").lower()
+        scenarios = {
+            "explicit priority outranks an attractive lower-priority goal": "authority and explicit project priority first",
+            "hard high-value work outranks easy low-value volume": "difficulty is cost, not value",
+            "risk and unlocks outrank merely fast feedback": "risk-reducing or unlocking work over low-value easy or fast work",
+            "unmeasured KPIs stay qualitative": "never invent a baseline, score, or precision",
+            "an exact tie has a stable fallback": "resume policy, then the lowest goal key",
+        }
+        for scenario, expected in scenarios.items():
+            with self.subTest(scenario=scenario):
+                self.assertIn(expected, execute)
+
     def test_refill_and_feedback_provenance_labels_stay_distinct(self):
         skills = Path(__file__).parent / "skills"
         refill = (skills / "suggest-zzzops-work" / "SKILL.md").read_text(encoding="utf-8").lower()


### PR DESCRIPTION
## Summary
- order selection by authority and explicit priority before qualitative leverage
- prefer evidenced value, risk reduction, and unlocks before confidence, feedback speed, and difficulty
- keep unmeasured KPIs qualitative and make exact ties deterministic

## Verification
- five adversarial prioritization prompt-contract cases
- 14/14 routed workflow checks with zero retries/tool calls
- prompt budget 54,606 bytes / ~13,660 tokens under the unchanged ceiling
- 89 core tests and 5 prompt-harness tests
- Python compilation and git diff --check

Closes #162