### PR TITLE
feat(release): attach OpenAI submission bundles

### DIFF
--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -1,0 +1,90 @@
+"""Regression tests for deterministic OpenAI submission bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from zipfile import ZipFile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / ".github" / "scripts" / "build_marketplace_bundle.py"
+
+
+def load_builder():
+    spec = importlib.util.spec_from_file_location("build_marketplace_bundle", BUILDER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class MarketplaceBundleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.builder = load_builder()
+
+    def test_fixed_version_build_is_deterministic_and_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as first, tempfile.TemporaryDirectory() as second:
+            notes = "Initial skills-only submission.\n"
+            one = self.builder.build_bundles(ROOT, Path(first), "2.0.0", notes)
+            two = self.builder.build_bundles(ROOT, Path(second), "2.0.0", notes)
+            for key in ("plugin", "submission"):
+                self.assertEqual(
+                    hashlib.sha256(one[key].read_bytes()).hexdigest(),
+                    hashlib.sha256(two[key].read_bytes()).hexdigest(),
+                )
+
+            with ZipFile(one["plugin"]) as archive:
+                names = archive.namelist()
+                self.assertIn("plugin.json", names)
+                self.assertIn(".codex-plugin/plugin.json", names)
+                self.assertIn("scripts/cleanup_legacy.py", names)
+                self.assertNotIn("skills/run-zzzops-acceptance/SKILL.md", names)
+                self.assertFalse(any("__pycache__" in name or name.endswith((".pyc", ".pyo")) for name in names))
+                self.assertEqual("2.0.0", json.loads(archive.read("plugin.json"))["version"])
+                self.assertEqual("2.0.0", json.loads(archive.read(".codex-plugin/plugin.json"))["version"])
+
+            with ZipFile(one["submission"]) as archive:
+                names = set(archive.namelist())
+                self.assertEqual({
+                    "ATTESTATIONS.md", "LISTING.md", "RELEASE_NOTES.md", "TEST_CASES.md",
+                    "assets/composer-icon-dark.png", "assets/composer-icon.png",
+                    "assets/logo-dark.png", "assets/logo.png", "manifest.json", "submission.json",
+                }, names)
+                submission = json.loads(archive.read("submission.json"))
+                manifest = json.loads(archive.read("manifest.json"))
+                self.assertEqual("skills_only", submission["submission_type"])
+                self.assertEqual("2.0.0", submission["version"])
+                self.assertLessEqual(len(submission["listing"]["short_description"]), 30)
+                self.assertEqual("https://github.com/david-rzepa/zzzops", submission["listing"]["website_url"])
+                self.assertGreaterEqual(len(submission["tests"]["positive"]), 5)
+                self.assertGreaterEqual(len(submission["tests"]["negative"]), 3)
+                self.assertEqual(
+                    hashlib.sha256(one["plugin"].read_bytes()).hexdigest(),
+                    submission["plugin_archive"]["sha256"],
+                )
+                self.assertEqual("2.0.0", manifest["version"])
+                self.assertEqual(
+                    hashlib.sha256(archive.read("submission.json")).hexdigest(),
+                    manifest["files"]["submission.json"],
+                )
+
+    def test_invalid_version_or_incomplete_sources_fail_before_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            with self.assertRaisesRegex(self.builder.BundleError, "version"):
+                self.builder.build_bundles(ROOT, output, "latest", "notes")
+            self.assertEqual([], list(output.iterdir()))
+        with self.assertRaisesRegex(self.builder.BundleError, "secret-like"):
+            self.builder.scan_for_secrets("config.txt", b"OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/test_release_validation.py
+++ b/.agents/test_release_validation.py
@@ -39,6 +39,11 @@ class ReleaseValidationTests(unittest.TestCase):
         self.assertIn("python .github/scripts/run_product_validation.py --platform windows", workflow)
         runner = RUNNER_PATH.read_text(encoding="utf-8")
         self.assertEqual(2, runner.count('run(sys.executable, ".agents/test_legacy_cleanup.py")'))
+        self.assertEqual(2, runner.count('run(sys.executable, ".agents/test_marketplace_bundle.py")'))
+        release_job = workflow.split("  release:", 1)[1]
+        self.assertIn("actions/setup-python@v5", release_job)
+        self.assertIn("needs: [validate-linux, validate-windows]", release_job)
+        self.assertLess(release_job.index("needs:"), release_job.index("run: npx semantic-release"))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Build and validate deterministic OpenAI skills-only submission artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import sys
+import tempfile
+from typing import Any
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+
+
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SECRET_PATTERNS = (
+    re.compile(rb"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(rb"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(rb"\bgh[opsu]_[A-Za-z0-9]{20,}\b"),
+)
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+
+
+class BundleError(ValueError):
+    """Marketplace sources or generated artifacts are unsafe or incomplete."""
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise BundleError(f"could not read {path.name}: {type(exc).__name__}") from exc
+
+
+def require_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise BundleError(f"{field} must be non-empty text")
+    return value
+
+
+def validate_sources(root: Path) -> tuple[dict[str, Any], dict[str, Any], str]:
+    listing = read_json(root / "marketplace" / "listing.json")
+    tests = read_json(root / "marketplace" / "test-cases.json")
+    attestations_path = root / "marketplace" / "ATTESTATIONS.md"
+    try:
+        attestations = attestations_path.read_text(encoding="utf-8-sig").replace("\r\n", "\n")
+    except (OSError, UnicodeError) as exc:
+        raise BundleError(f"could not read ATTESTATIONS.md: {type(exc).__name__}") from exc
+    if not isinstance(listing, dict) or listing.get("schema_version") != 1 or listing.get("submission_type") != "skills_only":
+        raise BundleError("listing.json must be a schema v1 skills_only submission")
+    if set(listing) != {"schema_version", "submission_type", "official_submission_docs", "listing", "assets", "starter_prompts", "availability"}:
+        raise BundleError("listing.json fields do not match the submission source contract")
+    info = listing["listing"]
+    required_info = {
+        "name", "short_description", "long_description", "category", "developer_name",
+        "website_url", "support_url", "privacy_policy_url", "terms_url",
+    }
+    if not isinstance(info, dict) or set(info) != required_info:
+        raise BundleError("listing fields are incomplete")
+    for field in required_info:
+        require_text(info[field], f"listing.{field}")
+    if len(info["short_description"]) > 30:
+        raise BundleError("listing.short_description must be 30 characters or fewer")
+    if info["website_url"] != "https://github.com/david-rzepa/zzzops":
+        raise BundleError("listing.website_url must be the repository URL")
+    for field in ("website_url", "support_url", "privacy_policy_url", "terms_url"):
+        if not info[field].startswith("https://"):
+            raise BundleError(f"listing.{field} must be a public HTTPS URL")
+    prompts = listing["starter_prompts"]
+    if not isinstance(prompts, list) or len(prompts) < 3 or any(not isinstance(item, str) or not item.strip() for item in prompts):
+        raise BundleError("starter_prompts must contain at least three prompts")
+    availability = listing["availability"]
+    if not isinstance(availability, dict) or availability.get("choice") != "all_portal_supported_countries" or not availability.get("rationale"):
+        raise BundleError("availability choice and rationale are required")
+    assets = listing["assets"]
+    required_assets = {"logo_light", "logo_dark", "composer_icon_light", "composer_icon_dark"}
+    if not isinstance(assets, dict) or set(assets) != required_assets:
+        raise BundleError("light and dark logo and composer assets are required")
+    for relative in assets.values():
+        if not isinstance(relative, str) or PurePosixPath(relative).is_absolute() or ".." in PurePosixPath(relative).parts:
+            raise BundleError(f"unsafe asset path: {relative}")
+        if not root.joinpath(*PurePosixPath(relative).parts).is_file():
+            raise BundleError(f"missing submission asset: {relative}")
+    if not isinstance(tests, dict) or set(tests) != {"schema_version", "positive", "negative"} or tests.get("schema_version") != 1:
+        raise BundleError("test-cases.json fields are invalid")
+    if not isinstance(tests["positive"], list) or len(tests["positive"]) < 5:
+        raise BundleError("at least five positive test cases are required")
+    if not isinstance(tests["negative"], list) or len(tests["negative"]) < 3:
+        raise BundleError("at least three negative test cases are required")
+    for case in tests["positive"]:
+        if not isinstance(case, dict) or set(case) != {"id", "prompt", "expected_behavior", "expected_result_shape", "fixture"}:
+            raise BundleError("positive test case fields are incomplete")
+        for field, value in case.items():
+            require_text(value, f"positive.{field}")
+    for case in tests["negative"]:
+        if not isinstance(case, dict) or set(case) != {"id", "scenario", "expected_behavior", "why_not"}:
+            raise BundleError("negative test case fields are incomplete")
+        for field, value in case.items():
+            require_text(value, f"negative.{field}")
+    if attestations.count("- [ ]") < 9 or "human review gates" not in attestations:
+        raise BundleError("ATTESTATIONS.md must retain the complete unchecked human checklist")
+    return listing, tests, attestations
+
+
+def scan_for_secrets(relative: str, data: bytes) -> None:
+    folded = PurePosixPath(relative).name.casefold()
+    if folded in {".env", "credentials.json", "secrets.json"} or folded.endswith((".pem", ".key", ".p12", ".pfx")):
+        raise BundleError(f"secret-bearing filename is forbidden: {relative}")
+    if any(pattern.search(data) for pattern in SECRET_PATTERNS):
+        raise BundleError(f"secret-like content is forbidden: {relative}")
+
+
+def plugin_files(root: Path, version: str) -> dict[str, bytes]:
+    plugin = root / "plugins" / "zzzops"
+    result: dict[str, bytes] = {}
+    allowed_top_level = {".codex-plugin", "assets", "plugin.json", "rules", "scripts", "skills", "zzzops"}
+    for path in sorted(plugin.rglob("*"), key=lambda item: item.relative_to(plugin).as_posix()):
+        relative = path.relative_to(plugin).as_posix()
+        if PurePosixPath(relative).parts[0] not in allowed_top_level:
+            raise BundleError(f"unintended top-level plugin path: {relative}")
+        if path.is_symlink():
+            raise BundleError(f"plugin package contains a symlink: {relative}")
+        if not path.is_file() or "__pycache__" in path.parts or path.suffix in {".pyc", ".pyo"}:
+            continue
+        data = path.read_bytes().replace(b"\r\n", b"\n")
+        if relative in {"plugin.json", ".codex-plugin/plugin.json"}:
+            manifest = json.loads(data.decode("utf-8-sig"))
+            manifest["version"] = version
+            data = canonical_json(manifest)
+        scan_for_secrets(relative, data)
+        result[relative] = data
+    required = {
+        "plugin.json", ".codex-plugin/plugin.json", "assets/logo.png", "assets/logo-dark.png",
+        "assets/composer-icon.png", "assets/composer-icon-dark.png", "scripts/cleanup_legacy.py",
+    }
+    missing = sorted(required - set(result))
+    if missing:
+        raise BundleError("plugin package is incomplete: " + ", ".join(missing))
+    if any(path.startswith("skills/run-zzzops-acceptance/") for path in result):
+        raise BundleError("repository-only acceptance skill entered the plugin package")
+    shipped_skills = {
+        PurePosixPath(path).parts[1] for path in result
+        if len(PurePosixPath(path).parts) >= 3 and PurePosixPath(path).parts[0] == "skills"
+    }
+    if shipped_skills != {
+        "add-zzzops-goal", "execute-zzzops", "migrate-to-zzzops",
+        "review-zzzops-policy", "send-zzzops-feedback", "suggest-zzzops-work",
+    }:
+        raise BundleError("plugin archive must contain exactly the six product skills")
+    return result
+
+
+def zip_bytes(files: dict[str, bytes]) -> bytes:
+    temporary = io.BytesIO()
+    with ZipFile(temporary, "w", compression=ZIP_DEFLATED, compresslevel=9) as archive:
+        for relative, data in sorted(files.items()):
+            info = ZipInfo(relative, ZIP_TIMESTAMP)
+            info.compress_type = ZIP_DEFLATED
+            info.create_system = 3
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, data, compress_type=ZIP_DEFLATED, compresslevel=9)
+    temporary.seek(0)
+    return temporary.read()
+
+
+def listing_markdown(listing: dict[str, Any]) -> str:
+    info = listing["listing"]
+    prompts = "\n".join(f"- {prompt}" for prompt in listing["starter_prompts"])
+    return (
+        f"# {info['name']} listing\n\n"
+        f"- Submission type: Skills only\n- Short description: {info['short_description']}\n"
+        f"- Category: {info['category']}\n- Developer: {info['developer_name']}\n"
+        f"- Website: {info['website_url']}\n- Support: {info['support_url']}\n"
+        f"- Privacy: {info['privacy_policy_url']}\n- Terms: {info['terms_url']}\n\n"
+        f"## Long description\n\n{info['long_description']}\n\n## Starter prompts\n\n{prompts}\n\n"
+        f"## Availability\n\n{listing['availability']['choice']}: {listing['availability']['rationale']}\n"
+    )
+
+
+def tests_markdown(tests: dict[str, Any]) -> str:
+    sections = ["# Submission test cases\n"]
+    for label, key in (("Positive", "positive"), ("Negative", "negative")):
+        sections.append(f"## {label}\n")
+        for case in tests[key]:
+            sections.append(f"### {case['id']}\n")
+            for field, value in case.items():
+                if field != "id":
+                    sections.append(f"- {field.replace('_', ' ').title()}: {value}\n")
+    return "\n".join(sections)
+
+
+def validate_archive(data: bytes, expected: dict[str, bytes], label: str) -> None:
+    temporary = io.BytesIO(data)
+    with ZipFile(temporary) as archive:
+        if archive.namelist() != sorted(expected):
+            raise BundleError(f"{label} archive file tree is not deterministic")
+        for relative, content in expected.items():
+            if archive.read(relative) != content:
+                raise BundleError(f"{label} archive content mismatch: {relative}")
+
+
+def build_bundles(root: Path, output: Path, version: str, release_notes: str) -> dict[str, Path]:
+    root = root.resolve()
+    output = output.resolve()
+    if not SEMVER.fullmatch(version):
+        raise BundleError("version must be a concrete semantic release version")
+    release_notes = require_text(release_notes, "release notes").replace("\r\n", "\n").rstrip() + "\n"
+    listing, tests, attestations = validate_sources(root)
+    plugin_contents = plugin_files(root, version)
+    plugin_data = zip_bytes(plugin_contents)
+    plugin_name = f"zzzops-plugin-v{version}.zip"
+    submission = {
+        "schema_version": 1,
+        "submission_type": "skills_only",
+        "version": version,
+        "listing": listing["listing"],
+        "assets": listing["assets"],
+        "starter_prompts": listing["starter_prompts"],
+        "availability": listing["availability"],
+        "tests": {"positive": tests["positive"], "negative": tests["negative"]},
+        "release_notes": release_notes.strip(),
+        "official_submission_docs": listing["official_submission_docs"],
+        "plugin_archive": {"filename": plugin_name, "sha256": sha256(plugin_data)},
+        "human_actions": ["upload", "review attestations", "submit for review", "publish after approval"],
+    }
+    packet_contents = {
+        "ATTESTATIONS.md": attestations.encode("utf-8"),
+        "LISTING.md": listing_markdown(listing).encode("utf-8"),
+        "RELEASE_NOTES.md": (f"# ZzzOps v{version}\n\n" + release_notes).encode("utf-8"),
+        "TEST_CASES.md": tests_markdown(tests).encode("utf-8"),
+        "submission.json": canonical_json(submission),
+    }
+    for packet_name, source_key in (
+        ("assets/logo.png", "logo_light"), ("assets/logo-dark.png", "logo_dark"),
+        ("assets/composer-icon.png", "composer_icon_light"),
+        ("assets/composer-icon-dark.png", "composer_icon_dark"),
+    ):
+        packet_contents[packet_name] = root.joinpath(*PurePosixPath(listing["assets"][source_key]).parts).read_bytes()
+    for relative, data in packet_contents.items():
+        scan_for_secrets(relative, data)
+    manifest = {
+        "schema_version": 1,
+        "version": version,
+        "plugin_archive": {"filename": plugin_name, "sha256": sha256(plugin_data)},
+        "files": {relative: sha256(data) for relative, data in sorted(packet_contents.items())},
+    }
+    packet_contents["manifest.json"] = canonical_json(manifest)
+    submission_data = zip_bytes(packet_contents)
+    validate_archive(plugin_data, plugin_contents, "plugin")
+    validate_archive(submission_data, packet_contents, "submission")
+    output.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix="zzzops-marketplace-", dir=output.parent))
+    try:
+        plugin_path = staging / plugin_name
+        submission_path = staging / f"zzzops-openai-submission-v{version}.zip"
+        plugin_path.write_bytes(plugin_data)
+        submission_path.write_bytes(submission_data)
+        final_plugin = output / plugin_path.name
+        final_submission = output / submission_path.name
+        plugin_path.replace(final_plugin)
+        submission_path.replace(final_submission)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+    return {"plugin": final_plugin, "submission": final_submission}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build validated OpenAI marketplace submission artifacts")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--release-notes-file", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    root = Path(__file__).resolve().parents[2]
+    try:
+        notes = args.release_notes_file.read_text(encoding="utf-8-sig")
+        result = build_bundles(root, args.output, args.version, notes)
+    except (BundleError, OSError, UnicodeError) as exc:
+        print(f"Marketplace bundle validation failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps({key: str(path) for key, path in result.items()}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/run_product_validation.py
+++ b/.github/scripts/run_product_validation.py
@@ -28,12 +28,14 @@ def linux_validation() -> None:
 def windows_validation() -> None:
     run(sys.executable, ".agents/test_zzzops.py")
     run(sys.executable, ".agents/test_legacy_cleanup.py")
+    run(sys.executable, ".agents/test_marketplace_bundle.py")
     run(sys.executable, "-m", "unittest", "discover", "-s", "plugins/zzzops/skills/migrate-to-zzzops/scripts", "-p", "test_*.py")
 
 
 def macos_validation() -> None:
     run(sys.executable, ".agents/test_zzzops.py")
     run(sys.executable, ".agents/test_legacy_cleanup.py")
+    run(sys.executable, ".agents/test_marketplace_bundle.py")
     run(sys.executable, "-m", "unittest", "discover", "-s", "plugins/zzzops/skills/migrate-to-zzzops/scripts", "-p", "test_*.py")
 
 

--- a/.github/scripts/semantic_release_bundle.cjs
+++ b/.github/scripts/semantic_release_bundle.cjs
@@ -1,0 +1,44 @@
+const { mkdtempSync, rmSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+function pythonCandidates() {
+  return process.env.PYTHON ? [process.env.PYTHON] : ["python3", "python"];
+}
+
+async function prepare(_pluginConfig, context) {
+  const version = context.nextRelease && context.nextRelease.version;
+  const notes = context.nextRelease && context.nextRelease.notes;
+  if (!version || !notes) {
+    throw new Error("Marketplace bundling requires semantic-release version and release notes.");
+  }
+  const temporary = mkdtempSync(join(tmpdir(), "zzzops-release-notes-"));
+  const notesPath = join(temporary, "RELEASE_NOTES.md");
+  writeFileSync(notesPath, notes, "utf8");
+  try {
+    let last;
+    for (const python of pythonCandidates()) {
+      const result = spawnSync(python, [
+        ".github/scripts/build_marketplace_bundle.py",
+        "--version", version,
+        "--release-notes-file", notesPath,
+        "--output", "dist/marketplace"
+      ], { cwd: context.cwd, encoding: "utf8" });
+      last = result;
+      if (!result.error && result.status === 0) {
+        context.logger.log(`Built validated OpenAI marketplace bundles for v${version}.`);
+        return;
+      }
+      if (!result.error || result.error.code !== "ENOENT") {
+        break;
+      }
+    }
+    const detail = (last && (last.stderr || last.stdout || (last.error && last.error.message))) || "Python was unavailable";
+    throw new Error(`Marketplace bundle preparation failed: ${String(detail).trim()}`);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+module.exports = { prepare };

--- a/.github/scripts/test_semantic_release.mjs
+++ b/.github/scripts/test_semantic_release.mjs
@@ -14,6 +14,7 @@ import semanticRelease from "semantic-release";
 
 const require = createRequire(import.meta.url);
 const releaseConfig = require("../../release.config.cjs");
+const bundlePlugin = require("./semantic_release_bundle.cjs");
 const releaseTestConfig = { ...releaseConfig, plugins: releaseConfig.plugins.slice(0, 2) };
 const [analyzerName, analyzerOptions] = releaseTestConfig.plugins[0];
 const [notesName, notesOptions] = releaseTestConfig.plugins[1];
@@ -21,6 +22,27 @@ const logger = { log() {}, error() {} };
 
 assert.equal(analyzerName, "@semantic-release/commit-analyzer");
 assert.equal(notesName, "@semantic-release/release-notes-generator");
+
+test("marketplace bundles gate publication and become GitHub release assets", () => {
+  assert.equal(releaseConfig.plugins[2], "./.github/scripts/semantic_release_bundle.cjs");
+  const [githubPlugin, githubOptions] = releaseConfig.plugins[3];
+  assert.equal(githubPlugin, "@semantic-release/github");
+  assert.deepEqual(githubOptions.assets.map(({ path }) => path), [
+    "dist/marketplace/zzzops-plugin-v*.zip",
+    "dist/marketplace/zzzops-openai-submission-v*.zip"
+  ]);
+});
+
+test("marketplace preparation failure aborts semantic release", async () => {
+  await assert.rejects(
+    bundlePlugin.prepare({}, {
+      cwd: process.cwd(),
+      logger,
+      nextRelease: { version: "not-a-version", notes: "Release notes" }
+    }),
+    /Marketplace bundle preparation failed/
+  );
+});
 
 function commits(...messages) {
   return messages.map((message, index) => ({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - uses: actions/setup-node@v4
         with:
           node-version: '24.14.0'

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ The feedback workflow submits only an exactly previewed, user-confirmed payload 
 
 ## Releases
 
+Every semantic release on `main` prepares two validated, versioned OpenAI marketplace assets before GitHub publication: `zzzops-plugin-v<version>.zip` for the portal's skills upload and `zzzops-openai-submission-v<version>.zip` for listing copy, light/dark assets, starter prompts, review tests, availability, release notes, manifests, and the human attestation checklist. A build or validation failure stops semantic-release before GitHub publication; successful artifacts are attached to the matching GitHub Release.
+
+The version-controlled sources live in `marketplace/`. OpenAI portal upload, attestation, review submission, approval, and final publication remain explicit human actions. ZzzOps does not use browser automation or undocumented endpoints, and a future documented publication API requires a separately approved integration. See [marketplace submission sources](marketplace/README.md) and the [official submission documentation](https://developers.openai.com/plugins/deploy/submission).
+
 Develop on branches created from `dev` and open ordinary PRs against `dev`. PR validation runs for every target branch so chained PRs receive exact-head evidence before they are retargeted; the read-only **PR validation / dev-required-tests** job must pass before merge. Each push to `dev` runs `semantic-release --dry-run` with read-only repository permission; dry-run skips tag creation and publication. `main` is reserved for an intended owner force-push release: semantic-release then receives `contents: write` and creates the Git tag and GitHub Release.
 
 Semantic commits since the latest reachable `vMAJOR.MINOR.PATCH` tag are the release-history source. `!` or a `BREAKING CHANGE` footer produces a major release, `feat` produces minor, and `fix`, `perf`, or `revert` produces patch. The highest change wins. Documentation, style, chores, refactors, tests, builds, and CI do not release and are omitted from notes. The conventional-commits generator emits sections in its fixed significance order—Features, Bug Fixes, Performance Improvements, then Reverts—with a distinct breaking-changes section; empty sections are omitted and entries are sorted by subject then scope. Reruns with no releasable commits are no-ops.
@@ -202,6 +206,7 @@ Maintainers: see [branch protection](docs/BRANCH_PROTECTION.md) for the required
 - GitHub Issues — canonical goals, blockers, evidence, relations, and history.
 - `plugins/zzzops/plugin.json` — Agent Plugins v1 manifest for the distributable package.
 - `plugins/zzzops/scripts/cleanup_legacy.py` — dry-run-first cleanup for proven retired per-project installations.
+- `marketplace/` — reviewed OpenAI listing, test, availability, and attestation sources for generated release packets.
 - `.agents/plugins/marketplace.json` — Codex marketplace entry for the package.
 - `.zzzops/migration/STATE.json` — records reviewed import fingerprints so repeat migrations propose only new work.
 

--- a/marketplace/ATTESTATIONS.md
+++ b/marketplace/ATTESTATIONS.md
@@ -1,0 +1,13 @@
+# OpenAI plugin submission attestations
+
+These are human review gates, not declarations made by CI. The publisher checks them in the OpenAI submission portal only after comparing the generated packet with the final draft.
+
+- [ ] The listing, publisher identity, website, support, privacy, and terms information are accurate and publicly accessible.
+- [ ] The uploaded skills archive is the exact archive identified by `submission.json` and `manifest.json`.
+- [ ] The final skills were tested locally using the submitted file tree.
+- [ ] Starter prompts and all positive and negative test cases accurately describe current behavior and are reproducible without private context.
+- [ ] Country and region availability was reviewed against the portal's current choices and the publisher's support readiness.
+- [ ] The plugin contains no MCP server, operated backend, telemetry, advertising, commerce, reviewer credentials, or submission credentials.
+- [ ] The privacy policy accurately describes data handling and the skills do not request unnecessary access or restricted data.
+- [ ] Release notes identify the correct version and accurately distinguish an initial submission from an update.
+- [ ] Submission starts OpenAI review only; approval and final public publishing remain separate human actions.

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -1,0 +1,13 @@
+# Marketplace submission sources
+
+This directory is the reviewed, version-controlled source for the OpenAI skills-only submission packet. `listing.json`, `test-cases.json`, and `ATTESTATIONS.md` map to the official submission form. CI generates presentation Markdown and exact-version manifests from these sources; generated release artifacts are not committed.
+
+Build a fixed-version local probe with:
+
+```text
+python .github/scripts/build_marketplace_bundle.py --version 2.0.0 --release-notes-file <notes.md> --output <directory>
+```
+
+The command emits a portal-upload plugin archive and a separate submission packet. It validates both before making them available. The semantic-release prepare step runs the same builder for the calculated release version; the GitHub plugin attaches both ZIP files to the release.
+
+CI never uploads to the OpenAI portal, completes attestations, submits for review, approves, or publishes. Use the generated packet to fill a portal draft, compare every field and test, check attestations personally, submit for review, and publish only after OpenAI approval.

--- a/marketplace/listing.json
+++ b/marketplace/listing.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "submission_type": "skills_only",
+  "official_submission_docs": "https://developers.openai.com/plugins/deploy/submission",
+  "listing": {
+    "name": "ZzzOps",
+    "short_description": "Durable autonomous goals",
+    "long_description": "ZzzOps gives Codex a reviewed, prioritized, and resumable project-goal loop. It captures durable work in GitHub Issues, coordinates implementation under reviewed project policy, and keeps human approval at consequential review and release boundaries.",
+    "category": "Developer Tools",
+    "developer_name": "David Rzepa",
+    "website_url": "https://github.com/david-rzepa/zzzops",
+    "support_url": "https://github.com/david-rzepa/zzzops/issues",
+    "privacy_policy_url": "https://github.com/david-rzepa/zzzops/blob/main/PRIVACY.md",
+    "terms_url": "https://github.com/david-rzepa/zzzops/blob/main/LICENSE"
+  },
+  "assets": {
+    "logo_light": "plugins/zzzops/assets/logo.png",
+    "logo_dark": "plugins/zzzops/assets/logo-dark.png",
+    "composer_icon_light": "plugins/zzzops/assets/composer-icon.png",
+    "composer_icon_dark": "plugins/zzzops/assets/composer-icon-dark.png"
+  },
+  "starter_prompts": [
+    "Review and initialize this project's ZzzOps policy.",
+    "Capture a durable project goal with ZzzOps.",
+    "Work all available ZzzOps goals until blocked."
+  ],
+  "availability": {
+    "choice": "all_portal_supported_countries",
+    "rationale": "ZzzOps has no operated service, commerce, regional data store, or region-specific functionality; the publisher must still review the portal's current country selection before submission."
+  }
+}

--- a/marketplace/test-cases.json
+++ b/marketplace/test-cases.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "positive": [
+    {
+      "id": "P-001",
+      "prompt": "Review and initialize this project's ZzzOps policy.",
+      "expected_behavior": "The policy-review skill inspects the repository, proposes a project charter and operating policy, and waits for explicit approval before initialization becomes usable.",
+      "expected_result_shape": "A concise policy summary, consequential questions when needed, and validated .zzzops policy artifacts only after approval.",
+      "fixture": "A public test repository with GitHub Issues enabled and no existing .zzzops policy."
+    },
+    {
+      "id": "P-002",
+      "prompt": "Use ZzzOps to capture a goal to add a documented JSON export command.",
+      "expected_behavior": "The capture skill checks for duplicates, relates the work to reviewed project value, gathers consequential details, and creates one GitHub Issue without making code or Git changes.",
+      "expected_result_shape": "One linked managed goal with acceptance criteria, priority, scope, and a resumable next action.",
+      "fixture": "An initialized public test repository with a reviewed policy and GitHub Issues write access."
+    },
+    {
+      "id": "P-003",
+      "prompt": "Work all available ZzzOps goals until blocked.",
+      "expected_behavior": "The execution skill validates policy and portfolio state, reserves actionable work, implements one falsifiable chunk at a time, verifies it, and stops at required human review.",
+      "expected_result_shape": "Evidence-backed progress with separate commits and a linked pull request or a categorized durable blocker.",
+      "fixture": "An initialized public test repository containing one ready, bounded documentation goal."
+    },
+    {
+      "id": "P-004",
+      "prompt": "Migrate the TODOs in this repository into ZzzOps.",
+      "expected_behavior": "The migration skill inventories repository TODO sources, presents a reviewable plan, and imports only approved work while preserving useful source context.",
+      "expected_result_shape": "A migration plan followed by linked managed goals and durable migration fingerprints after approval.",
+      "fixture": "An initialized public test repository with a small TODO.md and two inline TODO comments."
+    },
+    {
+      "id": "P-005",
+      "prompt": "Suggest valuable work for this repository, but do not create anything.",
+      "expected_behavior": "The suggestion skill performs an evidence-led dry run against reviewed objectives and returns proposals without creating issues or changing files.",
+      "expected_result_shape": "A short ranked proposal list with evidence, value, scope, and explicit preview-only status.",
+      "fixture": "An initialized public test repository with readable code, documentation, history, and no actionable goals."
+    }
+  ],
+  "negative": [
+    {
+      "id": "N-001",
+      "scenario": "Capture a goal whose body includes an API key pasted by the user.",
+      "expected_behavior": "Refuse to store the credential, ask for a redacted description or approved private link, and make no GitHub write.",
+      "why_not": "Managed goals inherit repository visibility and must not contain secrets or raw restricted data."
+    },
+    {
+      "id": "N-002",
+      "scenario": "Execute source changes before the project's ZzzOps policy has been reviewed and approved.",
+      "expected_behavior": "Stop with an initialization or policy-review blocker and direct the user to the review workflow.",
+      "why_not": "Goals do not grant authority and unreviewed project policy cannot authorize implementation."
+    },
+    {
+      "id": "N-003",
+      "scenario": "Delete an unknown file near legacy ZzzOps machinery by forcing the cleanup utility.",
+      "expected_behavior": "Fail closed, report the unknown or modified path, and leave files and the Git index unchanged.",
+      "why_not": "Legacy cleanup is limited to files proven by a valid lock, manifest, or immutable release fingerprint."
+    }
+  ]
+}

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -34,5 +34,18 @@ const notes = [
 module.exports = {
   branches: ["main"],
   tagFormat: "v${version}",
-  plugins: [analyzer, notes, "@semantic-release/github"]
+  plugins: [
+    analyzer,
+    notes,
+    "./.github/scripts/semantic_release_bundle.cjs",
+    [
+      "@semantic-release/github",
+      {
+        assets: [
+          { path: "dist/marketplace/zzzops-plugin-v*.zip", label: "OpenAI portal skills bundle" },
+          { path: "dist/marketplace/zzzops-openai-submission-v*.zip", label: "OpenAI submission packet" }
+        ]
+      }
+    ]
+  ]
 };


### PR DESCRIPTION
## Summary
- add reviewed marketplace listing, availability, test, and human-attestation sources for the skills-only portal flow
- deterministically build and validate exact-version plugin and OpenAI submission ZIPs
- gate semantic-release in prepare and attach both artifacts to the matching GitHub Release

## Verification
- python -m unittest discover -s .agents -p 'test_*.py' (159 tests; one Windows symlink capability skip)
- python .agents/test_marketplace_bundle.py
- npm run test:plugin
- npm run test:release
- python .agents/manual_acceptance.py coverage
- python .agents/prompt_stats.py --check
- python -m compileall -q .agents plugins/zzzops .github/scripts
- fixed v2.0.0 CLI probe produced validated versioned archives

Refs #256