### PR TITLE
feat(goals): preserve compact transition history

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -874,8 +874,10 @@ class FakeGoalTransitionAdapter:
         self.repository = "owner/repo"
         self.issue = json.loads(json.dumps(issue))
         self.updates = []
+        self.comments = []
         self.failure = None
         self.response_mutation = None
+        self.comment_response_mutation = None
 
     def get_issue(self, number):
         self.assert_number(number)
@@ -889,10 +891,28 @@ class FakeGoalTransitionAdapter:
         updated = json.loads(json.dumps(self.issue))
         updated.update({"body": payload["body"], "state": payload["state"], "updated_at": "2026-07-21T21:00:00Z"})
         updated["labels"] = [{"name": label} for label in payload["labels"]]
-        if self.response_mutation:
-            self.response_mutation(updated)
         self.issue = updated
-        return json.loads(json.dumps(updated))
+        response = json.loads(json.dumps(updated))
+        if self.response_mutation:
+            self.response_mutation(response)
+        return response
+
+    def get_issue_comments(self, number):
+        self.assert_number(number)
+        return json.loads(json.dumps(self.comments))
+
+    def create_issue_comment(self, number, body):
+        self.assert_number(number)
+        comment = {
+            "id": len(self.comments) + 1, "body": body,
+            "html_url": f"https://github.com/owner/repo/issues/42#issuecomment-{len(self.comments) + 1}",
+        }
+        self.comments.append(json.loads(json.dumps(comment)))
+        self.issue["updated_at"] = "2026-07-21T20:30:00Z"
+        response = json.loads(json.dumps(comment))
+        if self.comment_response_mutation:
+            self.comment_response_mutation(response)
+        return response
 
     @staticmethod
     def assert_number(number):
@@ -939,6 +959,7 @@ class GoalTransitionTests(unittest.TestCase):
         adapter = FakeGoalTransitionAdapter(issue)
         result = zzzops.apply_goal_transition(adapter, "owner/repo", 42, self.transition(issue))
         self.assertEqual(1, len(adapter.updates))
+        self.assertEqual(1, len(adapter.comments))
         payload = adapter.updates[0]
         self.assertTrue(payload["body"].startswith("## Outcome / Why\n\nPreserve this human text."))
         self.assertEqual("open", payload["state"])
@@ -948,6 +969,10 @@ class GoalTransitionTests(unittest.TestCase):
         )
         self.assertEqual({"number": 42, "revision": 2, "state": "open", "status": "blocked",
                           "url": "https://github.com/owner/repo/issues/42"}, result)
+        history = zzzops.parse_goal_history(adapter.comments[0]["body"])
+        self.assertEqual(issue["body"], history["prior_body"])
+        self.assertEqual(["Baseline."], history["requested_goal"]["evidence"])
+        self.assertEqual([], zzzops.parse_managed_goal(payload["body"], 42)["evidence"])
 
         adapter = FakeGoalTransitionAdapter(issue)
         transition = self.transition(issue)
@@ -979,13 +1004,68 @@ class GoalTransitionTests(unittest.TestCase):
         adapter.failure = "provider failed"
         with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "provider failed"):
             zzzops.apply_goal_transition(adapter, "owner/repo", 42, self.transition(issue))
-        self.assertEqual(issue, adapter.issue)
+        self.assertEqual(issue["body"], adapter.issue["body"])
+        self.assertEqual("2026-07-21T20:30:00Z", adapter.issue["updated_at"])
+        self.assertEqual(1, len(adapter.comments))
+
+        adapter.failure = None
+        result = zzzops.apply_goal_transition(adapter, "owner/repo", 42, self.transition(issue))
+        self.assertEqual(1, len(adapter.comments))
+        self.assertEqual(2, result["revision"])
 
         adapter = FakeGoalTransitionAdapter(issue)
         adapter.response_mutation = lambda updated: updated.update({"body": "unexpected"})
         with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "unexpected"):
             zzzops.apply_goal_transition(adapter, "owner/repo", 42, self.transition(issue))
         self.assertEqual(1, len(adapter.updates))
