### PR TITLE
docs(execution): bound GitHub state reads

### DIFF
--- a/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
+++ b/.agents/skills/execute-zzzops/references/BRANCH_REVIEW.md
@@ -22,7 +22,7 @@ Use `Tracks #N`; default-branch closing keywords are insufficient. Only after th
 
 ## Review gate
 
-At each checkpoint, perform PROJECT `review_state_reads_per_checkpoint` bounded reads of review state, unresolved inline threads, and relevant comments. Prefer thread-aware data; classify actionable, resolved/outdated, discussion-only, automated, ambiguous, or unauthorized. Record actionable file/line context. Poll only under an enabled human-unblock watch.
+At each checkpoint, perform PROJECT `review_state_reads_per_checkpoint` bounded consolidated reads of review state, unresolved inline threads, relevant comments, PR checks, and exact head. Prefer thread-aware data; classify actionable, resolved/outdated, discussion-only, automated, ambiguous, or unauthorized. Reuse the one result for that checkpoint instead of issuing equivalent separate reads. Record actionable file/line context. Poll only under an enabled human-unblock watch.
 
 Change only authorized actionable feedback on the recorded branch/PR. Re-read head/threads first; after each verified change rerun self-review/checks, record the new exact checkpoint, and invalidate approval. Ambiguous, expanding, conflicting, or unauthorized feedback becomes a categorized blocker. Code changes do not resolve provider threads.
 

--- a/.agents/skills/execute-zzzops/references/EXECUTE.md
+++ b/.agents/skills/execute-zzzops/references/EXECUTE.md
@@ -6,6 +6,7 @@
 
 1. Read the charter and use the current BACKENDS checkpoint portfolio; never reread it. Require `complete:true` and `valid:true`; resolve findings instead of selecting from an invalid graph, and use its compact relationships/claims/reviews rather than rereading goals. If the present user's human queue is non-empty, run `UNBLOCK.md` first to identify consequential gates, but continue independently actionable work without waiting for a non-blocking answer.
    Specially tagged `zzzops-feedback` goals are absent unless the user approved them for this execution session. One session approval includes the whole feedback queue; never request approval per issue, and retain `--include-feedback` on every checkpoint refresh in that session.
+   Treat that complete checkpoint as the current queue read until a local state mutation, provider failure, explicit freshness requirement, or observed drift requires one refresh. Do not run an extra portfolio command merely to rediscover the same goals.
 2. Route `new` goals through `CREATE.md` according to PROJECT triage/continuation policy.
 3. Use the portfolio's PROJECT-derived `actionable` field. The installed default waits for every dependency to be `done` before writable implementation; a reviewed PROJECT override such as `stack_from_reviewed_checkpoint` may make a child actionable earlier. Read-only investigation may prepare waiting work when policy permits, but never claims, edits, branches, or marks it started. Recheck blocked work only on its trigger.
 4. Obey authority and explicit PROJECT priority first. Within the same effective priority, prefer evidenced charter/KPI value, safety/risk reduction, and unlocks: choose high-value, risk-reducing or unlocking work over low-value easy or fast work. Then prefer confidence, faster observable feedback, and lower difficulty; difficulty is cost, not value and never a reason to maximize item count. Unmeasured KPIs may support qualitative rationale, but never invent a baseline, score, or precision. On an exact tie use PROJECT resume policy, then the lowest goal key.
@@ -18,6 +19,12 @@ Ask immediately only for a consequential decision, authority, or safety boundary
 2. For source changes, establish/resume the policy-selected topology from `BRANCH_REVIEW.md` and persist branch/base/target before editing. Then follow `.zzzops/rules/EXECUTION_STRATEGY.md`: capture baseline; implement one smallest falsifiable chunk; run/inspect/record the real probe before continuing; widen only after proof.
 3. Work to a verified checkpoint without silent scope expansion. Classify discoveries as scope, checklist, child, dependency, or root. Apply PROJECT test-bug policy; never hide a failure, weaken the test, or expand authority silently.
 4. Persist evidence at natural checkpoints. Follow PROJECT-limited parallel/worktree rules; coordinator owns ZzzOps state and integration.
+
+## GitHub read budget
+
+- Use one consolidated PR-state read per review checkpoint: request the PR state, exact head, checks, review decision, and comments together. Reuse that result for the matching checkpoint rather than issuing separate status, checks, and review reads.
+- Poll only through an enabled bounded watch or heartbeat. Each unchanged poll uses one consolidated PR-state read; do not poll while implementing, and stop the watch as soon as a terminal state or a human decision is reached.
+- Exact-head, permission, merge, and transition readbacks remain mandatory at their safety boundaries. Reuse reduces equivalent reads; it never authorizes stale cached state.
 
 ## Block, complete, cycle
 

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -1985,6 +1985,18 @@ class WorkflowContractTests(unittest.TestCase):
         for phrase in ("zzzops-feedback", "current execution session", "Never ask per issue", "--include-feedback"):
             self.assertIn(phrase, execute)
 
+    def test_execute_guidance_bounds_github_reads_without_weakening_safety_checks(self):
+        root = Path(__file__).parent / "skills" / "execute-zzzops"
+        execute = (root / "references" / "EXECUTE.md").read_text(encoding="utf-8")
+        review = (root / "references" / "BRANCH_REVIEW.md").read_text(encoding="utf-8")
+        for phrase in (
+            "current queue read", "one consolidated PR-state read",
+            "Exact-head, permission, merge, and transition readbacks remain mandatory",
+        ):
+            self.assertIn(phrase, execute)
+        self.assertIn("bounded consolidated reads", review)
+        self.assertIn("exact head", review)
+
     def test_execute_continues_past_nonblocking_human_questions(self):
         execute = (Path(__file__).parent / "skills" / "execute-zzzops" / "references" / "EXECUTE.md").read_text(encoding="utf-8")
         unblock = (Path(__file__).parent / "skills" / "execute-zzzops" / "references" / "UNBLOCK.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- reuse a complete checkpoint portfolio until a defined freshness boundary
- consolidate PR state, checks, reviews, comments, and exact head into one bounded checkpoint read
- preserve mandatory exact-state safety readbacks and add a workflow contract test

## Verification

- `py -3 .agents/test_zzzops.py WorkflowContractTests` (14 passed)
- `py -3 .agents/prompt_stats.py --check`
- `git diff --check`
