### PR TITLE
fix(policy): skip redundant unchanged approval

### DIFF
--- a/.agents/prompt_stats.py
+++ b/.agents/prompt_stats.py
@@ -60,7 +60,7 @@ WORKFLOW_PROMPTS = {
 WORKFLOW_SIGNALS = {
     "capture": ("duplicate/relationship checks", "adaptive requirements interview", "sole stakeholder", "active same-task execute intent"),
     "execution": ("complete:true", "smallest falsifiable chunk", "difficulty is cost, not value", "human_after_checks", "Execution assumes the user is absent", "continue while policy permits safe useful work"),
-    "policy-review": ("only this workflow changes or confirms policy", "explicit approval of the current digest", "execution-report recording"),
+    "policy-review": ("only this workflow changes or confirms policy", "explicit approval of the current digest", "The policy is already approved", "privacy-safe execution reports"),
     "migration": ("explicit completeness review", "preserve every source location", "apply only after explicit approval"),
     "suggestion": ("no-write default", "zzzops-refill", "never copy source labels"),
     "acceptance": ("exactly one active item", "Never infer an ID", "blockers unchecked"),

--- a/.agents/skills/review-zzzops-policy/SKILL.md
+++ b/.agents/skills/review-zzzops-policy/SKILL.md
@@ -7,8 +7,8 @@ description: Review, initialize, summarize, reconcile, or adjust ZzzOps project 
 
 Follow `.zzzops/rules/INITIALIZATION.md`; only this workflow changes or confirms policy.
 
-Before `init inspect`, check INITIALIZATION's exact installer commit scope. If pending, ask: `The ZzzOps installation needs to be committed before policy review. Would you like me to commit the lock file and related ZzzOps installation changes now? I will leave unrelated changes untouched.` Stop for the answer; after yes, commit only that scope. Then run `init inspect` once, summarize choices, and invite adjustments. Include execution-report recording (default enabled; may be disabled).
+Before `init inspect`, check INITIALIZATION's installer commit scope. If pending, ask: `The ZzzOps installation needs to be committed before policy review. Would you like me to commit the lock file and related ZzzOps installation changes now? I will leave unrelated changes untouched.` Stop for the answer; after yes commit only that scope. Inspect once and summarize meaningful choices, including whether privacy-safe execution reports are enabled.
 
-Ask consequential questions only. Only explicit approval of the current digest confirms review; ask for it alone. Then confirm and checkpoint once. Ask separately before committing policy changes or handling PR closure.
+For valid canonical policy with a current approval digest and all required sections approved, say `The policy is already approved.` Do not ask for approval or run `init confirm`; invite adjustments and checkpoint. Changed/stale artifacts or digest, pending sections, and new proposals require explicit approval of the current digest alone, then confirmation and checkpoint. Ask consequential questions only. Ask separately before policy commits or PR handling.
 
 Before stopping or handing off, apply `.zzzops/rules/FEEDBACK.md`.

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -2051,6 +2051,18 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("Would you like me to commit the lock file", review_skill)
         self.assertIn("Stop for the answer", review_skill)
         self.assertIn("Ask separately", review_skill)
+        for text in (review_skill, initialization):
+            self.assertIn("The policy is already approved.", text)
+            self.assertIn("Do not ask for approval", text)
+            self.assertIn("do not", text.lower())
+            self.assertIn("`init confirm`", text)
+            self.assertIn("approval digest", text)
+            self.assertIn("required section", text)
+            self.assertIn("Changed/stale", text)
+            self.assertIn("privacy-safe execution reports", text)
+        engine = (root / "zzzops" / "installer.py").read_text(encoding="utf-8")
+        self.assertIn('add_tree(result, source, f".agents/skills/{name}")', engine)
+        self.assertIn('add_tree(result, source, f".claude/skills/{name}")', engine)
 
     def test_skills_apply_shared_privacy_safe_feedback_handoff(self):
         root = Path(__file__).parent / "skills"

--- a/.zzzops/ZZZOPS_LOCK.json
+++ b/.zzzops/ZZZOPS_LOCK.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "revision": "81d293533dc58c255c2ed1651e33f2c2fa744ece",
-  "version": "v1.0.0-100-g81d2935",
+  "revision": "05a925de189b833ce69d0c4f25ecb117fc06ffc7",
+  "version": "v1.0.0-103-g05a925d",
   "files": {
     ".agents/skills/add-zzzops-goal/SKILL.md": "86c408ae0b8a1a18cd86b1a8b470af7925bc5a49996b70baf16452d13d7b72c6",
     ".agents/skills/add-zzzops-goal/agents/openai.yaml": "f1deff9c5f87c3c72ae8584a4b35423bbde401cf7aab3314953ad9d6d168239d",
@@ -16,7 +16,7 @@
     ".agents/skills/migrate-to-zzzops/agents/openai.yaml": "796e0267f1471dfe7733843fb3a96f0c27a9a4cfa1e2270033320e7964b68f62",
     ".agents/skills/migrate-to-zzzops/scripts/inventory.py": "98fe5e34d7d8c7ed337143ef80c006be2a7da6c1e18e774924fb58198f698f71",
     ".agents/skills/migrate-to-zzzops/scripts/test_inventory.py": "50e429f851aade4268907037a78584a391d1b26a4ceb7ff9735fb06069519def",
-    ".agents/skills/review-zzzops-policy/SKILL.md": "17cb2d6e375508900d5168ce108d74906bf6f989bcd4e81096dbfe3d153fac9d",
+    ".agents/skills/review-zzzops-policy/SKILL.md": "c8785f34bb55c465afe07e186879d4c712f65958635ef622946c6ce35548cc8c",
     ".agents/skills/review-zzzops-policy/agents/openai.yaml": "75db2f7e65c73e8522d7aba9e3c165c64b1be168bd320803df73852e5b597993",
     ".agents/skills/send-zzzops-feedback/SKILL.md": "a2f5f6e9c911d4b68ae3bde7b4656367a14ff10b73396d76e87c058235fe25e2",
     ".agents/skills/send-zzzops-feedback/agents/openai.yaml": "30a405fc7ed61cf47b9f44c99ce3c0715105ca1658ed25115e390fde019a9f47",
@@ -41,6 +41,6 @@
     ".zzzops/rules/EXECUTION_STRATEGY.md": "8f7031cab4b9215c23c191ec13d4c9ac77720fd4690c043fee7aa058b46be938",
     ".zzzops/rules/FEEDBACK.md": "68b67b809de403a00eae86bae54a09d944d59799a8c44ddff01669670c7331c1",
     ".zzzops/rules/GOAL_SYSTEM.md": "459ae32f1df9adabb00f8f15f976cdfd834ec7b3adbec6aefdf6d1e55583ad7f",
-    ".zzzops/rules/INITIALIZATION.md": "a0f8c36704c2ebc4b166ef45c869cdb64afbdc58885684c33ef99464e4677e1a"
+    ".zzzops/rules/INITIALIZATION.md": "40df128ca26405acb965b5f0a7e15451281c846ad5bf0211923c72e81427c27d"
   }
 }

--- a/.zzzops/rules/INITIALIZATION.md
+++ b/.zzzops/rules/INITIALIZATION.md
@@ -1,21 +1,17 @@
 # Initialization preflight
 
-Installed workflows run this before ordinary work; installers do not. Defer invalid or unreviewed policy to `$review-zzzops-policy`.
+Run this before ordinary installed workflows. Defer invalid/unreviewed policy to `$review-zzzops-policy`.
 
-1. Resolve Python 3.10 or newer once: prefer harness discovery, else probe `python3`, `python`, and Windows `py -3` together. Reject an older interpreter. Reuse the exact `<python>` command; never hard-code a harness path. If none works, block once with the observed version and actionable install/selection detail.
-2. For reviewed policy run `<python> .agents/zzzops/zzzops.py --repo . checkpoint` once. Under Codex, use scoped approved authenticated context for the first attempt at checkpoint and `gh`; keep local-only commands in the normal sandbox. Never reauthenticate or persistently relax the sandbox. Elsewhere retry once after unexpected auth failure. Machinery must match committed `.zzzops/ZZZOPS_LOCK.json`; drift requires the installer, never checkpoint repair or a machinery commit. Continue only on `ready:true` with its complete valid portfolio; do not re-read it.
-3. `$review-zzzops-policy` handles initialization/reconciliation. Before `init inspect`, check Git for the installer scope: lock, scoped ignores, and legacy machinery deletions. If pending, ask to commit it first; after yes commit only that scope, never policy or unrelated changes. Then inspect instructions, repository evidence, CI/settings, tools, capabilities, and size. Copy `INIT_PLAN.json` to ignored `.zzzops/init/plan.json`; replace placeholders with evidence or labeled defaults. Safety/authority is invariant; operational defaults are policy. Never make safety optional.
-4. Summarize evidence, conflicts, defaults, capability, and consequential unknowns; interview compactly once. User/repository evidence wins. Unavailable decisions become blockers, never inferred approval.
-5. After proposal approval run `init validate`, then `init apply`. It writes pending charter/audit/policy, not initialization. Summarize meaningful choices/conflicts and invite adjustment.
-6. Stop for explicit review confirmation, then run `init confirm --policy-digest DIGEST --reviewer NAME --all` (or repeated `--section ID`). Bound artifact/policy changes stale approval; unchecked required sections remain `decision` blockers. Hide the digest unless needed.
-7. Run `checkpoint`. If review changed policy/instructions, separately ask to commit that scope. Do not stage/commit unless asked. Continue under policy. Initialization makes no Git/GitHub writes. Later reviews resummarize.
+1. Resolve Python 3.10 or newer once: use harness discovery or probe `python3`, `python`, and Windows `py -3` together; reject an older interpreter. Reuse `<python>`, never a hard-coded harness path. If none works, block once with observed version and install/selection action.
+2. For reviewed policy run `<python> .agents/zzzops/zzzops.py --repo . checkpoint` once. Under Codex, use scoped approved authenticated context for the first attempt at checkpoint/`gh`; keep local-only commands in the normal sandbox. Never reauthenticate or persistently relax the sandbox; elsewhere retry one unexpected auth failure. Machinery must match committed `.zzzops/ZZZOPS_LOCK.json`; drift requires reinstall. Continue only on `ready:true` with a complete valid portfolio; do not re-read it.
+3. `$review-zzzops-policy` owns initialization/reconciliation. Before `init inspect`, check installer lock, scoped ignores, and legacy deletions. If pending, ask to commit it first; after yes commit only that scope, never policy or unrelated changes. Inspect evidence, CI/settings, tools, capability, and size. Put evidenced/labeled defaults in ignored `.zzzops/init/plan.json` from `INIT_PLAN.json`. Safety/authority is invariant; operations are policy.
+4. Summarize evidence, conflicts, defaults, capability, consequential unknowns, and whether privacy-safe execution reports are enabled. Interview compactly once; evidence wins and unavailable decisions block.
+5. For valid canonical artifacts with a current approval digest and every required section approved, say `The policy is already approved.` Do not ask for approval; do not run `init confirm`. Invite adjustments, then checkpoint. Only exact unchanged state qualifies.
+6. Otherwise, after proposal approval run `init validate`, then `init apply`; it writes pending policy. Summarize and invite adjustment. Changed/stale artifacts or digest, pending required sections, and new proposals require explicit confirmation; then run `init confirm --policy-digest DIGEST --reviewer NAME --all` (or repeated `--section ID`). Bound changes stale approval; unchecked required sections stay blocked. Hide the digest unless needed.
+7. Run `checkpoint`. If policy/instructions changed, separately ask to commit them; never stage without approval. Continue under policy. Initialization makes no Git/GitHub writes. Later reviews resummarize.
 
-Unsupported/partial state, identity drift, or policy-evidence conflict stops affected work. There is no prior-schema migration path. Never reset or invent fallback authority.
+Unsupported state, identity drift, or policy-evidence conflict stops affected work. Never reset or invent fallback authority.
 
 ## User-facing communication
 
-Apply reviewed PROJECT communication policy. During initialization propose this operational fallback unless evidence supports another style.
-
-Let canonical state hold audit detail. Lead with the outcome. If needed ask for one clear action, why, and what follows; otherwise state changes and remaining work briefly.
-
-Keep mechanics and exhaustive lists internal unless needed. Name uncertainty. Never hide safety, destructive effects, authority, or consequential tradeoffs.
+Apply PROJECT communication policy. Lead with outcome. Ask one clear action with reason/next step only when needed; otherwise state changes/work. Keep mechanics and exhaustive lists internal. Name uncertainty; expose safety, destructive effects, authority, and consequential tradeoffs.


### PR DESCRIPTION
## Outcome

Closes [#222](https://github.com/david-rzepa/zzzops/issues/222).

- unchanged, valid, fully approved canonical policy is stated as already approved
- no redundant approval question or confirmation write occurs
- changed, stale, pending, and proposed policy still requires explicit approval
- installation commit authorization remains first and separate
- the shared source ships the behavior to Codex and Claude

## Evidence

- focused shipped-workflow contract probe passes
- prompt budget passes at about 14,386 tokens without raising the ceiling
- installation lock and normal checkpoint validate with zero portfolio findings