+        result = zzzops.apply_goal_transition(adapter, "owner/repo", 42, self.transition(issue))
+        self.assertEqual(1, len(adapter.updates))
+        self.assertEqual(1, len(adapter.comments))
+        self.assertEqual(2, result["revision"])
+
+    def test_transition_compacts_history_sections_and_recovers_comment_confirmation(self):
+        issue = self.issue()
+        issue["body"] = zzzops.render_managed_goal(
+            self.goal(),
+            "## Outcome / Why\n\nKeep this.\n\n```md\n## Evidence\nKeep fenced example.\n```\n\n"
+            "## Evidence\n\nArchive this.\n\n## Scope\n\nKeep scope.\n",
+            42,
+        )
+        transition = self.transition(issue)
+        transition["goal"]["blockers"].append({
+            "id": "B-old", "status": "resolved", "category": "human-action", "resolution": "Done",
+        })
+        adapter = FakeGoalTransitionAdapter(issue)
+        adapter.comment_response_mutation = lambda comment: comment.update({"body": "unconfirmed"})
+        self.assertIn("transition evidence", zzzops.validate_compact_goal_body(issue["body"], 42)[0])
+
+        with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "exact transition history"):
+            zzzops.apply_goal_transition(adapter, "owner/repo", 42, transition)
+        self.assertEqual([], adapter.updates)
+        self.assertEqual(1, len(adapter.comments))
+
+        adapter.comment_response_mutation = None
+        zzzops.apply_goal_transition(adapter, "owner/repo", 42, transition)
+        self.assertEqual(1, len(adapter.comments))
+        self.assertNotIn("Archive this.", adapter.issue["body"])
+        self.assertIn("Keep fenced example.", adapter.issue["body"])
+        self.assertIn("## Outcome / Why", adapter.issue["body"])
+        self.assertIn("## Scope", adapter.issue["body"])
+        compact = zzzops.parse_managed_goal(adapter.issue["body"], 42)
+        self.assertEqual([], compact["evidence"])
+        self.assertEqual(["B-001"], [blocker["id"] for blocker in compact["blockers"]])
+        self.assertEqual([], zzzops.validate_compact_goal_body(adapter.issue["body"], 42))
+
+        history = zzzops.parse_goal_history(adapter.comments[0]["body"])
+        tampered = json.loads(json.dumps(history))
+        tampered["prior_body"] += "tampered"
+        tampered_body = (
+            f"{zzzops._goals.GOAL_HISTORY_BLOCK_START}\n"
+            f"{json.dumps(tampered, sort_keys=True, separators=(',', ':'))}\n"
+            f"{zzzops._goals.GOAL_HISTORY_BLOCK_END}\n"
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid goal history payload"):
+            zzzops.parse_goal_history(tampered_body)
 
     def test_transition_file_is_bom_tolerant(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -1007,6 +1087,28 @@ class GoalTransitionTests(unittest.TestCase):
             run.call_args.args[0],
         )
         self.assertEqual(payload, json.loads(run.call_args.kwargs["input"]))
+
+    @mock.patch.object(zzzops.shutil, "which", return_value="gh")
+    @mock.patch.object(zzzops.subprocess, "run")
+    def test_github_transition_adapter_reads_and_appends_selected_history(self, run, _which):
+        comment = {"id": 9, "body": "history", "html_url": "https://example.test/comment/9"}
+        run.side_effect = [
+            SimpleNamespace(returncode=0, stderr="", stdout=json.dumps({
+                "nameWithOwner": "owner/repo", "hasIssuesEnabled": True, "viewerPermission": "ADMIN",
+            })),
+            SimpleNamespace(returncode=0, stderr="", stdout=json.dumps([[comment]])),
+            SimpleNamespace(returncode=0, stderr="", stdout=json.dumps(comment)),
+        ]
+        adapter = zzzops.GitHubGoalTransitionAdapter(Path.cwd(), "owner/repo")
+
+        self.assertEqual([comment], adapter.get_issue_comments(42))
+        self.assertEqual(comment, adapter.create_issue_comment(42, "history"))
+
+        read_command = run.call_args_list[1].args[0]
+        self.assertEqual(["gh", "api", "--paginate", "--slurp", "repos/owner/repo/issues/42/comments?per_page=100"], read_command)
+        write_command = run.call_args_list[2].args[0]
+        self.assertEqual(["gh", "api", "--method", "POST", "repos/owner/repo/issues/42/comments", "--input", "-"], write_command)
+        self.assertEqual({"body": "history"}, json.loads(run.call_args_list[2].kwargs["input"]))
 
 
 class PortfolioTests(unittest.TestCase):

--- a/.agents/zzzops/goals.py
+++ b/.agents/zzzops/goals.py
@@ -13,6 +13,9 @@ from typing import Any, Callable
 GOAL_SCHEMA_VERSION = 1
 GOAL_BLOCK_START = "<!-- zzzops-goal"
 GOAL_BLOCK_END = "zzzops-goal -->"
+GOAL_HISTORY_BLOCK_START = "<!-- zzzops-history"
+GOAL_HISTORY_BLOCK_END = "zzzops-history -->"
+GOAL_HISTORY_SCHEMA_VERSION = 1
 GOAL_FIELDS = {
     "schema_version", "status", "priority", "value", "difficulty", "confidence",
     "parent", "depends_on", "claim", "blockers", "evidence", "next_action",
@@ -27,6 +30,10 @@ GOAL_TRANSITION_SCHEMA_VERSION = 1
 GOAL_TRANSITION_FIELDS = {"schema_version", "expected_revision", "expected_digest", "goal"}
 BLOCKER_CATEGORIES = {"specification", "decision", "access-approval", "human-action", "external-dependency", "technical-unknown", "safety-compliance"}
 REDUNDANT_GOAL_TITLE_PREFIX = re.compile(r"^\[G-\d{8}-\d{3}-[^\]]+\]\s*")
+HISTORICAL_HUMAN_SECTIONS = {
+    "completed evidence", "evidence", "history", "implementation history",
+    "prior checkpoints", "resolved blockers", "superseded requirements",
+}
 _normalize_resources: Callable[[Any], list[str]] | None = None
 _text_present: Callable[[Any], bool] | None = None
 
@@ -141,6 +148,144 @@ def render_managed_goal(goal: dict[str, Any], body: str = "", issue_number: int 
     return f"{body}{separator}{block}\n"
 
 
+def compact_human_goal_text(body: str) -> str:
+    """Retain current human sections while removing explicitly historical sections."""
+    human = body.split(GOAL_BLOCK_START, 1)[0].strip("\ufeff\r\n ")
+    sections: list[list[str]] = []
+    fence: tuple[str, int] | None = None
+    for line in human.splitlines():
+        marker = re.match(r"^\s*(`{3,}|~{3,})", line)
+        if marker:
+            token = marker.group(1)
+            if fence is None:
+                fence = (token[0], len(token))
+            elif token[0] == fence[0] and len(token) >= fence[1]:
+                fence = None
+        if fence is None and re.match(r"^##\s+", line) and sections and sections[-1]:
+            sections.append([])
+        if not sections:
+            sections.append([])
+        sections[-1].append(line)
+    kept = []
+    for section in sections:
+        text = "\n".join(section).strip()
+        if not text:
+            continue
+        heading = section[0]
+        normalized = re.sub(r"\s+", " ", heading.removeprefix("##").strip()).casefold()
+        if normalized in HISTORICAL_HUMAN_SECTIONS:
+            continue
+        kept.append(text)
+    return "\n\n".join(kept) + "\n"
+
+
+def compact_managed_goal(goal: dict[str, Any]) -> dict[str, Any]:
+    """Project requested transition state into the current-state-only body schema."""
+    compact = json.loads(json.dumps(goal))
+    compact["evidence"] = []
+    compact["blockers"] = [
+        blocker for blocker in compact.get("blockers", [])
+        if isinstance(blocker, dict) and blocker.get("status") == "open"
+    ]
+    return compact
+
+
+def validate_compact_goal_body(body: Any, issue_number: int | None = None) -> list[str]:
+    if not isinstance(body, str):
+        return ["compact goal body must be text"]
+    errors = []
+    try:
+        goal = parse_managed_goal(body, issue_number)
+    except ValueError as exc:
+        return [str(exc)]
+    if goal is None:
+        return ["managed goal block is required"]
+    if goal.get("evidence"):
+        errors.append("current managed state must not retain transition evidence")
+    if any(not isinstance(blocker, dict) or blocker.get("status") != "open" for blocker in goal.get("blockers", [])):
+        errors.append("current managed state may contain only open blockers")
+    human = body.split(GOAL_BLOCK_START, 1)[0].strip("\ufeff\r\n ") + "\n"
+    if compact_human_goal_text(body) != human:
+        errors.append("current human text contains an explicitly historical section")
+    return errors
+
+
+def goal_history_id(issue_number: int, expected_digest: str, desired: dict[str, Any]) -> str:
+    source = json.dumps(
+        {"issue": issue_number, "expected_digest": expected_digest, "desired": compact_managed_goal(desired)},
+        ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    )
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def render_goal_history(
+    issue_number: int, expected_digest: str, prior_body: str, desired: dict[str, Any],
+) -> tuple[str, str]:
+    """Render one lossless, deterministic append-only transition record."""
+    history_id = goal_history_id(issue_number, expected_digest, desired)
+    payload = {
+        "schema_version": GOAL_HISTORY_SCHEMA_VERSION,
+        "id": history_id,
+        "issue": issue_number,
+        "expected_digest": expected_digest,
+        "from_revision": desired["revision"] - 1,
+        "to_revision": desired["revision"],
+        "prior_body": prior_body,
+        "requested_goal": desired,
+    }
+    payload["payload_digest"] = hashlib.sha256(json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    ).encode("utf-8")).hexdigest()
+    block = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return history_id, (
+        f"## ZzzOps transition history\n\n"
+        f"Archived canonical state before revision {desired['revision']}.\n\n"
+        f"{GOAL_HISTORY_BLOCK_START}\n{block}\n{GOAL_HISTORY_BLOCK_END}\n"
+    )
+
+
+def parse_goal_history(body: Any) -> dict[str, Any] | None:
+    if not isinstance(body, str):
+        return None
+    pattern = re.compile(
+        re.escape(GOAL_HISTORY_BLOCK_START) + r"\s*\n(.*?)\n" + re.escape(GOAL_HISTORY_BLOCK_END),
+        re.DOTALL,
+    )
+    match = pattern.search(body)
+    if not match:
+        return None
+    try:
+        payload = json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid goal history JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Invalid goal history payload")
+    digest = payload.get("payload_digest")
+    digest_payload = {key: value for key, value in payload.items() if key != "payload_digest"}
+    calculated_digest = hashlib.sha256(json.dumps(
+        digest_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    ).encode("utf-8")).hexdigest()
+    if (
+        payload.get("schema_version") != GOAL_HISTORY_SCHEMA_VERSION
+        or not isinstance(payload.get("id"), str)
+        or not re.fullmatch(r"[0-9a-f]{64}", payload["id"])
+        or not isinstance(payload.get("issue"), int)
+        or isinstance(payload.get("issue"), bool)
+        or payload["issue"] < 1
+        or not isinstance(payload.get("expected_digest"), str)
+        or not re.fullmatch(r"[0-9a-f]{64}", payload["expected_digest"])
+        or not isinstance(payload.get("prior_body"), str)
+        or not isinstance(payload.get("requested_goal"), dict)
+        or not isinstance(digest, str)
+        or not hmac.compare_digest(digest, calculated_digest)
+        or not hmac.compare_digest(
+            payload["id"], goal_history_id(payload["issue"], payload["expected_digest"], payload["requested_goal"])
+        )
+    ):
+        raise ValueError("Invalid goal history payload")
+    return payload
+
+
 def goal_needs_human(goal: dict[str, Any]) -> bool:
     return any(
         isinstance(blocker, dict)
@@ -186,7 +331,7 @@ def github_goal_record(issue: dict[str, Any]) -> dict[str, Any]:
     errors = validate_github_issue_goal(number, issue.get("title"), body)
     if errors:
         raise ValueError("; ".join(errors))
-    digest_source = "\0".join((issue.get("title") or "", body, issue.get("updated_at") or ""))
+    digest_source = "\0".join((issue.get("title") or "", body))
     return {
         "key": number, "title": issue["title"], "status": goal["status"],
         "priority": goal["priority"], "value": goal["value"], "difficulty": goal["difficulty"],
@@ -250,6 +395,44 @@ def apply_goal_transition(
         record = github_goal_record(issue)
     except ValueError as exc:
         raise GoalTransitionProviderError("The current goal could not be validated; no goal update was made.") from exc
+    requested = transition["goal"]
+    desired = compact_managed_goal(requested)
+    history_id = goal_history_id(issue_number, transition["expected_digest"], requested)
+    comments = adapter.get_issue_comments(issue_number)
+    histories = []
+    for comment in comments:
+        try:
+            history = parse_goal_history(comment.get("body") if isinstance(comment, dict) else None)
+        except ValueError as exc:
+            raise GoalTransitionProviderError("The selected goal has malformed transition history; no update was made.") from exc
+        if history is not None and history.get("id") == history_id:
+            histories.append((comment, history))
+    if len(histories) > 1:
+        raise GoalTransitionProviderError("The selected goal has duplicate transition history; no update was made.")
+
+    state = "closed" if desired["status"] in {"done", "cancelled"} else "open"
+    if record["revision"] == desired["revision"]:
+        compact_body = render_managed_goal(desired, compact_human_goal_text(issue["body"]), issue_number)
+        returned_labels = {
+            label["name"] for label in issue.get("labels", [])
+            if isinstance(label, dict) and isinstance(label.get("name"), str)
+        }
+        if (
+            issue.get("body") == compact_body
+            and str(issue.get("state", "")).casefold() == state
+            and f"zzzops:status:{desired['status']}" in returned_labels
+            and f"zzzops:priority:{desired['priority']}" in returned_labels
+            and len(histories) == 1
+            and histories[0][1].get("issue") == issue_number
+            and histories[0][1].get("to_revision") == desired["revision"]
+            and histories[0][1].get("requested_goal") == requested
+        ):
+            return {
+                "number": issue_number, "revision": desired["revision"], "state": state,
+                "status": desired["status"], "url": f"https://github.com/{repository}/issues/{issue_number}",
+            }
+        raise ValueError(f"Goal #{issue_number} changed; the requested transition was not confirmed.")
+
     if record["revision"] != transition["expected_revision"]:
         raise ValueError(
             f"Goal #{issue_number} changed from revision {transition['expected_revision']} to {record['revision']}; no update was made."
@@ -257,8 +440,24 @@ def apply_goal_transition(
     if not hmac.compare_digest(record["digest"], transition["expected_digest"]):
         raise ValueError(f"Goal #{issue_number} digest changed; no update was made.")
 
-    desired = transition["goal"]
-    body = render_managed_goal(desired, issue["body"], issue_number)
+    body = render_managed_goal(desired, compact_human_goal_text(issue["body"]), issue_number)
+    compact_errors = validate_compact_goal_body(body, issue_number)
+    if compact_errors:
+        raise ValueError("Invalid compact goal body: " + "; ".join(compact_errors))
+    _, history_body = render_goal_history(
+        issue_number, transition["expected_digest"], issue["body"], requested,
+    )
+    if len(history_body) > 65536:
+        raise GoalTransitionProviderError("Transition history exceeds GitHub's comment limit; no update was made.")
+    if histories:
+        if histories[0][0].get("body") != history_body:
+            raise GoalTransitionProviderError("Existing transition history does not match the requested update.")
+    else:
+        created = adapter.create_issue_comment(issue_number, history_body)
+        if created.get("body") != history_body or not isinstance(created.get("html_url"), str):
+            raise GoalTransitionProviderError(
+                "GitHub did not confirm exact transition history; body replacement was not attempted."
+            )
     _, text_present = _require_configured()
     retained_labels = sorted({
         label["name"] for label in issue.get("labels", [])
@@ -268,7 +467,6 @@ def apply_goal_transition(
         and not label["name"].startswith("zzzops:priority:")
     })
     labels = ["zzzops", *retained_labels, f"zzzops:status:{desired['status']}", f"zzzops:priority:{desired['priority']}"]
-    state = "closed" if desired["status"] in {"done", "cancelled"} else "open"
     updated = adapter.update_issue(issue_number, {"body": body, "labels": labels, "state": state})
 
     expected_url = f"https://github.com/{repository}/issues/{issue_number}"

--- a/.agents/zzzops/zzzops.py
+++ b/.agents/zzzops/zzzops.py
@@ -153,6 +153,12 @@ compact_portfolio_output = _portfolio.compact_portfolio_output
 parse_managed_goal = _goals.parse_managed_goal
 validate_managed_goal = _goals.validate_managed_goal
 render_managed_goal = _goals.render_managed_goal
+compact_human_goal_text = _goals.compact_human_goal_text
+compact_managed_goal = _goals.compact_managed_goal
+validate_compact_goal_body = _goals.validate_compact_goal_body
+goal_history_id = _goals.goal_history_id
+render_goal_history = _goals.render_goal_history
+parse_goal_history = _goals.parse_goal_history
 goal_needs_human = _goals.goal_needs_human
 validate_github_issue_goal = _goals.validate_github_issue_goal
 github_goal_record = _goals.github_goal_record
@@ -264,6 +270,46 @@ class GitHubGoalTransitionAdapter:
                 "GitHub returned an incomplete goal-transition response; success was not assumed."
             )
         return issue
+
+    def get_issue_comments(self, number: int) -> list[dict[str, Any]]:
+        self.ensure_identity()
+        result = self._run([
+            "api", "--paginate", "--slurp",
+            f"repos/{self.repository}/issues/{number}/comments?per_page=100",
+        ])
+        if result.returncode:
+            raise self._provider_error(result)
+        try:
+            pages = json.loads(result.stdout)
+            if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+                raise TypeError("comment pages must be lists")
+            comments = [comment for page in pages for comment in page]
+            if any(not isinstance(comment, dict) for comment in comments):
+                raise TypeError("comments must be objects")
+            return comments
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise GoalTransitionProviderError(
+                "GitHub returned invalid goal history; no body update was made."
+            ) from exc
+
+    def create_issue_comment(self, number: int, body: str) -> dict[str, Any]:
+        result = self._run(
+            ["api", "--method", "POST", f"repos/{self.repository}/issues/{number}/comments", "--input", "-"],
+            input_text=json.dumps({"body": body}, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        )
+        if result.returncode:
+            raise self._provider_error(result)
+        try:
+            comment = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise GoalTransitionProviderError(
+                "GitHub returned an invalid history response; body replacement was not attempted."
+            ) from exc
+        if not isinstance(comment, dict):
+            raise GoalTransitionProviderError(
+                "GitHub returned an incomplete history response; body replacement was not attempted."
+            )
+        return comment
 
 
 _validate_reservation_goal = _reservation._validate_reservation_goal

--- a/.zzzops/ZZZOPS_LOCK.json
+++ b/.zzzops/ZZZOPS_LOCK.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "revision": "efde09132ff1806ebbd9c2a13fb1e3a6b62a53a0",
-  "version": "v1.0.0-103-gefde091",
+  "revision": "3b499edb28c647c0606883c1660c4767782376fb",
+  "version": "v1.0.0-106-g3b499ed",
   "files": {
     ".agents/skills/add-zzzops-goal/SKILL.md": "86c408ae0b8a1a18cd86b1a8b470af7925bc5a49996b70baf16452d13d7b72c6",
     ".agents/skills/add-zzzops-goal/agents/openai.yaml": "f1deff9c5f87c3c72ae8584a4b35423bbde401cf7aab3314953ad9d6d168239d",
@@ -23,7 +23,7 @@
     ".agents/skills/suggest-zzzops-work/SKILL.md": "a9ff3087d80da02b0ed6687c16ec2c793a07103b6ef69992b192da1970aeaa8e",
     ".agents/skills/suggest-zzzops-work/agents/openai.yaml": "9536a89c6d2b3bf0d62474a53a51a3325dc73c6c18dfe3b909a8314ba18e9ee3",
     ".agents/zzzops/feedback.py": "32e5974366148caf7e9b3ba835067449df04f5dcb226f3c4fee0f016533e46b1",
-    ".agents/zzzops/goals.py": "8824825af30b06aec70905451d823ca9390fda1b543e410724a2ab6b5eb6ea31",
+    ".agents/zzzops/goals.py": "6da3b33ce59e65df7dc7e4449030486d92b436727f62f04af24871d93f3d56e8",
     ".agents/zzzops/install_lock.py": "59004dd72ddb062fa9beb971ef47e3cb763aa6314d5a7abef818b5fcbfe30f11",
     ".agents/zzzops/installer.py": "76b01daeb69c8f4499a62e210cb06beceb603a6e42187ee48e48abf0f0f820cd",
     ".agents/zzzops/policy.py": "6fe9dbb418f698aa06ec11255cce40eacd1014ac27663618311625be4c6d8088",
@@ -34,13 +34,13 @@
     ".agents/zzzops/templates/project-goals/MIGRATION_STATE.json": "0343639fac1511a32a4c9a92c7655a6e9f9ad3a600fc6f30b5bdad6806160a97",
     ".agents/zzzops/templates/project-goals/MIGRATION_SUMMARY.md": "8fd4826d3352e7bdc43943e0fa9721dee0e133b3f6b138dd6fae751e6a85f770",
     ".agents/zzzops/templates/project-goals/ZZZOPS_GITIGNORE": "353f71c5c4e1a9d2199db0d276493be9266b3fdd6295c1888e44bfbd173dd6ab",
-    ".agents/zzzops/zzzops.py": "8a13ada1dbf00f650a06741f425fb87c2052b706acc553126a9f2cc5d2fc7d73",
-    ".zzzops/rules/BACKENDS.md": "2ddded525dc06a42d714001fe68693361be2db3d026ea86df6a5b01eac13c460",
+    ".agents/zzzops/zzzops.py": "064be341fc7a37d873ec7426e156273db5f2b848557d9a595035e434c7567ca6",
+    ".zzzops/rules/BACKENDS.md": "cf0c1e86c6ed8c459dc20648591ee166a6e8e64241faf56e0305490155336895",
     ".zzzops/rules/BLOCKERS.md": "9188bb5ef85ae521df8e9b1cbff9c773e4639e745f4cf037304cec345f2b9ea6",
     ".zzzops/rules/CONTINUATION.md": "78cdb44777015a9fbb2dc24e5954582824c01ff03a76f6da32e58ef923d1b2dd",
     ".zzzops/rules/EXECUTION_STRATEGY.md": "8f7031cab4b9215c23c191ec13d4c9ac77720fd4690c043fee7aa058b46be938",
     ".zzzops/rules/FEEDBACK.md": "68b67b809de403a00eae86bae54a09d944d59799a8c44ddff01669670c7331c1",
-    ".zzzops/rules/GOAL_SYSTEM.md": "459ae32f1df9adabb00f8f15f976cdfd834ec7b3adbec6aefdf6d1e55583ad7f",
+    ".zzzops/rules/GOAL_SYSTEM.md": "a0b831c3f3b52e1817a0ba6fc9297daf56e62666e5bf29def5d0c81d14d50baf",
     ".zzzops/rules/INITIALIZATION.md": "a0f8c36704c2ebc4b166ef45c869cdb64afbdc58885684c33ef99464e4677e1a"
   }
 }

--- a/.zzzops/rules/BACKENDS.md
+++ b/.zzzops/rules/BACKENDS.md
@@ -15,7 +15,8 @@ Ordinary checkpoints omit `zzzops-feedback`. `--include-feedback` requires one e
 - Identity is repository plus issue number/URL. Use a plain human title without ZzzOps/date ID; start with concise human sections, no rendered metadata/frontmatter or repeated title.
 - Explain that goals inherit repository visibility and forbid secrets/raw sensitive data.
 - Append one hidden `<!-- zzzops-goal ... zzzops-goal -->` JSON state block using `render_managed_goal`. GitHub supplies identity/title; inverse edges, human queue, labels, and open/closed are derived. Preserve unmanaged text.
-- Parent/dependencies are same-repository positive issue numbers; derive inverse edges portfolio-wide. Append resolutions/history as immutable-provenance comments.
+- Parent/dependencies are same-repository positive issue numbers; derive inverse edges portfolio-wide.
+- Keep bodies current-only: active human sections plus relationships, open blockers, next action, and compact managed state. Before replacement, confirm one lossless content-addressed history comment containing the prior body and requested transition. Retries reuse its transition ID and never duplicate confirmed history.
 - Use label `zzzops`, one `zzzops:status:*`, and one `zzzops:priority:*` as derived indexes.
 - Reservations use transient goal/resource labels; GitHub name uniqueness chooses one Issues-permitted winner. Metadata binds repository, goal/revision, owner/run, expiry; renew/recover by immutable node ID and exact readback so delayed cleanup cannot delete a replacement. Drift, conflict, malformed state, provider failure, or uncertainty denies ownership; no fallback lock.
 - Apply updates via `<python> .agents/zzzops/zzzops.py goal transition --goal N --input FILE`. UTF-8 input binds expected revision/digest to the next goal, preserves human text, derives labels/state, and validates the write.

--- a/.zzzops/rules/GOAL_SYSTEM.md
+++ b/.zzzops/rules/GOAL_SYSTEM.md
@@ -2,15 +2,13 @@
 
 ## Authority and records
 
-Order: user/safety; project instructions; reviewed `.zzzops/PROJECT.md` (bound to canonical policy); canonical GitHub issue. A repository-policy conflict invalidates the assumption: stop and reconcile rather than choosing silently.
+Order: user/safety; project instructions; reviewed `.zzzops/PROJECT.md`; canonical GitHub issue. Repository-policy conflict stops for reconciliation. Before non-install workflows follow `INITIALIZATION.md`, then `BACKENDS.md`.
 
-Before every non-install workflow follow `INITIALIZATION.md`, then use the GitHub Issues authority in `BACKENDS.md`.
-
-- Goal identity is repository plus issue number/URL; never invent another ID or duplicate GitHub title/relations in managed JSON.
+- Goal identity is repository plus issue number/URL; never invent IDs or duplicate provider-owned title/relations.
 - Never store secrets/raw sensitive data; link approved systems and name authority/sync direction.
-- The charter defines success/value. Preserve unknown KPIs/targets/tradeoffs; capture asks, while execution records blockers rather than inventing answers.
+- The charter defines value. Preserve unknown KPIs/targets/tradeoffs; capture asks and execution blocks rather than inventing answers.
 - Reviewed PROJECT holds operational choices; installed rules are overridable defaults, not another policy layer.
-- Initialization plans and migration artifact shapes live in `.agents/zzzops/templates/project-goals/`; `init apply` renders project state. Installation copies mechanics/templates only and never creates or overwrites project state.
+- Templates live in `.agents/zzzops/templates/project-goals/`; installation copies mechanics/templates, never project state.
 
 ## Lifecycle
 
@@ -36,19 +34,21 @@ Open blockers may coexist with active states while useful work remains. Reopen t
 
 ## Relationships and claims
 
-One parent maximum; any children/dependencies; reject self-links/cycles. GitHub stores only parent/dependency issue numbers and derives inverse edges portfolio-wide. Create a child only for a separately verifiable/prioritized/blocked/claimed outcome or distinct risk; use checklists otherwise. Obey PROJECT depth/required-child policy. Required children finishing does not replace parent criteria.
+One parent maximum; any children/dependencies; reject self-links/cycles. Store issue numbers and derive inverse edges. Use children only for distinct verifiable/prioritized/blocked/claimed outcomes or risks; otherwise use checklists. Obey PROJECT depth/required-child policy; children do not replace parent criteria.
 
-A dependency edge preserves required ancestry and final integration order. The installed default requires every dependency to be `done` before writable implementation begins. Reviewed PROJECT policy may override actionability; for example, `stack_from_reviewed_checkpoint` may permit a child to stack from an unfinished dependency's exact technically ready checkpoint while preserving merge order. Read-only investigation may prepare dependent work when policy allows, but it does not claim, edit, branch, or mark that implementation started.
+Dependencies preserve ancestry/integration order and default to `done` before writes. PROJECT may permit `stack_from_reviewed_checkpoint` while preserving merge order. Allowed read-only preparation never claims, edits, branches, or starts implementation.
 
-Before substantial GitHub work, declare `path:`, `branch:`, `integration:`, `generated:`, and `external:` resources; atomically reserve revision/resources with `<python> .agents/zzzops/zzzops.py reserve acquire --goal N --revision R --owner OWNER --run-id RUN`. Claims/branches are always exclusive. Default: text paths/integration targets are advisory; generated/external resources are exclusive. Policy may mark hard-to-merge paths, change configurable categories, or select strict mode. Only exclusive contention rejects bundles or creates `resource_collision`; reconcile advisory overlap in branch review. On contention refresh once and choose other work. Renew at checkpoints; release before blocking, terminal state, or handoff. Claims audit; reservations exclude. Never assume ownership; record expiry recovery.
+Declare `path:`, `branch:`, `integration:`, `generated:`, and `external:` resources; atomically reserve revision/resources with `<python> .agents/zzzops/zzzops.py reserve acquire --goal N --revision R --owner OWNER --run-id RUN`. Claims/branches are exclusive; paths/integration default advisory and generated/external resources exclusive unless PROJECT changes them. Exclusive contention rejects; reconcile advisory overlap. Refresh contention once, renew at checkpoints, and release before blocking/terminal/handoff. Never assume ownership; claims audit, reservations exclude.
 
 ## Update invariants
 
 One logical update: re-read affected records/premise; perform and observe work; update state, next action, evidence, blockers, and history. Prefer a smaller consistent update if interrupted.
+
+Use BACKENDS' current-body, append-first history, and idempotent retry contract.
 
 - Apply the PROJECT policy's triage/continuation order; every active goal has an action or gate.
 - Human blockers appear in the portfolio human queue; resolutions retain request/answer/resolver/date.
 - Checked criteria cite observed evidence. Reassess due reviews.
 - Follow `.zzzops/rules/EXECUTION_STRATEGY.md`: baseline and observable probe before implementation; coordinator reconciles parallel work.
 - Policy never justifies invented work, priority distortion, or busywork.
-- The installed initialization default enables exhausted-queue refill for documentation, test coverage, and non-behavioral code quality, capped at three goals per run. It takes effect only through reviewed PROJECT policy, which may override or disable it; never loop-refill.
+- Reviewed PROJECT may enable one capped exhausted-queue refill; never loop-refill or infer permission.


### PR DESCRIPTION
## Outcome

Tracks [#219](https://github.com/david-rzepa/zzzops/issues/219) under [#217](https://github.com/david-rzepa/zzzops/issues/217).

- writes a lossless content-addressed history comment before replacing selected goal bodies
- keeps only active human sections, open blockers, and compact managed state in the current body
- retries comment and PATCH ambiguity without duplicate history or repeated body writes
- detects malformed, duplicate, mismatched, oversized, or tampered history before replacement
- keeps comment-driven timestamp changes out of transition digests

## Evidence

- focused transition and staged-discovery probes pass
- prompt budget passes at about 14,223 tokens without raising the ceiling
- first live transition on #219 produced one history comment, preserved the prior state, and left revision 4 with zero evidence and zero resolved blockers in its current body
- installation lock exactly matches the committed machinery