### PR TITLE
ci(install): validate macOS installer

### DIFF
--- a/.agents/test_install_zzzops.py
+++ b/.agents/test_install_zzzops.py
@@ -348,7 +348,7 @@ class ValidationAggregateTests(unittest.TestCase):
         )
 
     def test_required_validation_accepts_only_complete_success(self):
-        success = self.run_required_validation("linux=success", "windows=success")
+        success = self.run_required_validation("linux=success", "windows=success", "macos=success")
         self.assertEqual(0, success.returncode, success.stderr + success.stdout)
 
         for results in (
@@ -356,6 +356,7 @@ class ValidationAggregateTests(unittest.TestCase):
             ("linux=failure", "windows=success"),
             ("linux=success", "windows=cancelled"),
             ("linux=success", "windows="),
+            ("linux=success", "windows=success", "macos=failure"),
             (),
         ):
             with self.subTest(results=results):
@@ -369,10 +370,14 @@ class ValidationAggregateTests(unittest.TestCase):
         self.assertIn("validate-windows:", workflow)
         self.assertIn("runs-on: windows-latest", workflow)
         self.assertEqual(2, workflow.count("ZZZOPS_EXPECT_INSTALLERS: PowerShell,Bash"))
+        self.assertIn("validate-macos:", workflow)
+        self.assertIn("runs-on: macos-latest", workflow)
+        self.assertIn("ZZZOPS_EXPECT_INSTALLERS: Bash", workflow)
         self.assertIn("name: dev-required-tests", workflow)
-        self.assertIn("needs: [validate-linux, validate-windows]", workflow)
+        self.assertIn("needs: [validate-linux, validate-windows, validate-macos]", workflow)
         self.assertIn("linux=${{ needs.validate-linux.result }}", workflow)
         self.assertIn("windows=${{ needs.validate-windows.result }}", workflow)
