### PR TITLE
fix(policy): preserve review history

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -191,6 +191,40 @@ class InitializationTests(unittest.TestCase):
         final = zzzops.confirm_project(self.repo, first["policy_digest"], "test-user", [], True)
         self.assertTrue(final["initialized"])
 
+    def test_policy_rereview_preserves_history_and_appends_once(self):
+        first = zzzops.apply_plan(self.repo, self.plan())
+        zzzops.confirm_project(self.repo, first["policy_digest"], "first-reviewer", [], True)
+        prior = json.loads(json.dumps(zzzops.read_project_state(self.repo)[2]["history"]))
+
+        second = zzzops.apply_plan(self.repo, self.plan())
+        pending = zzzops.read_project_state(self.repo)[2]
+        self.assertEqual(prior, pending["history"][:-1])
+        self.assertEqual(len(prior) + 1, len(pending["history"]))
+        self.assertEqual("ZzzOps initialization", pending["history"][-1]["actor"])
+
+        with self.assertRaisesRegex(ValueError, "base_digest is stale"):
+            zzzops.apply_plan(self.repo, second)
+        self.assertEqual(pending["history"], zzzops.read_project_state(self.repo)[2]["history"])
+
+        with self.assertRaisesRegex(ValueError, "digest changed"):
+            zzzops.confirm_project(self.repo, "sha256:stale", "second-reviewer", [], True)
+        self.assertEqual(pending["history"], zzzops.read_project_state(self.repo)[2]["history"])
+
+        zzzops.confirm_project(self.repo, second["policy_digest"], "second-reviewer", [], True)
+        reviewed = zzzops.read_project_state(self.repo)[2]
+        self.assertEqual(prior, reviewed["history"][:len(prior)])
+        self.assertEqual(len(prior) + 2, len(reviewed["history"]))
+        self.assertEqual("second-reviewer", reviewed["history"][-1]["actor"])
+        audit = (self.repo / ".zzzops" / "PROJECT_AUDIT.md").read_text(encoding="utf-8")
+        for entry in reviewed["history"]:
+            self.assertIn(entry["change"], audit)
+
+    def test_clean_initialization_starts_with_one_pending_history_entry(self):
+        zzzops.apply_plan(self.repo, self.plan())
+        history = zzzops.read_project_state(self.repo)[2]["history"]
+        self.assertEqual(1, len(history))
+        self.assertEqual("ZzzOps initialization", history[0]["actor"])
+
     def test_bound_charter_and_canonical_policy_changes_invalidate_review(self):
         applied = zzzops.apply_plan(self.repo, self.plan())
         zzzops.confirm_project(self.repo, applied["policy_digest"], "test-user", [], True)

--- a/.agents/zzzops/zzzops.py
+++ b/.agents/zzzops/zzzops.py
@@ -1482,6 +1482,12 @@ def apply_plan(repo: Path, plan: dict[str, Any]) -> dict[str, Any]:
     revision = int(old_state.get("revision", 0)) + 1 if old_state else 1
     policy = json.loads(json.dumps(plan["policy"]))
     policy["evidence"] = plan["evidence"]
+    history = json.loads(json.dumps(old_state["history"])) if old_state else []
+    history.append({
+        "date": date.today().isoformat(), "actor": "ZzzOps initialization",
+        "change": f"Created pending revision {revision}",
+        "reason": "Confirmed agent-generated draft; explicit policy review still required.",
+    })
     state = {
         "schema_version": PROJECT_SCHEMA_VERSION,
         "initialized": False,
@@ -1490,11 +1496,7 @@ def apply_plan(repo: Path, plan: dict[str, Any]) -> dict[str, Any]:
         "revision": revision,
         "charter": plan["charter"],
         "policy": policy,
-        "history": [{
-            "date": date.today().isoformat(), "actor": "ZzzOps initialization",
-            "change": f"Created pending revision {revision}",
-            "reason": "Confirmed agent-generated draft; explicit policy review still required.",
-        }],
+        "history": history,
         "bindings": {},
         "approval": None,
     }

--- a/.zzzops/ZZZOPS_LOCK.json
+++ b/.zzzops/ZZZOPS_LOCK.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "revision": "cda5352de9bd8dd80055db77abd359f2ea048feb",
-  "version": "v1.0.0-128-gcda5352",
+  "revision": "794d8b419398e2648c5e6d352ec8235a165f7a05",
+  "version": "v1.0.0-133-g794d8b4",
   "files": {
     ".agents/skills/add-zzzops-goal/SKILL.md": "843fdd30025cc0e0debae89eae6b95a750bb9f79926cac1e9ed9c1a41b764e75",
     ".agents/skills/add-zzzops-goal/agents/openai.yaml": "f1deff9c5f87c3c72ae8584a4b35423bbde401cf7aab3314953ad9d6d168239d",
@@ -34,7 +34,7 @@
     ".agents/zzzops/templates/project-goals/MIGRATION_STATE.json": "0343639fac1511a32a4c9a92c7655a6e9f9ad3a600fc6f30b5bdad6806160a97",
     ".agents/zzzops/templates/project-goals/MIGRATION_SUMMARY.md": "8fd4826d3352e7bdc43943e0fa9721dee0e133b3f6b138dd6fae751e6a85f770",
     ".agents/zzzops/templates/project-goals/ZZZOPS_GITIGNORE": "353f71c5c4e1a9d2199db0d276493be9266b3fdd6295c1888e44bfbd173dd6ab",
-    ".agents/zzzops/zzzops.py": "0728f60834ba8dde6383677cade3f26d3d3c31f6ff577c754162c1277b86ecb8",
+    ".agents/zzzops/zzzops.py": "13ec3854f5d6580d3c0f9fcbe90c0eaf35407da271199e65ce169928627b5110",
     ".zzzops/rules/BACKENDS.md": "2aa48513005031c6cd47963531041aa17b5f1c87ad8eaedbc769387e21f62c93",
     ".zzzops/rules/BLOCKERS.md": "9188bb5ef85ae521df8e9b1cbff9c773e4639e745f4cf037304cec345f2b9ea6",
     ".zzzops/rules/CONTINUATION.md": "78cdb44777015a9fbb2dc24e5954582824c01ff03a76f6da32e58ef923d1b2dd",


### PR DESCRIPTION
## Summary
- preserve existing valid policy history when applying a re-review plan
- append exactly one pending and one approval entry across a successful review
- keep clean initialization and stale retry behavior unchanged
- refresh the disposable-machinery lock

## Verification
- focused re-review history regression
- focused clean-initialization guard
- existing apply/confirm/reinspect contract
- git diff --check dev...HEAD`n
Tracks #208