### PR TITLE
feat(execution): describe work before each goal

### DIFF
--- a/.agents/prompt_stats.py
+++ b/.agents/prompt_stats.py
@@ -59,7 +59,7 @@ WORKFLOW_PROMPTS = {
 
 WORKFLOW_SIGNALS = {
     "capture": ("duplicate/relationship checks", "adaptive requirements interview", "sole stakeholder", "active same-task execute intent"),
-    "execution": ("complete:true", "smallest falsifiable chunk", "difficulty is cost, not value", "human_after_checks", "Execution assumes the user is absent", "continue while policy permits safe useful work"),
+    "execution": ("complete:true", "smallest falsifiable chunk", "difficulty is cost, not value", "human_after_checks", "Execution assumes the user is absent", "Before substantive work on a newly selected goal", "continue while policy permits safe useful work"),
     "policy-review": ("only this workflow changes or confirms policy", "explicit approval of the current digest", "The policy is already approved", "privacy-safe execution reports"),
     "migration": ("explicit completeness review", "preserve every source location", "apply only after explicit approval"),
     "suggestion": ("no-write default", "zzzops-refill", "never copy source labels"),

--- a/.agents/skills/execute-zzzops/references/EXECUTE.md
+++ b/.agents/skills/execute-zzzops/references/EXECUTE.md
@@ -5,13 +5,15 @@
 ## Select
 
 1. Read the charter and use the current BACKENDS checkpoint portfolio; never reread it. Require `complete:true` and `valid:true`; resolve findings instead of selecting from an invalid graph, and use its compact relationships/claims/reviews rather than rereading goals. If the human queue is non-empty, run `UNBLOCK.md` to order and persist consequential gates, then continue independently actionable work.
-   Specially tagged `zzzops-feedback` goals are absent unless the user approved them for this execution session. One session approval includes the whole feedback queue; never request approval per issue, and retain `--include-feedback` on every checkpoint refresh in that session.
+   `zzzops-feedback` goals appear only with current-session approval covering the whole queue; never ask per issue, and keep `--include-feedback` on every checkpoint refresh.
    Treat that complete checkpoint as the current queue read until a local state mutation, provider failure, explicit freshness requirement, or observed drift requires one refresh. Do not run an extra portfolio command merely to rediscover the same goals.
 2. Route `new` goals through `CREATE.md` according to PROJECT triage/continuation policy.
 3. Use the portfolio's PROJECT-derived `actionable` field. The installed default waits for every dependency to be `done` before writable implementation; a reviewed PROJECT override such as `stack_from_reviewed_checkpoint` may make a child actionable earlier. Read-only investigation may prepare waiting work when policy permits, but never claims, edits, branches, or marks it started. Recheck blocked work only on its trigger.
 4. Obey authority and explicit PROJECT priority first. Within the same effective priority, prefer evidenced charter/KPI value, safety/risk reduction, and unlocks: choose high-value, risk-reducing or unlocking work over low-value easy or fast work. Then prefer confidence, faster observable feedback, and lower difficulty; difficulty is cost, not value and never a reason to maximize item count. Unmeasured KPIs may support qualitative rationale, but never invent a baseline, score, or precision. On an exact tie use PROJECT resume policy, then the lowest goal key.
 
-Execution assumes the user is absent and never asks an interactive question, including for decisions, authority, or safety boundaries. Persist each unanswered consequential question on the affected goal with its category, evidence, recommendation, continuation boundary, safe work, and recheck trigger. Stop only affected work, never infer approval, and continue independent authorized goals until true queue exhaustion.
+Execution assumes the user is absent: never ask interactively or infer decisions, authority, safety, or approval. Persist consequential questions with their category, evidence, recommendation, boundary, safe work, and recheck trigger. Stop only affected work and continue independently authorized goals.
+
+Before substantive work on a newly selected goal or later-turn resume, tell the user in one plain sentence the intended outcome and immediate scope. Do this before reservation, edits, or implementation commands; do not repeat it for same-turn tool progress or make it an approval gate.
 
 ## Execute
 

--- a/.zzzops/ZZZOPS_LOCK.json
+++ b/.zzzops/ZZZOPS_LOCK.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "revision": "633eb66ad44922341344f904400b0e409a02a848",
-  "version": "v1.0.0-120-g633eb66",
+  "revision": "78d1184a17a6be088b039d97442ba89b521aefb4",
+  "version": "v1.0.0-125-g78d1184",
   "files": {
     ".agents/skills/add-zzzops-goal/SKILL.md": "843fdd30025cc0e0debae89eae6b95a750bb9f79926cac1e9ed9c1a41b764e75",
     ".agents/skills/add-zzzops-goal/agents/openai.yaml": "f1deff9c5f87c3c72ae8584a4b35423bbde401cf7aab3314953ad9d6d168239d",
@@ -9,7 +9,7 @@
     ".agents/skills/execute-zzzops/agents/openai.yaml": "7b01721e471598eff99488904085af1bda48b7ce2b15e8ccd112747414915fea",
     ".agents/skills/execute-zzzops/references/BRANCH_REVIEW.md": "0994ce2b8cbd4a424d4e375e2d31b5df4ba8d06c5a951a44afa77bfef415d4b8",
     ".agents/skills/execute-zzzops/references/CREATE.md": "5806507b901d1220a6ec65195a29260913d66c53a2faf40bc719a3c720abb44d",
-    ".agents/skills/execute-zzzops/references/EXECUTE.md": "088884387a0b70eff9683c7cc5202b9a478ac331cd1c4e3b2c8d5c3141dfdc32",
+    ".agents/skills/execute-zzzops/references/EXECUTE.md": "5a01b7876544c20c241fe7bb6d05de1b561f9fc8dab751920f25875ea11acd71",
     ".agents/skills/execute-zzzops/references/SELF_REVIEW.md": "4a4624789628a5be5fd2520479050992f65745a251857ae91cb4189d5efa3cc2",
     ".agents/skills/execute-zzzops/references/UNBLOCK.md": "0ee727616c887f9bb8951cbea655fdce4c4235f38f9c70d5c40275be2b754d8a",
     ".agents/skills/migrate-to-zzzops/SKILL.md": "eadf7836096671aa9f25676575fd38dbb01b2d7af7827e9601aad92a76c0a594",


### PR DESCRIPTION
## Summary
- require one short plain-language goal-start description before substantive execution
- avoid repeated tool-level chatter and preserve unattended execution
- route the behavior through the prompt contract and refresh the installer lock

## Verification
- python .agents/prompt_stats.py --eval`n- python .agents/prompt_stats.py --check`n- git diff --check dev...HEAD`n
Tracks #229