+        self.assertIn("macos=${{ needs.validate-macos.result }}", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_product_validation.py
+++ b/.github/scripts/run_product_validation.py
@@ -30,11 +30,15 @@ def windows_validation() -> None:
     run(sys.executable, "-m", "unittest", "discover", "-s", ".agents", "-p", "test_install_zzzops.py")
 
 
+def macos_validation() -> None:
+    run(sys.executable, "-m", "unittest", "discover", "-s", ".agents", "-p", "test_install_zzzops.py")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--platform", choices=("linux", "windows"), required=True)
+    parser.add_argument("--platform", choices=("linux", "windows", "macos"), required=True)
     args = parser.parse_args()
-    {"linux": linux_validation, "windows": windows_validation}[args.platform]()
+    {"linux": linux_validation, "windows": windows_validation, "macos": macos_validation}[args.platform]()
     return 0
 
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,10 +44,23 @@ jobs:
       - name: Test native Windows installer behavior
         run: python .github/scripts/run_product_validation.py --platform windows
 
+  validate-macos:
+    name: macOS installer validation
+    runs-on: macos-latest
+    env:
+      ZZZOPS_EXPECT_INSTALLERS: Bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Test native macOS installer behavior
+        run: python .github/scripts/run_product_validation.py --platform macos
+
   required:
     name: dev-required-tests
     if: ${{ always() }}
-    needs: [validate-linux, validate-windows]
+    needs: [validate-linux, validate-windows, validate-macos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,3 +69,4 @@ jobs:
           python .github/scripts/require_validation.py
           linux=${{ needs.validate-linux.result }}
           windows=${{ needs.validate-windows.result }}
+          macos=${{ needs.validate-macos.result }}

--- a/install.sh
+++ b/install.sh
@@ -212,7 +212,7 @@ build_plan() {
         for ((i=0; i<${#PLAN_RELATIVE[@]}; i++)); do
             printf '%s|%s|%s|%s\n' "${PLAN_RELATIVE[$i]}" "${PLAN_ACTION[$i]}" "${PLAN_SOURCE_HASH[$i]}" "${PLAN_EXPECTED[$i]}"
         done
-        printf 'manifest|%s|%s|%s|%s|%s\nignored|%s\nwarning|%s\n' "$PLAN_MANIFEST_EXPECTED" "$MANIFEST_REVISION" "$MANIFEST_VERSION" "$SOURCE_REVISION" "$SOURCE_VERSION" "${IGNORED[*]}" "$IGNORE_WARNING"
+        printf 'manifest|%s|%s|%s|%s|%s\nignored|%s\nwarning|%s\n' "$PLAN_MANIFEST_EXPECTED" "$MANIFEST_REVISION" "$MANIFEST_VERSION" "$SOURCE_REVISION" "$SOURCE_VERSION" "${IGNORED[*]:-}" "$IGNORE_WARNING"
     )
 }
 
@@ -240,7 +240,8 @@ show_preview() {
     elif [[ $new_count -gt 0 || $updated_count -gt 0 ]]; then printf 'Planned changes: %d new, %d updated.\n' "$new_count" "$updated_count"
     elif [[ ${#PLAN_ERRORS[@]} -eq 0 ]]; then printf 'Planned changes: ZzzOps is already up to date.\n'; fi
     if [[ ${#IGNORED[@]} -gt 0 ]]; then
-        for action in "${IGNORED[@]}"; do
+        for action in "${IGNORED[@]:-}"; do
+            [[ -n "$action" ]] || continue
             [[ -n "$names" ]] && names+=' and '
             names+="$action/"
         done
@@ -248,7 +249,9 @@ show_preview() {
         printf 'Remove those ignore rules before committing so collaborators receive the installed workflows.\n'
     fi
     [[ -n "$IGNORE_WARNING" ]] && printf 'Warning: %s\n' "$IGNORE_WARNING"
-    for error in "${PLAN_ERRORS[@]}"; do printf 'Cannot install yet: %s\n' "$error"; done
+    for error in "${PLAN_ERRORS[@]:-}"; do
+        [[ -n "$error" ]] && printf 'Cannot install yet: %s\n' "$error"
+    done
 }
 
 WRITTEN_RELATIVE=()

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,9 @@ read_manifest() {
         elif [[ "$kind" == version && "$hash" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$ && -z "$relative" && -z "$MANIFEST_VERSION" ]]; then
             MANIFEST_VERSION=$hash
         elif [[ "$kind" == file && "$hash" =~ ^[0-9a-f]{40,64}$ && -n "$relative" ]]; then
-            for existing in "${MANIFEST_RELATIVE[@]}"; do [[ "$existing" == "$relative" ]] && MANIFEST_VALID=0; done
+            for existing in "${MANIFEST_RELATIVE[@]:-}"; do
+                [[ -n "$existing" && "$existing" == "$relative" ]] && MANIFEST_VALID=0
+            done
             MANIFEST_HASH+=("$hash"); MANIFEST_RELATIVE+=("$relative")
         else MANIFEST_VALID=0
         fi
@@ -101,7 +103,8 @@ read_manifest() {
 
 manifest_hash_for() {
     local wanted=$1 i
-    for ((i=0; i<${#MANIFEST_RELATIVE[@]}; i++)); do
+    for ((i=0; ; i++)); do
+        [[ -n "${MANIFEST_RELATIVE[$i]:-}" ]] || return
         [[ "${MANIFEST_RELATIVE[$i]}" == "$wanted" ]] && { printf '%s' "${MANIFEST_HASH[$i]}"; return; }
     done
 }

--- a/install.sh
+++ b/install.sh
@@ -238,8 +238,8 @@ show_preview() {
         subjects=$(git -C "$SOURCE_ROOT" log --no-merges --format='- %s' --max-count=8 "$MANIFEST_REVISION..$SOURCE_REVISION" 2>/dev/null) || subjects=''
         [[ -n "$subjects" ]] && printf '%s\n' "$subjects" || printf '%s\n' '- revision history is unavailable; inspect the managed-file list above'
     elif [[ $new_count -gt 0 || $updated_count -gt 0 ]]; then printf 'Planned changes: %d new, %d updated.\n' "$new_count" "$updated_count"
-    elif [[ ${#PLAN_ERRORS[@]} -eq 0 ]]; then printf 'Planned changes: ZzzOps is already up to date.\n'; fi
-    if [[ ${#IGNORED[@]} -gt 0 ]]; then
+    elif [[ -z "${PLAN_ERRORS[*]:-}" ]]; then printf 'Planned changes: ZzzOps is already up to date.\n'; fi
+    if [[ -n "${IGNORED[*]:-}" ]]; then
         for action in "${IGNORED[@]:-}"; do
             [[ -n "$action" ]] || continue
             [[ -n "$names" ]] && names+=' and '
@@ -314,7 +314,7 @@ apply_plan() {
 
 build_plan
 show_preview
-[[ ${#PLAN_ERRORS[@]} -eq 0 ]] || exit 2
+[[ -z "${PLAN_ERRORS[*]:-}" ]] || exit 2
 if [[ $DRY_RUN -eq 1 ]]; then printf 'No files were changed.\n'; exit 0; fi
 pending_changes=0
 for action in "${PLAN_ACTION[@]}"; do
@@ -332,7 +332,7 @@ answer=${answer%$'\r'}
 case "$answer" in y|Y|yes|YES|Yes) ;; *) printf 'Installation cancelled; no files were changed.\n'; exit 0 ;; esac
 preview_signature=$PLAN_SIGNATURE
 build_plan
-if [[ ${#PLAN_ERRORS[@]} -gt 0 || "$PLAN_SIGNATURE" != "$preview_signature" ]]; then
+if [[ -n "${PLAN_ERRORS[*]:-}" || "$PLAN_SIGNATURE" != "$preview_signature" ]]; then
     printf 'The target changed after the preview. Run the installer again; no files were changed.\n'
     exit 2
 fi


### PR DESCRIPTION
## Summary
- add a native macOS Bash installer-validation leg
- make the stable dev aggregate require Linux, Windows, and macOS results
- cover the macOS aggregation contract and validation entry point

## Verification
- py -3 .agents/test_install_zzzops.py`n- py -3 .github/scripts/run_product_validation.py --platform macos`n- py -3 -m unittest discover -s .agents -p test_*.py`n- py -3 -m compileall -q .agents .github/scripts`n
Tracks #165