### PR TITLE
feat(compliance): publish OpenAI app disclosures

### DIFF
--- a/.agents/test_agent_plugin.py
+++ b/.agents/test_agent_plugin.py
@@ -15,6 +15,7 @@ SHIPPED_SKILLS = {
     "send-zzzops-feedback",
     "suggest-zzzops-work",
 }
+SUPPORT_EMAIL = "zzzops.support@gmail.com"
 
 
 class AgentPluginTests(unittest.TestCase):
@@ -52,6 +53,49 @@ class AgentPluginTests(unittest.TestCase):
             "plugins/zzzops/zzzops/install_lock.py",
         ):
             self.assertFalse((ROOT / relative).exists(), relative)
+
+    def test_published_compliance_disclosures_are_complete(self) -> None:
+        privacy = (ROOT / "PRIVACY.md").read_text(encoding="utf-8")
+        compliance = (ROOT / "docs" / "OPENAI_COMPLIANCE.md").read_text(encoding="utf-8")
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        codex_manifest = json.loads((PLUGIN / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8"))
+
+        for required in (
+            SUPPORT_EMAIL,
+            "## Data ZzzOps processes",
+            "## Why data is processed",
+            "## Who receives data",
+            "## Retention",
+            "## Your choices and controls",
+            "GitHub Issues",
+            "OpenAI processes",
+            "public feedback",
+            "no ZzzOps-operated server",
+        ):
+            self.assertIn(required, privacy)
+        self.assertIn("[Privacy policy](PRIVACY.md)", readme)
+        self.assertIn("[OpenAI compliance review](docs/OPENAI_COMPLIANCE.md)", readme)
+        self.assertIn(SUPPORT_EMAIL, readme)
+        self.assertIn("not created, supported, certified, endorsed by, or affiliated with OpenAI", readme)
+        self.assertIn("no ZzzOps-operated server, telemetry, advertising, or commerce", readme)
+        self.assertIn(SUPPORT_EMAIL, compliance)
+        self.assertIn("https://openai.com/policies/developer-apps-terms/", compliance)
+        self.assertIn("https://developers.openai.com/plugins/app-guidelines", compliance)
+        self.assertIn("## Owner checklist before submission or publication", compliance)
+        self.assertIn("GitHub Issues", codex_manifest["interface"]["longDescription"])
+        self.assertEqual(["Write"], codex_manifest["interface"]["capabilities"])
+
+    def test_restricted_data_boundary_is_shipped(self) -> None:
+        goal_rules = (PLUGIN / "rules" / "GOAL_SYSTEM.md").read_text(encoding="utf-8")
+        feedback_skill = (PLUGIN / "skills" / "send-zzzops-feedback" / "SKILL.md").read_text(encoding="utf-8")
+        for restricted in (
+            "credentials",
+            "payment cards",
+            "health data",
+            "government IDs",
+        ):
+            self.assertIn(restricted, goal_rules)
+            self.assertIn(restricted, feedback_skill)
 
 
 if __name__ == "__main__":

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,66 @@
+# ZzzOps Privacy Policy
+
+**Effective date:** August 9, 2026
+
+**Contact:** [zzzops.support@gmail.com](mailto:zzzops.support@gmail.com)
+
+ZzzOps is an open-source, skills-only Agent Plugin. It has no ZzzOps-operated server, account system, analytics, advertising, or payment service. The plugin runs through Codex in the user's environment and uses tools and accounts that the user has configured there.
+
+## Data ZzzOps processes
+
+ZzzOps may process the following data to perform a user-requested workflow:
+
+- Repository content and metadata available to Codex, including source files, documentation, configuration, Git history, branches, pull requests, checks, and repository instructions.
+- Project policy and local ZzzOps state stored under `.zzzops/` in the user's repository.
+- Goal content and metadata stored in GitHub Issues, including titles, descriptions, relationships, blockers, evidence, labels, comments, and GitHub-generated account or repository identifiers.
+- For optional public feedback, user-authored feedback and explicitly selected execution reports. Reports contain a content-derived identifier, creation timestamp, bounded workflow and cause codes, an agent category, numeric impact, and the installed ZzzOps version and revision. They are designed not to contain project names, paths, code, goals, domain facts, user content, or secrets.
+
+ZzzOps does not need and must not be given authentication secrets, passwords, API keys, MFA or one-time codes, payment-card data, protected health information, government identifiers, or other restricted or regulated data.
+
+## Why data is processed
+
+ZzzOps processes repository and goal data only to initialize reviewed project policy; capture, migrate, prioritize, and execute project goals; coordinate Git and GitHub work; verify results; and prepare user-requested feedback. It does not use this data for advertising, behavioral profiling, model training, sale, or unrelated purposes.
+
+## Who receives data
+
+- OpenAI processes conversations, repository context, and tool activity provided to Codex under the terms and privacy choices for the user's account or workspace. ZzzOps does not control OpenAI's retention or use of that data.
+- Local repository data is handled in the user's Codex environment and by tools the user authorizes. The ZzzOps developer does not receive it through a ZzzOps-operated service.
+- GitHub receives data that ZzzOps reads or writes through the user's existing GitHub authentication. Goal and implementation records are visible to the selected repository's permitted audience; in a public repository, they are public. GitHub attributes writes to the authenticated GitHub account, so its username and public profile may be visible with an issue, comment, commit, or pull request. GitHub processes that data under its own terms and privacy statement.
+- Optional feedback is submitted only after ZzzOps shows the exact payload and the user explicitly confirms it. The payload is posted to the public `david-rzepa/zzzops` GitHub repository and becomes visible to the public and GitHub.
+
+ZzzOps does not sell personal data or disclose it to advertisers or data brokers.
+
+## Retention
+
+- Local `.zzzops/` state and execution reports remain in the user's repository until the user removes them or the documented workflow removes them.
+- An execution report selected for feedback is deleted locally only after successful submission. Cancellation, validation failure, or submission failure retains it for review or retry.
+- Data written to GitHub remains according to the user's repository settings, actions, and [GitHub's privacy practices](https://docs.github.com/site-policy/privacy-policies/github-general-privacy-statement). ZzzOps does not control GitHub backups, forks, caches, or copies made by repository viewers.
+- Public feedback issues are retained as project records. Requests for correction or deletion can be sent to the contact below and will be handled where technically and legally possible; removal cannot guarantee deletion of third-party copies.
+
+## Your choices and controls
+
+Users can:
+
+- choose whether to install or use ZzzOps and which repository it may access;
+- use a private GitHub repository and restrict repository collaborators;
+- redact sensitive context or link to an approved private system instead of placing it in a goal;
+- review, edit, or remove local ZzzOps state and manage GitHub records using their normal repository controls;
+- disable local execution-report recording in reviewed ZzzOps policy;
+- inspect the exact public feedback payload, cancel submission, or remove content before confirming it; and
+- request privacy, support, or security assistance at [zzzops.support@gmail.com](mailto:zzzops.support@gmail.com).
+
+If restricted data is entered accidentally, do not submit it as feedback. Remove or redact it from local and GitHub records where possible, and rotate any exposed credential through its provider.
+
+## Security and children
+
+ZzzOps uses the permissions of the user's existing Codex, Git, and GitHub environment and does not request a separate credential. Users remain responsible for repository access controls and for reviewing proposed external or destructive actions. Security concerns can be reported to [zzzops.support@gmail.com](mailto:zzzops.support@gmail.com); do not include active credentials in a report.
+
+ZzzOps is a developer tool for a general audience and is not directed to children under 13. Do not use it to submit personal data about children under 13 or below the applicable age of digital consent.
+
+## Changes
+
+This policy will be updated when ZzzOps data practices materially change. Marketplace releases review the current [OpenAI App Developer Terms](https://openai.com/policies/developer-apps-terms/) and [OpenAI Plugin Guidelines](https://developers.openai.com/plugins/app-guidelines); the repository history records policy changes.
+
+## Contact
+
+For support, privacy requests, or security reports, email [zzzops.support@gmail.com](mailto:zzzops.support@gmail.com).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ You can perform the equivalent actions from Codex's `/plugins` interface. Codex 
 
 ZzzOps v2 supports Codex. Claude Code users can remain on [v1.2.0, the final legacy installer release](https://github.com/david-rzepa/zzzops/releases/tag/v1.2.0); that line is retained for download but is not updated by the v2 marketplace workflow.
 
+[Privacy policy](PRIVACY.md) · [OpenAI compliance review](docs/OPENAI_COMPLIANCE.md) · Support, privacy, and security: [zzzops.support@gmail.com](mailto:zzzops.support@gmail.com)
+
+ZzzOps is independently developed and is not created, supported, certified, endorsed by, or affiliated with OpenAI. It uses your existing GitHub authentication to read and write GitHub Issues and, when your reviewed project policy authorizes implementation, to coordinate Git branches, commits, and pull requests. ZzzOps has no ZzzOps-operated server, telemetry, advertising, or commerce.
+
 Open a new Codex task in the target project after installation so its ZzzOps skills are discovered, then start the policy review workflow.
 
 ### 3. Initialize the project
@@ -39,7 +43,7 @@ GitHub Issues is the canonical goal authority. Initialization requires a success
 
 The plugin CLI requires Python 3.10 or newer. CLI examples use `<python>` for one compatible interpreter resolved once (`python3`, `python`, Windows `py -3`, or a harness-provided runtime). Agents resolve the CLI from the installed plugin package rather than assuming it exists in the target repository.
 
-**Visibility:** GitHub-backed goals inherit the repository's visibility. Never put secrets or raw sensitive data in a goal; redact it or link to an approved private system before capture or migration.
+**Visibility:** GitHub-backed goals inherit the repository's visibility. Never put authentication secrets, payment-card data, protected health information, government identifiers, or other restricted or raw sensitive data in a goal; redact it or link to an approved private system before capture or migration.
 
 Maintainers: see the [initialization and policy contract](docs/INITIALIZATION.md).
 
@@ -114,6 +118,7 @@ This is the complete list of shipped user-facing ZzzOps features. It is a catalo
 | Feature | Primary surface |
 | --- | --- |
 | Discover, install, update, and remove ZzzOps through Codex | `.agents/plugins/marketplace.json` / `plugins/zzzops/plugin.json` |
+| Publish the privacy boundary, compliance review, and support contact | `PRIVACY.md` / `docs/OPENAI_COMPLIANCE.md` / `README.md` |
 | Initialize, summarize, and adjust reviewed project policy | `plugins/zzzops/skills/review-zzzops-policy/SKILL.md` |
 | Use GitHub Issues as the canonical goal backend | `plugins/zzzops/rules/BACKENDS.md` |
 | Capture durable work | `plugins/zzzops/skills/add-zzzops-goal/SKILL.md` |

--- a/docs/OPENAI_COMPLIANCE.md
+++ b/docs/OPENAI_COMPLIANCE.md
@@ -1,0 +1,52 @@
+# OpenAI marketplace compliance review
+
+This document is the human review checkpoint for publishing ZzzOps through OpenAI's plugin marketplace. It is evidence and a checklist, not legal certification. Automated validation can prove that required repository disclosures exist and agree; only the owner can accept terms, make legal attestations, verify identity, submit, or publish.
+
+**Last reviewed:** August 9, 2026
+
+**Support, privacy, and security contact:** [zzzops.support@gmail.com](mailto:zzzops.support@gmail.com)
+
+## Authoritative sources
+
+- [OpenAI App Developer Terms](https://openai.com/policies/developer-apps-terms/) — page updated July 9, 2026 when reviewed.
+- [OpenAI Plugin Guidelines](https://developers.openai.com/plugins/app-guidelines) — reviewed August 9, 2026.
+- [OpenAI Usage Policies](https://openai.com/policies/usage-policies/) — incorporated by the App Developer Terms.
+- [OpenAI plugin submission requirements](https://developers.openai.com/plugins/deploy/submission).
+
+Re-read the live sources before each marketplace submission and after a material policy, data-flow, permission, capability, or monetization change. Update the review date and dispositions in the same reviewed release change. A repository check cannot establish that unchanged links still contain unchanged requirements.
+
+## Current applicability and evidence
+
+| Requirement | ZzzOps disposition and evidence |
+| --- | --- |
+| Clear, original, reliable purpose | ZzzOps provides reviewed durable project-goal workflows. The README describes the complete user-facing surface; plugin and prompt validation run in required CI. |
+| Accurate name, description, capabilities, and side effects | The Codex manifest declares `Write`; its long description and the README disclose GitHub Issue writes, existing GitHub authentication, and policy-governed Git/PR operations. |
+| MCP tool annotations and server security | Not applicable: ZzzOps is skills-only and ships no MCP server, tools, API, hosted backend, or UI. Reassess before adding any such surface. |
+| Authentication and minimum permissions | ZzzOps requests no separate credential. It uses the user's existing Codex, Git, and GitHub environment, and deterministic checkpoints fail when required access is unavailable. |
+| Privacy notice and minimization | [The privacy policy](../PRIVACY.md) lists processed data, purposes, recipients, retention, controls, restricted-data exclusions, and the optional exactly confirmed public feedback flow. |
+| Surveillance, profiling, advertising, and commerce | Not applicable: ZzzOps has no telemetry, behavioral profiling, advertising, checkout, sale, subscription, or payment path. |
+| External writes and user intent | GitHub and Git side effects are disclosed. Goal capture is bounded; public feedback shows the exact payload and requires fresh confirmation; reviewed project policy and higher authority govern implementation writes. |
+| Restricted and sensitive data | Shipped goal and feedback instructions reject credentials, payment data, health data, government identifiers, and other restricted/raw sensitive data. The privacy policy provides accidental-disclosure guidance. |
+| Safety and general audience | User and safety authority outrank goals. ZzzOps is not directed to children under 13 and must not receive children's personal data. OpenAI Usage Policy compliance remains required for every use. |
+| Intellectual property and independent branding | The repository is Apache-2.0 licensed; the ZzzOps name and cat images are submitted as project assets. The owner must confirm the necessary rights. The README states that ZzzOps is independently developed and not endorsed by or affiliated with OpenAI. |
+| Support and developer verification | `zzzops.support@gmail.com` is the published support/privacy/security contact. The owner must complete and maintain OpenAI developer verification in the portal. |
+| Incident response | Security reports go to the published contact. The owner must assess, contain, and report a relevant App/API vulnerability or breach to OpenAI promptly when the terms require it. |
+| Accurate submission and ongoing compliance | Portal information must match the reviewed release exactly. The owner reviews live requirements, attestations, test cases, availability, and release notes before submission and publication. |
+
+## Owner checklist before submission or publication
+
+- [ ] Re-read every authoritative source above and record the current review date and any changed requirement.
+- [ ] Confirm the public privacy-policy URL resolves and still describes observed behavior, recipients, retention, controls, and the feedback payload.
+- [ ] Confirm `zzzops.support@gmail.com` is monitored and can receive support, privacy, and security requests.
+- [ ] Confirm the listing and manifest accurately describe GitHub authentication, external writes, capabilities, limitations, and independent-developer status.
+- [ ] Confirm the necessary rights to every submitted name, logo, icon, description, and other asset.
+- [ ] Confirm the plugin contains no MCP server, hosted service, UI, telemetry, advertising, commerce, or new data flow; otherwise stop and reassess every affected disposition.
+- [ ] Inspect the release archive and submission materials for secrets, personal data, repository-only tooling, stale versions, and unintended files.
+- [ ] Run the required plugin, cross-platform, prompt-budget, and release validation at the exact submitted commit.
+- [ ] Supply reviewer-runnable positive and negative tests, starter prompts, availability, release notes, and attestations from the portal-ready sources tracked by [#256](https://github.com/david-rzepa/zzzops/issues/256).
+- [ ] Complete developer verification and personally review and make every legal or policy attestation; automation must not accept terms or publish.
+- [ ] Record the submitted version, exact commit, bundle digest, portal result, and any reviewer conditions in the release evidence.
+
+## Owner-only legal considerations
+
+The owner—not CI or ZzzOps—must decide whether to accept the App Developer Terms and obtain legal advice where appropriate. The current terms include developer warranties, indemnification obligations, OpenAI's liability limitation, arbitration and class-action provisions, trade-control duties, changing terms, and OpenAI's discretion to reject or remove an app. Repository validation does not resolve those legal choices.

--- a/plugins/zzzops/.codex-plugin/plugin.json
+++ b/plugins/zzzops/.codex-plugin/plugin.json
@@ -14,7 +14,7 @@
   "interface": {
     "displayName": "ZzzOps",
     "shortDescription": "Durable autonomous goals",
-    "longDescription": "ZzzOps gives Codex a reviewed, prioritized, and resumable project-goal loop backed by GitHub Issues.",
+    "longDescription": "ZzzOps gives Codex a reviewed, prioritized, and resumable project-goal loop. It reads and writes GitHub Issues through your existing GitHub authentication and coordinates implementation only under reviewed project policy.",
     "developerName": "David Rzepa",
     "category": "Developer Tools",
     "capabilities": ["Write"],

--- a/plugins/zzzops/rules/GOAL_SYSTEM.md
+++ b/plugins/zzzops/rules/GOAL_SYSTEM.md
@@ -5,7 +5,7 @@
 Order: user/safety; project instructions; reviewed `.zzzops/PROJECT.md`; canonical GitHub issue. Repository-policy conflict stops for reconciliation. Before non-install workflows follow `INITIALIZATION.md`, then `BACKENDS.md`.
 
 - Goal identity is repository plus issue number/URL; never invent IDs or duplicate provider-owned title/relations.
-- Never store secrets/raw sensitive data; link approved systems and name authority/sync direction.
+- Never store credentials, payment cards, health data, government IDs, or raw sensitive data; redact or link an approved private system.
 - The charter defines value. Preserve unknown KPIs/targets/tradeoffs; capture asks and execution blocks rather than inventing answers.
 - Reviewed PROJECT holds operational choices; installed rules are overridable defaults, not another policy layer.
 - Templates live in the plugin package at `zzzops/templates/project-goals/`; plugin installation never creates or copies project state.

--- a/plugins/zzzops/skills/send-zzzops-feedback/SKILL.md
+++ b/plugins/zzzops/skills/send-zzzops-feedback/SKILL.md
@@ -9,7 +9,7 @@ Run `../../rules/INITIALIZATION.md`, then read `../../rules/FEEDBACK.md`. Use th
 
 Use checkpoint only for readiness; detailed inputs are local reports and explicit feedback, never goal bodies/history.
 
-1. Treat the user's text after the invocation as user-authored feedback. It may contain project information because the user controls it, but never merge that text into an execution report.
+1. Keep user text separate from execution reports. Before public preview, reject credentials, payment cards, health data, government IDs, and other restricted data.
 2. Run `report list` and inspect every valid archived report. Reports contain only constrained machinery codes, numeric impact, and validated ZzzOps build provenance; legacy schema-v2 provenance is explicitly unknown. Malformed or unknown content is a safety failure, so stop without submitting or deleting anything.
 3. Pass the feedback through stdin or a securely created temporary UTF-8 file to `feedback prepare`; never put it directly in a command-line argument. By default include all archived reports unless the user selected a subset.
 4. Show the exact target, title, labels, and body returned by `feedback prepare`, including cause/build-specific natural-language accounts and the collapsed immutable JSON appendix. State that `david-rzepa/zzzops` is public and ask the user to confirm that exact payload. The `zzzops-feedback` label keeps it outside ordinary execution unless a user approves the feedback queue for that session. Do not submit on an inferred, stale, or general approval.


### PR DESCRIPTION
## Outcome

Publishes the privacy, support, restricted-data, and independent-branding disclosures required for an OpenAI marketplace submission, without adding a hosted service or new data flow.

## Changes

- add the public ZzzOps privacy policy and approved support/privacy/security contact
- disclose GitHub authentication and external write behavior in the listing and README
- add a version-controlled owner compliance review and submission checklist
- reject restricted data in shipped goal and public-feedback prompts
- gate the required disclosures with focused plugin tests

## Verification

- `python .agents/test_agent_plugin.py`
- `npm run test:plugin`
- `python .agents/prompt_stats.py --check` — 14,389/14,400
- `python .agents/prompt_stats.py --eval` — 7/7
- `git diff --check`

Tracks #258