### PR TITLE
feat(goals): stage minimal GitHub discovery

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -1126,17 +1126,25 @@ class PortfolioTests(unittest.TestCase):
     @mock.patch.object(zzzops, "validate_project_artifacts", return_value=[])
     @mock.patch.object(zzzops, "validate_project_state", return_value=[])
     @mock.patch.object(zzzops, "read_project_state", return_value=(Path("POLICY.json"), "state", {"initialized": True, "backend": "github_issues", "repository": {"identity": "owner/repo"}}))
-    def test_github_adapter_uses_one_paginated_read_and_filters_prs(self, _read_state, _validate, _artifacts, run, _which):
+    def test_github_adapter_stages_minimal_discovery_and_targeted_bodies(self, _read_state, _validate, _artifacts, run, _which):
         with tempfile.TemporaryDirectory() as temporary:
             repo = Path(temporary)
             (repo / ".zzzops").mkdir()
             (repo / ".zzzops" / "PROJECT.md").write_text("state", encoding="utf-8")
             def graphql_issue(issue):
                 return {
-                    "number": issue["number"], "title": issue["title"], "body": issue["body"],
-                    "state": issue["state"].upper(), "updatedAt": issue["updated_at"], "url": issue["html_url"],
+                    "number": issue["number"], "title": issue["title"],
+                    "state": issue["state"].upper(),
                     "labels": {"nodes": issue["labels"]},
                 }
+
+            def body_payload(*issues):
+                return {"data": {"repository": {
+                    f"goal_{issue['number']}": {
+                        "number": issue["number"], "body": issue["body"], "updatedAt": issue["updated_at"],
+                    }
+                    for issue in issues
+                }}}
 
             feedback = self.issue(2, status="new")
             feedback["labels"].append({"name": "zzzops-feedback"})
@@ -1154,7 +1162,13 @@ class PortfolioTests(unittest.TestCase):
                                "pageInfo": {"hasNextPage": False, "endCursor": "page-2"}},
                 }}},
             ]
-            run.return_value = SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+            issue_one, issue_three = self.issue(1), self.issue(3)
+            run.side_effect = [
+                SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr=""),
+                SimpleNamespace(returncode=0, stdout=json.dumps(body_payload(issue_one, issue_three)), stderr=""),
+                SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr=""),
+                SimpleNamespace(returncode=0, stdout=json.dumps(body_payload(issue_one, feedback, issue_three)), stderr=""),
+            ]
             snapshot = zzzops.portfolio_snapshot(repo)
             _, included = zzzops.github_repository_portfolio_snapshot(
                 repo, {"backend": "github_issues", "repository": {"identity": "owner/repo"}},
@@ -1162,15 +1176,26 @@ class PortfolioTests(unittest.TestCase):
             )
         self.assertEqual([1, 3], [goal["key"] for goal in snapshot["goals"]])
         self.assertEqual([1, 2, 3], [goal["key"] for goal in included["goals"]])
-        self.assertEqual(2, snapshot["summary"]["reads"])
-        self.assertEqual(1, snapshot["summary"]["processes"])
+        self.assertEqual(3, snapshot["summary"]["reads"])
+        self.assertEqual(2, snapshot["summary"]["processes"])
         self.assertEqual(1, snapshot["summary"]["ignored"])
         self.assertEqual(0, included["summary"]["ignored"])
