### PR TITLE
docs(ci): clarify core validation scope

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   validate-linux:
-    name: Linux validation (Python ${{ matrix.python-version }})
+    name: Core validation (Linux, Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -22,7 +22,7 @@ The active `dev` ruleset targets only `refs/heads/dev` and:
 - requires the stable GitHub Actions check `dev-required-tests` (the rule does not require the branch to be current);
 - has an always-bypass RepositoryRole actor. Read the ruleset before relying on bypass scope; the current caller can bypass it.
 
-`dev-required-tests` is the stable aggregate emitted on every PR to `dev`. It succeeds only when Linux validation, Windows installer validation, and macOS installer validation have all succeeded. The workflow has no path filters, dynamic check names, secrets, or write permission, so protection can rely on that one stable context.
+`dev-required-tests` is the stable aggregate emitted on every PR to `dev`. It succeeds only when `Core validation (Linux, Python <version>)`, `Windows installer validation`, and `macOS installer validation` have all succeeded. The workflow has no path filters, dynamic check names, secrets, or write permission, so protection can rely on that one stable context.
 
 ## `main`
 


### PR DESCRIPTION
## Summary

- rename the Ubuntu/Python job to identify it as the core and repository validation surface
- align branch-protection documentation with the visible job names
- preserve all workflow commands, matrix entries, native installer jobs, and the stable `dev-required-tests` context

## Verification

- inspected the zero-context diff: exactly one workflow display name and one documentation sentence changed
- `git diff --check`
- required CI will validate the workflow at the exact PR head

Tracks #231
