### PR TITLE
refactor: extract policy state module

### DIFF
--- a/.agents/test_install_zzzops.py
+++ b/.agents/test_install_zzzops.py
@@ -125,6 +125,7 @@ class NativeInstallerTests(unittest.TestCase):
                 self.assertTrue((target / ".zzzops" / "rules" / "INITIALIZATION.md").is_file())
                 self.assertTrue((target / ".agents" / "zzzops" / "templates" / "project-goals" / "INIT_PLAN.json").is_file())
                 self.assertTrue((target / ".agents" / "zzzops" / ".gitignore").is_file())
+                self.assertTrue((target / ".agents" / "zzzops" / "policy.py").is_file())
                 self.assertEqual((ROOT / "LICENSE").read_bytes(), (target / ".agents" / "zzzops" / "LICENSE").read_bytes())
                 self.assertTrue((target / ".agents" / "zzzops" / "INSTALL_MANIFEST").is_file())
                 manifest_text = (target / ".agents" / "zzzops" / "INSTALL_MANIFEST").read_text(encoding="utf-8")

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -22,6 +22,17 @@ assert SPEC.loader
 SPEC.loader.exec_module(zzzops)
 
 
+class PolicyModuleTests(unittest.TestCase):
+    def test_entry_point_reexports_policy_state_contract(self):
+        policy = zzzops._policy
+        for name in (
+            "project_digest", "read_project_state", "validate_project_state",
+            "validate_policy", "render_project", "render_project_audit",
+            "normalize_resource_policy",
+        ):
+            self.assertIs(getattr(zzzops, name), getattr(policy, name))
+
+
 class InitializationTests(unittest.TestCase):
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory()