-        command = run.call_args.args[0]
-        self.assertIn("graphql", command)
-        self.assertIn("--paginate", command)
-        self.assertIn("--slurp", command)
-        self.assertEqual(2, run.call_count)
+        discovery = run.call_args_list[0].args[0]
+        hydration = run.call_args_list[1].args[0]
+        discovery_query = next(value[6:] for value in discovery if value.startswith("query="))
+        hydration_query = next(value[6:] for value in hydration if value.startswith("query="))
+        self.assertIn("--paginate", discovery)
+        self.assertIn("--slurp", discovery)
+        self.assertIn("number title state", discovery_query)
+        issue_fields = discovery_query.split("nodes{", 1)[1].split("}", 1)[0]
+        for excluded in ("body", "updatedAt", "url", "comments"):
+            self.assertNotIn(excluded, issue_fields)
+        self.assertIn("goal_1:issue(number:1){number body updatedAt}", hydration_query)
+        self.assertIn("goal_3:issue(number:3){number body updatedAt}", hydration_query)
+        self.assertNotIn("goal_2:", hydration_query)
+        self.assertEqual("https://example.test/owner/repo/issues/1", snapshot["goals"][0]["url"])
+        self.assertLess(snapshot["summary"]["discovery_raw_bytes"], snapshot["summary"]["raw_bytes"])
+        self.assertEqual(4, run.call_count)
 
     @mock.patch.object(zzzops.shutil, "which", side_effect=lambda command: command)
     @mock.patch.object(zzzops.subprocess, "run")
@@ -1192,8 +1217,8 @@ class PortfolioTests(unittest.TestCase):
         read_state.return_value = (Path("POLICY.json"), "state", state)
         issue = self.issue(1)
         graphql_issue = {
-            "number": issue["number"], "title": issue["title"], "body": issue["body"],
-            "state": issue["state"].upper(), "updatedAt": issue["updated_at"], "url": issue["html_url"],
+            "number": issue["number"], "title": issue["title"],
+            "state": issue["state"].upper(),
             "labels": {"nodes": issue["labels"]},
         }
         run.side_effect = [
@@ -1204,6 +1229,9 @@ class PortfolioTests(unittest.TestCase):
                 "issues": {"nodes": [graphql_issue],
                            "pageInfo": {"hasNextPage": False, "endCursor": "page-1"}},
             }}}]), stderr=""),
+            SimpleNamespace(returncode=0, stdout=json.dumps({"data": {"repository": {
+                "goal_1": {"number": 1, "body": issue["body"], "updatedAt": issue["updated_at"]},
+            }}}), stderr=""),
         ]
 
         result = zzzops.decision_checkpoint(Path("."))
@@ -1214,10 +1242,31 @@ class PortfolioTests(unittest.TestCase):
         self.assertTrue(result["capabilities"]["github_repository"]["usable"])
         self.assertTrue(result["portfolio"]["complete"])
         self.assertEqual([1], [goal["key"] for goal in result["portfolio"]["goals"]])
-        self.assertEqual({"total": 2, "github": 1}, result["processes"])
-        self.assertEqual(2, run.call_count)
+        self.assertEqual({"total": 3, "github": 2}, result["processes"])
+        self.assertEqual(3, run.call_count)
         self.assertEqual("git", run.call_args_list[0].args[0][0])
         self.assertIn("graphql", run.call_args_list[1].args[0])
