### PR TITLE
fix(execution): suppress redundant progress recaps

### DIFF
--- a/.agents/skills/execute-zzzops/references/EXECUTE.md
+++ b/.agents/skills/execute-zzzops/references/EXECUTE.md
@@ -15,6 +15,8 @@ Execution assumes the user is absent and never asks an interactive question. Per
 
 Before substantive work on a newly selected goal or later-turn resume, tell the user in one plain sentence the intended outcome and immediate scope. Do this before reservation, edits, or implementation commands; do not repeat it for same-turn tool progress or make it an approval gate.
 
+Update the user only for a new result, decision, risk, changed assumption, required action, or long-operation heartbeat; never recap unchanged state.
+
 ## Execute
 
 1. Re-read only the selected goal and selection-critical parent/dependencies; compare revision/digest, declare known resources, then reserve the bundle per `GOAL_SYSTEM.md`. On contention refresh once and choose other work; only the winner claims or begins work.

--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -2400,6 +2400,17 @@ class ReservationTests(unittest.TestCase):
 
 
 class WorkflowContractTests(unittest.TestCase):
+    def test_execute_progress_updates_require_new_information(self):
+        execute = (
+            Path(__file__).parent / "skills" / "execute-zzzops" / "references" / "EXECUTE.md"
+        ).read_text(encoding="utf-8")
+        for signal in (
+            "new result, decision, risk, changed assumption, required action",
+            "long-operation heartbeat",
+            "never recap unchanged state",
+        ):
+            self.assertIn(signal, execute)
+
     def test_execute_routes_explicit_work_states_without_blurring_write_authority(self):
         execute = (
             Path(__file__).parent / "skills" / "execute-zzzops" / "references" / "EXECUTE.md"


### PR DESCRIPTION
## Summary

- require progress updates to carry a new result, decision, risk, assumption change, required action, or bounded heartbeat
- suppress unchanged-state recaps without hiding meaningful execution communication
- add a focused installed workflow contract

## Verification

- `python .agents\test_zzzops.py WorkflowContractTests`
- `python .agents\prompt_stats.py --check`
- `git diff --check`

Tracks #248