--- a/.agents/zzzops/policy.py
+++ b/.agents/zzzops/policy.py
@@ -1,0 +1,437 @@
+"""Canonical project-policy state, validation, and rendering helpers.
+
+This module deliberately has no dependency on the ZzzOps CLI or provider layer so
+project-policy behavior can be exercised and reused without importing the control
+entry point.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_SCHEMA_VERSION = 1
+POLICY_SCHEMA_VERSION = 1
+PROJECT_POLICY_RELATIVE = ".zzzops/POLICY.json"
+PROJECT_AUDIT_RELATIVE = ".zzzops/PROJECT_AUDIT.md"
+BACKENDS = {"github_issues"}
+POLICY_SECTION_IDS = (
+    "backend",
+    "git_review_release",
+    "execution_continuation",
+    "verification_testing",
+    "code_quality",
+    "dependencies_tooling",
+    "security_privacy_compliance",
+    "documentation_style",
+    "deployment_resources",
+    "autonomy_approval_parallelism",
+)
+
+
+def nonempty(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip()) and value.strip().casefold() != "unknown"
+
+
+def text_present(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def nonempty_list(value: Any) -> bool:
+    return isinstance(value, list) and bool(value) and all(nonempty(item) for item in value)
+
+
+def normalize_resources(resources: Any) -> list[str]:
+    if not isinstance(resources, list):
+        raise ValueError("resources must be a list")
+    normalized = []
+    for resource in resources:
+        if not isinstance(resource, str):
+            raise ValueError("resource entries must be text")
+        value = resource.strip().replace("\\", "/")
+        prefix, separator, target = value.partition(":")
+        prefix = prefix.casefold()
+        if prefix not in {"path", "branch", "integration", "generated", "external"} or not separator or not target:
+            raise ValueError("resources must use path, branch, integration, generated, or external prefixes")
+        if len(value) > 200 or any(ord(character) < 32 for character in value):
+            raise ValueError("resource entries must be at most 200 printable characters")
+        normalized.append(value.casefold())
+    if len(normalized) != len(set(normalized)):
+        raise ValueError("resource entries must be unique")
+    return sorted(normalized)
+
+
+def normalize_resource_policy(policy: Any = None) -> dict[str, Any]:
+    if policy is None:
+        policy = {}
+    if not isinstance(policy, dict):
+        raise ValueError("resource_reservations must be an object")
+    unknown = sorted(set(policy) - {"mode", "exclusive_prefixes", "exclusive_resources"})
+    if unknown:
+        raise ValueError("resource_reservations has unknown fields: " + ", ".join(unknown))
+    mode = policy.get("mode", "conflict_tolerant")
+    if mode not in {"conflict_tolerant", "strict"}:
+        raise ValueError("resource_reservations.mode must be conflict_tolerant or strict")
+    prefixes = policy.get("exclusive_prefixes", ["generated", "external"])
+    supported = {"path", "integration", "generated", "external"}
+    if (
+        not isinstance(prefixes, list)
+        or any(not isinstance(prefix, str) or prefix not in supported for prefix in prefixes)
+        or len(prefixes) != len(set(prefixes))
+    ):
+        raise ValueError("resource_reservations.exclusive_prefixes must contain unique supported prefixes")
+    resources = normalize_resources(policy.get("exclusive_resources", []))
+    return {"mode": mode, "exclusive_prefixes": sorted(prefixes), "exclusive_resources": resources}
+
+
+def exclusive_resources(resources: Any, policy: Any = None) -> list[str]:
+    resources = normalize_resources(resources)
+    policy = normalize_resource_policy(policy)
+    if policy["mode"] == "strict":
+        return resources
+    exact = set(policy["exclusive_resources"])
+    prefixes = set(policy["exclusive_prefixes"])
+    return [
+        resource for resource in resources
+        if resource.startswith("branch:") or resource in exact or resource.partition(":")[0] in prefixes
+    ]
+
+
+def project_digest(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def project_path(repo: Path) -> Path:
+    return repo / ".zzzops" / "PROJECT.md"
+
+
+def project_audit_path(repo: Path) -> Path:
+    return repo / PROJECT_AUDIT_RELATIVE
+
+
+def project_policy_path(repo: Path) -> Path:
+    return repo / PROJECT_POLICY_RELATIVE
+
+
+def read_project(repo: Path) -> tuple[Path, str]:
+    path = project_path(repo)
+    try:
+        return path, path.read_text(encoding="utf-8-sig")
+    except FileNotFoundError:
+        return path, ""
+    except (OSError, UnicodeError) as exc:
+        raise ValueError(f"Cannot read project charter from {path}: {exc}") from exc
+
+
+def parse_policy_state(text: str) -> dict[str, Any]:
+    try:
+        state = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid canonical policy JSON: {exc}") from exc
+    if not isinstance(state, dict):
+        raise ValueError("Canonical policy state must be a JSON object")
+    return state
+
+
+def read_policy_text(repo: Path) -> tuple[Path, str]:
+    path = project_policy_path(repo)
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+    except FileNotFoundError:
+        return path, ""
+    except (OSError, UnicodeError) as exc:
+        raise ValueError(f"Cannot read canonical policy from {path}: {exc}") from exc
+    return path, text
+
+
+def read_project_state(repo: Path) -> tuple[Path, str, dict[str, Any] | None]:
+    path, text = read_policy_text(repo)
+    if not text:
+        return path, text, None
+    return path, text, parse_policy_state(text)
+
+
+def initialization_base_digest(repo: Path) -> str:
+    _project_path, project_text = read_project(repo)
+    _policy_path, policy_text = read_policy_text(repo)
+    return project_digest(project_text + "\0" + policy_text)
+
+
+def policy_review_digest(state: dict[str, Any]) -> str:
+    reviewable = {key: value for key, value in state.items() if key != "approval"}
+    payload = json.dumps(reviewable, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return project_digest(payload)
+
+
+def validate_project_state(state: Any) -> list[str]:
+    if not isinstance(state, dict):
+        return ["project state must be an object"]
+    allowed = {"schema_version", "initialized", "backend", "repository", "revision", "charter", "policy", "history", "bindings", "approval"}
+    errors = []
+    unknown = sorted(set(state) - allowed)
+    if unknown:
+        errors.append("unknown fields: " + ", ".join(unknown))
+    if state.get("schema_version") != PROJECT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {PROJECT_SCHEMA_VERSION}")
+    if not isinstance(state.get("initialized"), bool):
+        errors.append("initialized must be boolean")
+    if not isinstance(state.get("revision"), int) or isinstance(state.get("revision"), bool) or state.get("revision", -1) < 0:
+        errors.append("revision must be a non-negative integer")
+    policy_errors = validate_policy(state.get("policy"), require_pending=False) if state.get("policy") is not None else []
+    errors.extend(f"policy.{error}" for error in policy_errors)
+    pending_policy = policy_blockers(state.get("policy")) if not policy_errors else []
+    if state.get("initialized") is True:
+        if state.get("backend") not in BACKENDS:
+            errors.append("initialized backend must be github_issues")
+        repository = state.get("repository")
+        if not isinstance(repository, dict) or not nonempty(repository.get("identity")):
+            errors.append("initialized repository.identity is required")
+        if pending_policy:
+            errors.append("initialized state cannot have unreviewed required policy: " + ", ".join(pending_policy))
+        approval = state.get("approval")
+        if not isinstance(approval, dict) or not text_present(approval.get("reviewer")) or not text_present(approval.get("date")):
+            errors.append("initialized state requires explicit approval metadata")
+        elif approval.get("digest") != policy_review_digest(state):
+            errors.append("policy approval digest changed")
+    elif state.get("backend") is not None or state.get("repository") is not None or state.get("policy") is not None:
+        if state.get("backend") not in BACKENDS or not isinstance(state.get("repository"), dict) or not state.get("policy"):
+            errors.append("uninitialized state may select a backend only as a complete pending policy draft")
+    bindings = state.get("bindings")
+    if not isinstance(bindings, dict):
+        errors.append("bindings must be an object")
+    else:
+        for name, expected_path in (("project", ".zzzops/PROJECT.md"), ("audit", PROJECT_AUDIT_RELATIVE)):
+            binding = bindings.get(name)
+            if not isinstance(binding, dict) or binding.get("path") != expected_path or not text_present(binding.get("digest")):
+                errors.append(f"bindings.{name} must contain the canonical path and digest")
+    history = state.get("history")
+    if not isinstance(history, list) or not history:
+        errors.append("history must be a non-empty list")
+    else:
+        for index, entry in enumerate(history):
+            if not isinstance(entry, dict) or any(not text_present(entry.get(key)) for key in ("date", "actor", "change", "reason")):
+                errors.append(f"history[{index}] requires date, actor, change, and reason")
+    return errors
+
+
+def validate_project_artifacts(repo: Path, state: dict[str, Any] | None) -> list[str]:
+    if not isinstance(state, dict):
+        return []
+    bindings = state.get("bindings")
+    if not isinstance(bindings, dict):
+        return []
+    errors = []
+    for name, path in (("project", project_path(repo)), ("audit", project_audit_path(repo))):
+        binding = bindings.get(name)
+        if not isinstance(binding, dict) or not text_present(binding.get("digest")):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8-sig")
+        except (OSError, UnicodeError):
+            errors.append(f"{name} policy artifact is unavailable")
+            continue
+        if project_digest(text) != binding["digest"]:
+            errors.append(f"{name} policy artifact digest changed")
+    return errors
+
+
+def validate_policy(policy: Any, require_pending: bool) -> list[str]:
+    if not isinstance(policy, dict):
+        return ["must be an object"]
+    errors = []
+    if policy.get("schema_version") != POLICY_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {POLICY_SCHEMA_VERSION}")
+    sections = policy.get("sections")
+    if not isinstance(sections, list):
+        return errors + ["sections must be a list"]
+    evidence_ids = set()
+    if not require_pending:
+        evidence = policy.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            errors.append("evidence must be a non-empty list")
+        else:
+            for index, item in enumerate(evidence):
+                if not isinstance(item, dict) or not text_present(item.get("id")) or not text_present(item.get("source")) or not text_present(item.get("finding")):
+                    errors.append(f"evidence[{index}] requires id, source, and finding")
+                elif item["id"] in evidence_ids:
+                    errors.append(f"evidence[{index}].id must be unique")
+                else:
+                    evidence_ids.add(item["id"])
+    seen = set()
+    for index, section in enumerate(sections):
+        prefix = f"sections[{index}]"
+        if not isinstance(section, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        section_id = section.get("id")
+        if section_id not in POLICY_SECTION_IDS or section_id in seen:
+            errors.append(f"{prefix}.id must be unique and from the current taxonomy")
+        else:
+            seen.add(section_id)
+        for field in ("title", "decision", "rationale", "confidence", "default_origin", "default_disposition"):
+            if not text_present(section.get(field)):
+                errors.append(f"{prefix}.{field} is required")
+        if section.get("confidence") not in {"low", "medium", "high"}:
+            errors.append(f"{prefix}.confidence must be low, medium, or high")
+        if section.get("default_disposition") not in {"accepted", "changed", "rejected", "unknown"}:
+            errors.append(f"{prefix}.default_disposition must be accepted, changed, rejected, or unknown")
+        if not isinstance(section.get("required"), bool) or not isinstance(section.get("applicable"), bool):
+            errors.append(f"{prefix}.required and applicable must be booleans")
+        for field in ("source_ids", "exceptions", "unresolved"):
+            if not isinstance(section.get(field), list):
+                errors.append(f"{prefix}.{field} must be a list")
+        if not require_pending and isinstance(section.get("source_ids"), list):
+            missing_sources = sorted(set(section["source_ids"]) - evidence_ids)
+            if missing_sources:
+                errors.append(f"{prefix}.source_ids missing citations: {', '.join(missing_sources)}")
+        if not isinstance(section.get("settings"), dict):
+            errors.append(f"{prefix}.settings must be an object")
+        elif section_id == "autonomy_approval_parallelism":
+            settings = section["settings"]
+            if "execution_reports" in settings:
+                reporting = settings["execution_reports"]
+                if not isinstance(reporting, dict):
+                    errors.append(f"{prefix}.settings.execution_reports must be an object")
+                elif not isinstance(reporting.get("enabled"), bool):
+                    errors.append(f"{prefix}.settings.execution_reports.enabled must be boolean")
+            if "resource_reservations" in settings:
+                try:
+                    normalize_resource_policy(settings["resource_reservations"])
+                except ValueError as exc:
+                    errors.append(f"{prefix}.settings.{exc}")
+        review = section.get("review")
+        if not isinstance(review, dict) or not isinstance(review.get("approved"), bool):
+            errors.append(f"{prefix}.review.approved must be boolean")
+        elif require_pending and review.get("approved") is not False:
+            errors.append(f"{prefix}.review must be pending in an agent-generated plan")
+        elif review.get("approved") is True and any(not text_present(review.get(field)) for field in ("reviewer", "date", "reviewed_digest")):
+            errors.append(f"{prefix}.review approval requires reviewer, date, and reviewed_digest")
+        elif review.get("approved") is True and section.get("unresolved"):
+            errors.append(f"{prefix}.review cannot approve unresolved choices")
+        if section.get("applicable") is False and not text_present(section.get("rationale")):
+            errors.append(f"{prefix}.rationale is required for not applicable")
+    missing = sorted(set(POLICY_SECTION_IDS) - seen)
+    if missing:
+        errors.append("missing sections: " + ", ".join(missing))
+    return errors
+
+
+def policy_blockers(policy: Any) -> list[str]:
+    if not isinstance(policy, dict) or not isinstance(policy.get("sections"), list):
+        return ["policy:missing"]
+    return [
+        f"policy:{section.get('id')}"
+        for section in policy["sections"]
+        if isinstance(section, dict)
+        and section.get("required") is True
+        and not (isinstance(section.get("review"), dict) and section["review"].get("approved") is True)
+    ]
+
+
+def reviewed_project_state(repo: Path) -> dict[str, Any]:
+    _path, _policy_text, project = read_project_state(repo)
+    errors = validate_project_state(project) if project is not None else ["canonical policy is missing"]
+    errors.extend(validate_project_artifacts(repo, project))
+    if errors or project.get("initialized") is not True or policy_blockers(project.get("policy")):
+        raise ValueError("Project policy is not ready")
+    return project
+
+
+def cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def render_project(state: dict[str, Any]) -> str:
+    charter = state["charter"]
+    status = "complete" if state["initialized"] else "incomplete — policy review required"
+    reviewed = (state.get("approval") or {}).get("date", "not yet")
+    kpis = "\n".join(f"| {cell(k['name'])} | {cell(k['why'])} | {cell(k['baseline'])} | {cell(k['target'])} | {cell(k['evidence'])} | {cell(k['cadence'])} |" for k in charter["kpis"])
+    bullets = lambda values: "\n".join(f"- {value}" for value in values)
+    checks = "\n".join(f"- [x] {value}" for value in charter["acceptance_criteria"])
+    policy = "\n".join(f"- `[policy:{section['id']}]` **{section['title']}**: {section['decision']}" for section in state["policy"]["sections"])
+    return f"""# Project success charter
+
+**Status:** {status}
+**Last reviewed:** {reviewed}
+
+## Overall goal
+- Outcome: {charter['outcome']}
+- Primary beneficiaries: {', '.join(charter['beneficiaries'])}
+- Why it matters: {charter['why_it_matters']}
+- Time horizon: {charter['time_horizon']}
+
+## Success metrics
+| KPI | Why it matters | Baseline | Target / threshold | Evidence source | Review cadence |
+| --- | --- | --- | --- | --- | --- |
+{kpis}
+
+## Project acceptance criteria
+{checks}
+
+## Value rubric
+- `critical`: required for project acceptance, safety, or a binding deadline.
+- `high`: materially moves a priority KPI or unlocks critical/high-value work.
+- `medium`: useful measurable contribution with limited leverage.
+- `low`: weak, speculative, cosmetic, or currently unmeasured contribution.
+
+When KPIs conflict, prefer: {charter['precedence']}
+
+## Constraints and non-goals
+### Constraints
+{bullets(charter['constraints'])}
+
+### Non-goals
+{bullets(charter['non_goals'])}
+
+### Unacceptable tradeoffs
+{bullets(charter['unacceptable_tradeoffs'])}
+
+## Assumptions and open questions
+- None recorded at initialization; add evidence-backed changes with history.
+
+## Operating policy
+
+{policy}
+
+Detailed rationale and review history: [PROJECT_AUDIT.md](PROJECT_AUDIT.md). Canonical policy state: [POLICY.json](POLICY.json).
+"""
+
+
+def render_policy_sections(policy: dict[str, Any]) -> str:
+    rendered = []
+    evidence = {item["id"]: f"{item['source']} — {item['finding']}" for item in policy.get("evidence", []) if isinstance(item, dict) and text_present(item.get("id"))}
+    for section in policy["sections"]:
+        approved = section["review"]["approved"] is True
+        applicable = "applicable" if section["applicable"] else "not applicable"
+        settings = json.dumps(section["settings"], ensure_ascii=False, sort_keys=True)
+        rendered.append(
+            f"- [{'x' if approved else ' '}] `[policy:{section['id']}]` **{section['title']}** ({applicable})\n"
+            f"  - Decision: {section['decision']}\n"
+            f"  - Rationale: {section['rationale']}\n"
+            f"  - Sources: {'; '.join(f'{source_id}: {evidence.get(source_id, 'missing citation')}' for source_id in section['source_ids'])}\n"
+            f"  - Confidence/default: {section['confidence']}; {section['default_origin']} → {section['default_disposition']}\n"
+            f"  - Settings: `{settings}`\n"
+            f"  - Exceptions: {', '.join(section['exceptions']) or 'none'}\n"
+            f"  - Unresolved: {', '.join(section['unresolved']) or 'none'}"
+        )
+    return "\n".join(rendered)
+
+
+def render_project_audit(state: dict[str, Any]) -> str:
+    status = "complete" if state["initialized"] else "pending explicit review"
+    reviewer = (state.get("approval") or {}).get("reviewer", "not yet approved")
+    history = "\n".join(f"| {cell(entry['date'])} | {cell(entry['actor'])} | {cell(entry['change'])} | {cell(entry['reason'])} |" for entry in state["history"])
+    return (
+        "# ZzzOps project policy audit\n\n"
+        f"Status: {status}. Reviewer: {reviewer}. Revision: {state['revision']}.\n\n"
+        "## Evidence and decisions\n\n"
+        f"{render_policy_sections(state['policy'])}\n\n"
+        "## Review record\n\n"
+        "| Date | Actor/run | Change | Reason/evidence |\n"
+        "| --- | --- | --- | --- |\n"
+        f"{history}\n\n"
+        "The machine-readable authority is [POLICY.json](POLICY.json); this file is its human audit view.\n"
+    )

--- a/.agents/zzzops/zzzops.py
+++ b/.agents/zzzops/zzzops.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import hashlib
 import hmac
 import json
@@ -18,29 +19,25 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-PROJECT_SCHEMA_VERSION = 1
+_POLICY_MODULE_PATH = Path(__file__).with_name("policy.py")
+_POLICY_MODULE_SPEC = importlib.util.spec_from_file_location("zzzops_policy", _POLICY_MODULE_PATH)
+assert _POLICY_MODULE_SPEC and _POLICY_MODULE_SPEC.loader
+_policy = importlib.util.module_from_spec(_POLICY_MODULE_SPEC)
+sys.modules[_POLICY_MODULE_SPEC.name] = _policy
+_POLICY_MODULE_SPEC.loader.exec_module(_policy)
+
+PROJECT_SCHEMA_VERSION = _policy.PROJECT_SCHEMA_VERSION
 PLAN_SCHEMA_VERSION = 1
-POLICY_SCHEMA_VERSION = 1
+POLICY_SCHEMA_VERSION = _policy.POLICY_SCHEMA_VERSION
 GOAL_SCHEMA_VERSION = 1
 GOAL_TRANSITION_SCHEMA_VERSION = 1
 PORTFOLIO_SCHEMA_VERSION = 1
-PROJECT_POLICY_RELATIVE = ".zzzops/POLICY.json"
-PROJECT_AUDIT_RELATIVE = ".zzzops/PROJECT_AUDIT.md"
+PROJECT_POLICY_RELATIVE = _policy.PROJECT_POLICY_RELATIVE
+PROJECT_AUDIT_RELATIVE = _policy.PROJECT_AUDIT_RELATIVE
 GOAL_BLOCK_START = "<!-- zzzops-goal"
 GOAL_BLOCK_END = "zzzops-goal -->"
-BACKENDS = {"github_issues"}
-POLICY_SECTION_IDS = (
-    "backend",
-    "git_review_release",
-    "execution_continuation",
-    "verification_testing",
-    "code_quality",
-    "dependencies_tooling",
-    "security_privacy_compliance",
-    "documentation_style",
-    "deployment_resources",
-    "autonomy_approval_parallelism",
-)
+BACKENDS = _policy.BACKENDS
+POLICY_SECTION_IDS = _policy.POLICY_SECTION_IDS
 GOAL_FIELDS = {
     "schema_version", "status", "priority", "value", "difficulty", "confidence",
     "parent", "depends_on", "claim", "blockers",
@@ -78,6 +75,7 @@ MANAGED_SKILLS = (
 )
 MACHINERY_PATHS = (
     ".agents/zzzops/zzzops.py",
+    ".agents/zzzops/policy.py",
     ".agents/zzzops/.gitignore",
     ".agents/zzzops/INSTALL_MANIFEST",
     ".agents/zzzops/templates/project-goals",
@@ -215,60 +213,9 @@ def reservation_repository_key(repository: str) -> str:
     return hashlib.sha256(repository.casefold().encode("utf-8")).hexdigest()[:12]
 
 
-def normalize_resources(resources: Any) -> list[str]:
-    if not isinstance(resources, list):
-        raise ValueError("resources must be a list")
-    normalized = []
-    for resource in resources:
-        if not isinstance(resource, str):
-            raise ValueError("resource entries must be text")
-        value = resource.strip().replace("\\", "/")
-        prefix, separator, target = value.partition(":")
-        prefix = prefix.casefold()
-        if prefix not in {"path", "branch", "integration", "generated", "external"} or not separator or not target:
-            raise ValueError("resources must use path, branch, integration, generated, or external prefixes")
-        if len(value) > 200 or any(ord(character) < 32 for character in value):
-            raise ValueError("resource entries must be at most 200 printable characters")
-        normalized.append(value.casefold())
-    if len(normalized) != len(set(normalized)):
-        raise ValueError("resource entries must be unique")
-    return sorted(normalized)
-
-
-def normalize_resource_policy(policy: Any = None) -> dict[str, Any]:
-    if policy is None:
-        policy = {}
-    if not isinstance(policy, dict):
-        raise ValueError("resource_reservations must be an object")
-    unknown = sorted(set(policy) - {"mode", "exclusive_prefixes", "exclusive_resources"})
-    if unknown:
-        raise ValueError("resource_reservations has unknown fields: " + ", ".join(unknown))
-    mode = policy.get("mode", "conflict_tolerant")
-    if mode not in {"conflict_tolerant", "strict"}:
-        raise ValueError("resource_reservations.mode must be conflict_tolerant or strict")
-    prefixes = policy.get("exclusive_prefixes", ["generated", "external"])
-    supported = {"path", "integration", "generated", "external"}
-    if (
-        not isinstance(prefixes, list)
-        or any(not isinstance(prefix, str) or prefix not in supported for prefix in prefixes)
-        or len(prefixes) != len(set(prefixes))
-    ):
-        raise ValueError("resource_reservations.exclusive_prefixes must contain unique supported prefixes")
-    resources = normalize_resources(policy.get("exclusive_resources", []))
-    return {"mode": mode, "exclusive_prefixes": sorted(prefixes), "exclusive_resources": resources}
-
-
-def exclusive_resources(resources: Any, policy: Any = None) -> list[str]:
-    resources = normalize_resources(resources)
-    policy = normalize_resource_policy(policy)
-    if policy["mode"] == "strict":
-        return resources
-    exact = set(policy["exclusive_resources"])
-    prefixes = set(policy["exclusive_prefixes"])
-    return [
-        resource for resource in resources
-        if resource.startswith("branch:") or resource in exact or resource.partition(":")[0] in prefixes
-    ]
+normalize_resources = _policy.normalize_resources
+normalize_resource_policy = _policy.normalize_resource_policy
+exclusive_resources = _policy.exclusive_resources
 
 
 def resource_label_name(resource: str) -> str:
@@ -1255,13 +1202,7 @@ def submit_feedback(
     }
 
 
-def reviewed_project_state(repo: Path) -> dict[str, Any]:
-    _path, _policy_text, project = read_project_state(repo)
-    errors = validate_project_state(project) if project is not None else ["canonical policy is missing"]
-    errors.extend(validate_project_artifacts(repo, project))
-    if errors or project.get("initialized") is not True or policy_blockers(project.get("policy")):
-        raise ValueError("Project policy is not ready")
-    return project
+reviewed_project_state = _policy.reviewed_project_state
 
 
 def read_cli_text(value: str) -> str:
@@ -1281,70 +1222,16 @@ def configure_cli_stdout() -> None:
         reconfigure(encoding="utf-8", errors="strict")
 
 
-def project_digest(text: str) -> str:
-    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
-
-
-def project_path(repo: Path) -> Path:
-    return repo / ".zzzops" / "PROJECT.md"
-
-
-def project_audit_path(repo: Path) -> Path:
-    return repo / PROJECT_AUDIT_RELATIVE
-
-
-def project_policy_path(repo: Path) -> Path:
-    return repo / PROJECT_POLICY_RELATIVE
-
-
-def read_project(repo: Path) -> tuple[Path, str]:
-    path = project_path(repo)
-    try:
-        return path, path.read_text(encoding="utf-8-sig")
-    except FileNotFoundError:
-        return path, ""
-    except (OSError, UnicodeError) as exc:
-        raise ValueError(f"Cannot read project charter from {path}: {exc}") from exc
-
-
-def parse_policy_state(text: str) -> dict[str, Any]:
-    try:
-        state = json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"Invalid canonical policy JSON: {exc}") from exc
-    if not isinstance(state, dict):
-        raise ValueError("Canonical policy state must be a JSON object")
-    return state
-
-
-def read_policy_text(repo: Path) -> tuple[Path, str]:
-    path = project_policy_path(repo)
-    try:
-        text = path.read_text(encoding="utf-8-sig")
-    except FileNotFoundError:
-        return path, ""
-    except (OSError, UnicodeError) as exc:
-        raise ValueError(f"Cannot read canonical policy from {path}: {exc}") from exc
-    return path, text
-
-
-def read_project_state(repo: Path) -> tuple[Path, str, dict[str, Any] | None]:
-    path, text = read_policy_text(repo)
-    if not text:
-        return path, text, None
-    return path, text, parse_policy_state(text)
-
-
-def initialization_base_digest(repo: Path) -> str:
-    _project_path, project_text = read_project(repo)
-    _policy_path, policy_text = read_policy_text(repo)
-    return project_digest(project_text + "\0" + policy_text)
-
-
-def policy_review_digest(state: dict[str, Any]) -> str:
-    reviewable = {key: value for key, value in state.items() if key != "approval"}
-    payload = json.dumps(reviewable, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    return project_digest(payload)
+project_digest = _policy.project_digest
+project_path = _policy.project_path
+project_audit_path = _policy.project_audit_path
+project_policy_path = _policy.project_policy_path
+read_project = _policy.read_project
+parse_policy_state = _policy.parse_policy_state
+read_policy_text = _policy.read_policy_text
+read_project_state = _policy.read_project_state
+initialization_base_digest = _policy.initialization_base_digest
+policy_review_digest = _policy.policy_review_digest
 
 
 def validate_project_state(state: Any) -> list[str]:
@@ -1514,6 +1401,13 @@ def policy_blockers(policy: Any) -> list[str]:
         and section.get("required") is True
         and not (isinstance(section.get("review"), dict) and section["review"].get("approved") is True)
     ]
+
+
+# Stable entry-point re-exports for existing callers and installed skill prompts.
+validate_project_state = _policy.validate_project_state
+validate_project_artifacts = _policy.validate_project_artifacts
+validate_policy = _policy.validate_policy
+policy_blockers = _policy.policy_blockers
 
 
 def parse_managed_goal(text: str, issue_number: int | None = None) -> dict[str, Any] | None:
@@ -2737,6 +2631,17 @@ def render_project_audit(state: dict[str, Any]) -> str:
 
 def cell(value: str) -> str:
     return value.replace("|", "\\|").replace("\n", " ")
+
+
+# Policy rendering and text predicates are likewise exposed through the historic
+# CLI module while their implementation lives in the acyclic policy module.
+nonempty = _policy.nonempty
+text_present = _policy.text_present
+nonempty_list = _policy.nonempty_list
+cell = _policy.cell
+render_project = _policy.render_project
+render_policy_sections = _policy.render_policy_sections
+render_project_audit = _policy.render_project_audit
 
 
 def atomic_text(path: Path, text: str) -> None:

--- a/install.ps1
+++ b/install.ps1
@@ -89,7 +89,7 @@ function Get-InstallPairs {
     $fixed = @(
         '.zzzops/rules/BACKENDS.md', '.zzzops/rules/BLOCKERS.md', '.zzzops/rules/CONTINUATION.md',
         '.zzzops/rules/EXECUTION_STRATEGY.md', '.zzzops/rules/FEEDBACK.md', '.zzzops/rules/GOAL_SYSTEM.md', '.zzzops/rules/INITIALIZATION.md',
-        '.agents/zzzops/zzzops.py', 'LICENSE'
+        '.agents/zzzops/zzzops.py', '.agents/zzzops/policy.py', 'LICENSE'
     )
     foreach ($relative in $fixed) {
         $destination = if ($relative -eq 'LICENSE') { '.agents/zzzops/LICENSE' } else { $relative }

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ build_pairs() {
     local fixed=(
         .zzzops/rules/BACKENDS.md .zzzops/rules/BLOCKERS.md .zzzops/rules/CONTINUATION.md
         .zzzops/rules/EXECUTION_STRATEGY.md .zzzops/rules/FEEDBACK.md .zzzops/rules/GOAL_SYSTEM.md .zzzops/rules/INITIALIZATION.md
-        .agents/zzzops/zzzops.py LICENSE
+        .agents/zzzops/zzzops.py .agents/zzzops/policy.py LICENSE
     )
     for relative in "${fixed[@]}"; do
         [[ "$relative" == LICENSE ]] && add_pair "$SOURCE_ROOT/$relative" '.agents/zzzops/LICENSE' || add_pair "$SOURCE_ROOT/$relative" "$relative"


### PR DESCRIPTION
Closes #187\n\nExtracts canonical policy state, validation, rendering, and policy-configured resource normalization into an acyclic module while preserving the zzzops.py entry-point API. Both installers now deploy the module, with regression coverage for re-exports and installed targets.\n\nVerification:\n- py -3 .agents/test_zzzops.py (102 tests)\n- py -3 .agents/test_install_zzzops.py