+
+    @mock.patch.object(zzzops.shutil, "which", return_value="gh")
+    @mock.patch.object(zzzops.subprocess, "run")
+    def test_goal_history_is_an_explicit_separate_hydration(self, run, _which):
+        run.return_value = SimpleNamespace(returncode=0, stderr="", stdout=json.dumps([
+            {"data": {"repository": {"issue": {"comments": {
+                "nodes": [{"body": "prior state", "createdAt": "2026-01-01T00:00:00Z", "url": "history", "author": {"login": "user"}}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }}}}},
+        ]))
+
+        comments = zzzops.github_issue_history(
+            Path("."), {"backend": "github_issues", "repository": {"identity": "owner/repo"}}, 7,
+        )
+
+        self.assertEqual("prior state", comments[0]["body"])
+        command = run.call_args.args[0]
+        query = next(value[6:] for value in command if value.startswith("query="))
+        self.assertIn("comments(first:100", query)
+        self.assertNotIn(" title", query)
+        self.assertNotIn(" labels", query)
 
     @mock.patch.object(zzzops.shutil, "which", return_value="gh")
     @mock.patch.object(zzzops, "repository_size_profile", return_value={"mode": "worktrees", "max_workers": 3})
@@ -1301,6 +1350,15 @@ class PortfolioTests(unittest.TestCase):
             issue["body"] = zzzops.render_managed_goal(goal, f"## Outcome / Why\n\n{context}\n", number)
             issues.append(issue)
         raw_bytes = sum(len((issue["title"] + issue["body"]).encode("utf-8")) for issue in issues)
+        full_discovery = json.dumps([{
+            "number": issue["number"], "title": issue["title"], "body": issue["body"],
+            "state": issue["state"], "updatedAt": issue["updated_at"], "url": issue["html_url"],
+            "labels": issue["labels"],
+        } for issue in issues], separators=(",", ":")).encode("utf-8")
+        minimal_discovery = json.dumps([{
+            "number": issue["number"], "title": issue["title"], "state": issue["state"],
+            "labels": issue["labels"],
+        } for issue in issues], separators=(",", ":")).encode("utf-8")
         snapshot = zzzops.build_portfolio_snapshot(
             "github_issues", [zzzops.github_goal_record(issue) for issue in issues], reads=2, raw_bytes=raw_bytes,
         )
@@ -1309,6 +1367,22 @@ class PortfolioTests(unittest.TestCase):
         self.assertEqual(2, snapshot["summary"]["reads"])
         self.assertLess(json_bytes, raw_bytes)
         self.assertLess(summary_bytes, json_bytes)
+        self.assertLess(len(minimal_discovery), len(full_discovery) // 10)
+
+    def test_minimal_index_identifies_schema_from_labels_and_reconstructs_url(self):
+        issue = {
+            "number": 7, "title": "Selected goal", "state": "OPEN",
+            "labels": {"nodes": [{"name": "zzzops"}, {"name": "zzzops:schema:v2"}]},
+        }
+
+        indexed = zzzops._graphql_issue_index(issue, "https://github.com/owner/repo")
+
+        self.assertEqual(2, indexed["schema_version"])
+        self.assertEqual("https://github.com/owner/repo/issues/7", indexed["html_url"])
+        duplicate = json.loads(json.dumps(issue))
+        duplicate["labels"]["nodes"].append({"name": "zzzops:schema:v1"})
+        with self.assertRaisesRegex(ValueError, "multiple goal schema labels"):
+            zzzops._graphql_issue_index(duplicate, "https://github.com/owner/repo")
 
     def test_terminal_output_is_archived_after_full_validation(self):
         records = [zzzops.github_goal_record(self.issue(number, status="done")) for number in range(1, 121)]

--- a/.agents/zzzops/zzzops.py
+++ b/.agents/zzzops/zzzops.py
@@ -94,7 +94,7 @@ query($owner:String!,$name:String!,$labels:[String!],$endCursor:String){
     nameWithOwner url hasIssuesEnabled viewerPermission
     issues(first:100,after:$endCursor,states:[OPEN,CLOSED],labels:$labels,orderBy:{field:CREATED_AT,direction:ASC}){
       nodes{
-        number title body state updatedAt url
+        number title state
         labels(first:100){nodes{name}}
       }
       pageInfo{hasNextPage endCursor}
@@ -102,6 +102,20 @@ query($owner:String!,$name:String!,$labels:[String!],$endCursor:String){
   }
 }
 """.strip()
+GITHUB_GOAL_HISTORY_QUERY = """
+query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
+  repository(owner:$owner,name:$name){
+    issue(number:$number){
+      comments(first:100,after:$endCursor){
+        nodes{body createdAt url author{login}}
+        pageInfo{hasNextPage endCursor}
+      }
+    }
+  }
+}
+""".strip()
+GOAL_SCHEMA_LABEL = re.compile(r"^zzzops:schema:v(?P<version>[1-9][0-9]*)$")
+GOAL_HYDRATION_BATCH_SIZE = 100
 REPOSITORY_SIZE_THRESHOLD_BYTES = 100 * 1024 * 1024
 MANAGED_SKILLS = (
     "add-zzzops-goal", "execute-zzzops", "migrate-to-zzzops", "review-zzzops-policy",
@@ -507,16 +521,121 @@ def _project_repository_identity(project: dict[str, Any]) -> str:
     return identity
 
 
-def _graphql_issue(issue: dict[str, Any]) -> dict[str, Any]:
+def _graphql_labels(issue: dict[str, Any]) -> list[dict[str, Any]]:
     labels = issue.get("labels")
     nodes = labels.get("nodes") if isinstance(labels, dict) else None
     if not isinstance(nodes, list):
         raise ValueError("issue labels are incomplete or malformed")
+    return [{"name": node.get("name")} for node in nodes if isinstance(node, dict)]
+
+
+def _graphql_issue_index(issue: dict[str, Any], repository_url: str) -> dict[str, Any]:
+    labels = _graphql_labels(issue)
+    schema_versions = [
+        int(match.group("version"))
+        for label in labels
+        if isinstance(label.get("name"), str) and (match := GOAL_SCHEMA_LABEL.fullmatch(label["name"]))
+    ]
+    if len(schema_versions) > 1:
+        raise ValueError("issue has multiple goal schema labels")
     return {
-        "number": issue["number"], "title": issue["title"], "body": issue.get("body") or "",
-        "state": str(issue["state"]).lower(), "updated_at": issue["updatedAt"], "html_url": issue["url"],
-        "labels": [{"name": node.get("name")} for node in nodes if isinstance(node, dict)],
+        "number": issue["number"], "title": issue["title"],
+        "state": str(issue["state"]).lower(), "labels": labels,
+        "schema_version": schema_versions[0] if schema_versions else None,
+        "html_url": f"{repository_url.rstrip('/')}/issues/{issue['number']}",
     }
+
+
+def _goal_body_query(numbers: list[int]) -> str:
+    fields = "\n".join(
+        f"    goal_{number}:issue(number:{number}){{number body updatedAt}}"
+        for number in numbers
+    )
+    return (
+        "query($owner:String!,$name:String!){\n"
+        "  repository(owner:$owner,name:$name){\n"
+        f"{fields}\n"
+        "  }\n"
+        "}"
+    )
+
+
+def _github_goal_bodies(
+    repo: Path, executable: str, owner: str, name: str, numbers: list[int],
+) -> tuple[dict[int, dict[str, Any]], int, int]:
+    if not numbers:
+        return {}, 0, 0
+    hydrated = {}
+    raw_bytes = 0
+    processes = 0
+    for offset in range(0, len(numbers), GOAL_HYDRATION_BATCH_SIZE):
+        batch = numbers[offset:offset + GOAL_HYDRATION_BATCH_SIZE]
+        command = [
+            executable, "api", "graphql", "-f", f"query={_goal_body_query(batch)}",
+            "-F", f"owner={owner}", "-F", f"name={name}",
+        ]
+        try:
+            result = subprocess.run(
+                command, cwd=repo, capture_output=True, text=True, encoding="utf-8", timeout=60, check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ValueError(f"GitHub targeted goal-body read failed: {type(exc).__name__}") from exc
+        processes += 1
+        if result.returncode:
+            raise ValueError("GitHub targeted goal-body read failed: " + (result.stderr.strip() or "unknown gh error"))
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"GitHub targeted goal-body read returned invalid JSON: {exc}") from exc
+        data = payload.get("data") if isinstance(payload, dict) else None
+        repository = data.get("repository") if isinstance(data, dict) else None
+        if not isinstance(repository, dict):
+            raise ValueError("GitHub targeted goal-body read is incomplete or malformed")
+        for number in batch:
+            issue = repository.get(f"goal_{number}")
+            if not isinstance(issue, dict) or issue.get("number") != number or not isinstance(issue.get("body"), str):
+                raise ValueError(f"GitHub targeted goal-body read omitted issue #{number}")
+            hydrated[number] = {"body": issue["body"], "updated_at": issue.get("updatedAt")}
+        raw_bytes += len(result.stdout.encode("utf-8"))
+    return hydrated, raw_bytes, processes
+
+
+def github_issue_history(repo: Path, project: dict[str, Any], issue_number: int) -> list[dict[str, Any]]:
+    """Hydrate append-only history for one explicitly selected goal."""
+    identity = _project_repository_identity(project)
+    owner, name = identity.split("/", 1)
+    executable = shutil.which("gh")
+    if not executable:
+        raise ValueError("GitHub CLI is unavailable")
+    command = [
+        executable, "api", "graphql", "--paginate", "--slurp",
+        "-f", f"query={GITHUB_GOAL_HISTORY_QUERY}", "-F", f"owner={owner}",
+        "-F", f"name={name}", "-F", f"number={issue_number}",
+    ]
+    try:
+        result = subprocess.run(
+            command, cwd=repo, capture_output=True, text=True, encoding="utf-8", timeout=60, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"GitHub goal-history read failed: {type(exc).__name__}") from exc
+    if result.returncode:
+        raise ValueError("GitHub goal-history read failed: " + (result.stderr.strip() or "unknown gh error"))
+    try:
+        pages = json.loads(result.stdout)
+        if not isinstance(pages, list) or not pages:
+            raise TypeError("pagination result must contain at least one page")
+        comments = []
+        for index, page in enumerate(pages):
+            connection = page["data"]["repository"]["issue"]["comments"]
+            page_info = connection["pageInfo"]
+            if index < len(pages) - 1 and page_info.get("hasNextPage") is not True:
+                raise TypeError("history pagination stopped before final page")
+            if index == len(pages) - 1 and page_info.get("hasNextPage") is not False:
+                raise TypeError("history pagination is incomplete")
+            comments.extend(connection["nodes"])
+        return comments
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ValueError("GitHub goal-history read is incomplete or malformed") from exc
 
 
 def _github_repository_capability(data: dict[str, Any]) -> dict[str, Any]:
@@ -588,13 +707,13 @@ def github_repository_portfolio_snapshot(
         )
     repository_probe = _github_repository_capability(first)
 
-    issues = []
+    indexed_issues = []
     findings = []
     for issue in issue_nodes:
         try:
             if not isinstance(issue, dict):
                 raise ValueError("issue must be an object")
-            issues.append(_graphql_issue(issue))
+            indexed_issues.append(_graphql_issue_index(issue, first["url"]))
         except (KeyError, TypeError, ValueError) as exc:
             goal = issue.get("number", "unknown") if isinstance(issue, dict) else "unknown"
             findings.append({"code": "malformed_record", "goal": goal, "detail": str(exc)})
@@ -604,10 +723,16 @@ def github_repository_portfolio_snapshot(
             for label in issue.get("labels", [])
         )
 
-    managed = [
-        issue for issue in issues
-        if GOAL_BLOCK_START in issue["body"] and (include_feedback or not is_feedback(issue))
-    ]
+    selected = [issue for issue in indexed_issues if include_feedback or not is_feedback(issue)]
+    bodies, hydration_bytes, hydration_processes = _github_goal_bodies(
+        repo, executable, owner, name, [issue["number"] for issue in selected],
+    )
+    managed = []
+    for issue in selected:
+        hydrated = bodies[issue["number"]]
+        candidate = {**issue, **hydrated}
+        if GOAL_BLOCK_START in candidate["body"]:
+            managed.append(candidate)
     records = []
     for issue in managed:
         try:
@@ -615,8 +740,9 @@ def github_repository_portfolio_snapshot(
         except (KeyError, TypeError, ValueError) as exc:
             findings.append({"code": "malformed_record", "goal": issue.get("number", "unknown"), "detail": str(exc)})
     snapshot = build_portfolio_snapshot(
-        project["backend"], records, reads=len(pages), raw_bytes=len(result.stdout.encode("utf-8")),
-        ignored=len(issues) - len(managed),
+        project["backend"], records, reads=len(pages) + hydration_processes,
+        raw_bytes=len(result.stdout.encode("utf-8")) + hydration_bytes,
+        ignored=len(indexed_issues) - len(managed),
         git_policy=next(
             (
                 section["settings"] for section in ((project.get("policy") or {}).get("sections") or [])
@@ -630,7 +756,9 @@ def github_repository_portfolio_snapshot(
     snapshot["summary"]["findings"] = len(snapshot["findings"])
     snapshot["complete"] = not findings
     snapshot["valid"] = not snapshot["findings"]
-    snapshot["summary"]["processes"] = 1
+    snapshot["summary"]["discovery_raw_bytes"] = len(result.stdout.encode("utf-8"))
+    snapshot["summary"]["hydration_raw_bytes"] = hydration_bytes
+    snapshot["summary"]["processes"] = 1 + hydration_processes
     return repository_probe, compact_portfolio_output(snapshot)
 
 
@@ -875,6 +1003,7 @@ def decision_checkpoint(repo: Path, include_feedback: bool = False) -> dict[str,
         github_processes = 1 if github_available else 0
         try:
             github_repository, portfolio = github_repository_portfolio_snapshot(repo, state, include_feedback)
+            github_processes = int(portfolio.get("summary", {}).get("processes", github_processes))
             github_auth = {"available": True, "ok": True, "detail": "github.com"}
         except ValueError as exc:
             detail = sanitize_output(str(exc))

--- a/.zzzops/ZZZOPS_LOCK.json
+++ b/.zzzops/ZZZOPS_LOCK.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "revision": "81d293533dc58c255c2ed1651e33f2c2fa744ece",
-  "version": "v1.0.0-100-g81d2935",
+  "revision": "efde09132ff1806ebbd9c2a13fb1e3a6b62a53a0",
+  "version": "v1.0.0-103-gefde091",
   "files": {
     ".agents/skills/add-zzzops-goal/SKILL.md": "86c408ae0b8a1a18cd86b1a8b470af7925bc5a49996b70baf16452d13d7b72c6",
     ".agents/skills/add-zzzops-goal/agents/openai.yaml": "f1deff9c5f87c3c72ae8584a4b35423bbde401cf7aab3314953ad9d6d168239d",
@@ -34,7 +34,7 @@
     ".agents/zzzops/templates/project-goals/MIGRATION_STATE.json": "0343639fac1511a32a4c9a92c7655a6e9f9ad3a600fc6f30b5bdad6806160a97",
     ".agents/zzzops/templates/project-goals/MIGRATION_SUMMARY.md": "8fd4826d3352e7bdc43943e0fa9721dee0e133b3f6b138dd6fae751e6a85f770",
     ".agents/zzzops/templates/project-goals/ZZZOPS_GITIGNORE": "353f71c5c4e1a9d2199db0d276493be9266b3fdd6295c1888e44bfbd173dd6ab",
-    ".agents/zzzops/zzzops.py": "7a073d1865eeff63cf1a54aa2e97bb55c61e9dce0fee92fec25aeaa00587c5b6",
+    ".agents/zzzops/zzzops.py": "8a13ada1dbf00f650a06741f425fb87c2052b706acc553126a9f2cc5d2fc7d73",
     ".zzzops/rules/BACKENDS.md": "2ddded525dc06a42d714001fe68693361be2db3d026ea86df6a5b01eac13c460",
     ".zzzops/rules/BLOCKERS.md": "9188bb5ef85ae521df8e9b1cbff9c773e4639e745f4cf037304cec345f2b9ea6",
     ".zzzops/rules/CONTINUATION.md": "78cdb44777015a9fbb2dc24e5954582824c01ff03a76f6da32e58ef923d1b2dd",


### PR DESCRIPTION
## Outcome

Implements [#218](https://github.com/david-rzepa/zzzops/issues/218) as the first child of [#217](https://github.com/david-rzepa/zzzops/issues/217).

- fetches only issue number, title, state, and labels during repository-wide discovery
- derives schema version from a label and reconstructs issue URLs
- hydrates selected current bodies in bounded batches
- keeps comment history behind a separate single-goal read
- exposes discovery versus hydration byte measurements

## Evidence

- focused staged-read, history, identity, failure, and projection probes pass
- real 54-goal checkpoint: 10,963 discovery bytes versus the 290,990-byte full-projection baseline
- machinery lock validates and the checkpoint reports zero portfolio findings

Closes #218