### PR TITLE
ci(release): gate publication on product validation

### DIFF
--- a/.agents/test_release_validation.py
+++ b/.agents/test_release_validation.py
@@ -1,0 +1,43 @@
+"""Regression checks for the shared release-validation contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER_PATH = ROOT / ".github" / "scripts" / "run_product_validation.py"
+
+
+def load_runner():
+    spec = importlib.util.spec_from_file_location("run_product_validation", RUNNER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseValidationTests(unittest.TestCase):
+    def test_linux_failure_stops_the_shared_validation_leg(self):
+        runner = load_runner()
+        failure = subprocess.CalledProcessError(1, ["failed-check"])
+        with mock.patch.object(runner, "run", side_effect=[None, failure]) as run:
+            with self.assertRaises(subprocess.CalledProcessError):
+                runner.linux_validation()
+        self.assertEqual(2, run.call_count)
+
+    def test_release_publish_waits_for_both_shared_validation_jobs(self):
+        workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        self.assertIn("validate-linux:", workflow)
+        self.assertIn("validate-windows:", workflow)
+        self.assertIn("needs: [validate-linux, validate-windows]", workflow)
+        self.assertIn("python .github/scripts/run_product_validation.py --platform linux", workflow)
+        self.assertIn("python .github/scripts/run_product_validation.py --platform windows", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/run_product_validation.py
+++ b/.github/scripts/run_product_validation.py
@@ -1,0 +1,42 @@
+"""Run one named, read-only ZzzOps product-validation leg."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(*command: str) -> None:
+    subprocess.run(command, cwd=ROOT, check=True)
+
+
+def linux_validation() -> None:
+    run(sys.executable, "-m", "unittest", "discover", "-s", ".agents", "-p", "test_*.py")
+    run(sys.executable, "-m", "unittest", "discover", "-s", ".agents/skills/migrate-to-zzzops/scripts", "-p", "test_*.py")
+    run(sys.executable, ".agents/manual_acceptance.py", "coverage")
+    run("npm", "run", "test:release")
+    run(sys.executable, ".agents/prompt_stats.py", "--check")
+    run(sys.executable, "-m", "compileall", "-q", ".agents", ".github/scripts")
+    run("bash", "-n", "install.sh")
+    run("pwsh", "-NoProfile", "-Command", "[void][scriptblock]::Create((Get-Content -Raw ./install.ps1))")
+
+
+def windows_validation() -> None:
+    run(sys.executable, "-m", "unittest", "discover", "-s", ".agents", "-p", "test_install_zzzops.py")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--platform", choices=("linux", "windows"), required=True)
+    args = parser.parse_args()
+    {"linux": linux_validation, "windows": windows_validation}[args.platform]()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,39 @@ jobs:
       - name: Preview semantic release
         run: node .github/scripts/preview_semantic_release.mjs
 
+  validate-linux:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.14.0'
+          cache: npm
+      - name: Install release tooling
+        run: npm ci
+      - name: Run the shared Linux product-validation leg
+        run: python .github/scripts/run_product_validation.py --platform linux
+
+  validate-windows:
+    if: github.ref == 'refs/heads/main'
+    runs-on: windows-latest
+    env:
+      ZZZOPS_EXPECT_INSTALLERS: PowerShell,Bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run the shared native Windows validation leg
+        run: python .github/scripts/run_product_validation.py --platform windows
+
   release:
     if: github.ref == 'refs/heads/main'
+    needs: [validate-linux, validate-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,21 +29,7 @@ jobs:
       - name: Install release tooling
         run: npm ci
       - name: Test ZzzOps core and repository contracts
-        run: python -m unittest discover -s .agents -p 'test_*.py'
-      - name: Test TODO migration inventory
-        run: python -m unittest discover -s .agents/skills/migrate-to-zzzops/scripts -p 'test_*.py'
-      - name: Test manual acceptance plan coverage
-        run: python .agents/manual_acceptance.py coverage
-      - name: Test semantic releases
-        run: npm run test:release
-      - name: Verify prompt budget
-        run: python .agents/prompt_stats.py --check
-      - name: Check script syntax
-        shell: pwsh
-        run: |
-          python -m compileall -q .agents .github/scripts
-          bash -n install.sh
-          [void][scriptblock]::Create((Get-Content -Raw ./install.ps1))
+        run: python .github/scripts/run_product_validation.py --platform linux
 
   validate-windows:
     name: Windows installer validation
@@ -56,7 +42,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Test native Windows installer behavior
-        run: python -m unittest discover -s .agents -p 'test_install_zzzops.py'
+        run: python .github/scripts/run_product_validation.py --platform windows
 
   required:
     name: dev-required-tests


### PR DESCRIPTION
Tracks #167\n\nShares the Linux and native Windows validation command contract between PR and main release workflows. Publishing now depends on both read-only validation legs.