### PR TITLE
feat(goals): add file-backed goal creation

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -63,7 +63,8 @@ class GoalsModuleTests(unittest.TestCase):
             "parse_managed_goal", "validate_managed_goal", "render_managed_goal",
             "github_goal_record", "github_archived_goal_record", "current_goal_schema_label",
             "validate_github_issue_goal", "validate_goal_transition", "load_goal_transition",
-            "apply_goal_transition", "ensure_current_goal_schema", "migrate_open_goal_schemas",
+            "apply_goal_transition", "validate_goal_create", "load_goal_create", "apply_goal_create",
+            "ensure_current_goal_schema", "migrate_open_goal_schemas",
             "GoalTransitionProviderError",
         ):
             self.assertIs(getattr(zzzops, name), getattr(goals, name))
@@ -951,6 +952,20 @@ class FakeGoalTransitionAdapter:
             self.response_mutation(response)
         return response
 
+    def create_issue(self, payload):
+        self.updates.append(json.loads(json.dumps(payload)))
+        if self.failure:
+            raise zzzops.GoalTransitionProviderError(self.failure)
+        number = 42
+        issue = {
+            "number": number, "title": payload["title"], "body": payload["body"], "state": "open",
+            "html_url": f"https://github.com/owner/repo/issues/{number}",
+            "labels": [{"name": label} for label in payload["labels"]],
+        }
+        if self.response_mutation:
+            self.response_mutation(issue)
+        return issue
+
     def get_issue_comments(self, number):
         self.assert_number(number)
         return json.loads(json.dumps(self.comments))
@@ -972,6 +987,136 @@ class FakeGoalTransitionAdapter:
     def assert_number(number):
         if number != 42:
             raise AssertionError(number)
+
+
+class GoalCreateTests(unittest.TestCase):
+    def request(self):
+        return {
+            "schema_version": 1,
+            "title": "Capture Unicode safely",
+            "body": "## Outcome\n\nPreserve café — and multiline text.\n",
+            "labels": ["documentation"],
+            "goal": {
+                "schema_version": 1, "status": "new", "priority": "P2", "value": "high",
+                "difficulty": "S", "confidence": "high", "parent": None, "depends_on": [],
+                "claim": None, "blockers": [], "evidence": ["Observed baseline."],
+                "next_action": "Triage the captured goal.", "revision": 1,
+                "implementation": None, "resources": [],
+            },
+        }
+
+    def test_create_preserves_unicode_and_derives_managed_labels(self):
+        adapter = FakeGoalTransitionAdapter({})
+        request = self.request()
+
+        result = zzzops.apply_goal_create(adapter, "owner/repo", request)
+
+        self.assertEqual(1, len(adapter.updates))
+        payload = adapter.updates[0]
+        self.assertEqual("Capture Unicode safely", payload["title"])
+        self.assertIn("Preserve café — and multiline text.", payload["body"])
+        self.assertEqual(request["goal"], zzzops.parse_managed_goal(payload["body"], 42))
+        self.assertEqual(
+            {"zzzops", "documentation", "zzzops:schema:v1", "zzzops:status:new", "zzzops:priority:P2"},
+            set(payload["labels"]),
+        )
+        self.assertEqual(
+            {"number": 42, "revision": 1, "state": "open", "status": "new",
+             "url": "https://github.com/owner/repo/issues/42"},
+            result,
+        )
+
+    def test_create_rejects_malformed_input_before_provider_write(self):
+        for change in ("title", "marker", "reserved_label", "long_label", "status", "revision", "implementation"):
+            adapter = FakeGoalTransitionAdapter({})
+            request = self.request()
+            if change == "title":
+                request["title"] = " "
+            elif change == "marker":
+                request["body"] += zzzops._goals.GOAL_BLOCK_START
+            elif change == "reserved_label":
+                request["labels"] = ["zzzops:status:ready"]
+            elif change == "long_label":
+                request["labels"] = ["x" * 51]
+            elif change == "status":
+                request["goal"]["status"] = "ready"
+            elif change == "revision":
+                request["goal"]["revision"] = 2
+            else:
+                request["goal"]["implementation"] = {
+                    "branch": None, "base": None, "target": None, "pr": None,
+                    "review": {"status": "not_started", "checkpoint": None},
+                }
+            with self.assertRaises(ValueError, msg=change):
+                zzzops.apply_goal_create(adapter, "owner/repo", request)
+            self.assertEqual([], adapter.updates)
+
+    def test_create_never_implies_success_on_provider_failure_or_bad_response(self):
+        adapter = FakeGoalTransitionAdapter({})
+        adapter.failure = "provider failed"
+        with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "provider failed"):
+            zzzops.apply_goal_create(adapter, "owner/repo", self.request())
+        self.assertEqual(1, len(adapter.updates))
+
+        adapter = FakeGoalTransitionAdapter({})
+        adapter.response_mutation = lambda issue: issue.update({"body": "unexpected"})
+        with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "unexpected"):
+            zzzops.apply_goal_create(adapter, "owner/repo", self.request())
+        self.assertEqual(1, len(adapter.updates))
+
+        adapter = FakeGoalTransitionAdapter({})
+        adapter.response_mutation = lambda issue: issue.update({"body": None})
+        with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "unexpected"):
+            zzzops.apply_goal_create(adapter, "owner/repo", self.request())
+
+        adapter = FakeGoalTransitionAdapter({})
+        adapter.response_mutation = lambda issue: issue.update({"labels": None})
+        with self.assertRaisesRegex(zzzops.GoalTransitionProviderError, "unexpected"):
+            zzzops.apply_goal_create(adapter, "owner/repo", self.request())
+
+    def test_create_file_is_bom_tolerant(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "create.json"
+            request = self.request()
+            path.write_bytes(b"\xef\xbb\xbf" + json.dumps(request, ensure_ascii=False).encode("utf-8"))
+            self.assertEqual(request, zzzops.load_goal_create(path))
+
+    @mock.patch.object(zzzops, "GitHubGoalTransitionAdapter")
+    @mock.patch.object(zzzops, "_project_repository_identity", return_value="owner/repo")
+    @mock.patch.object(zzzops, "reviewed_project_state", return_value={})
+    @mock.patch.object(zzzops, "load_goal_create", return_value={"schema_version": 1})
+    def test_create_cli_validates_before_constructing_provider_adapter(
+        self, _load, _project, _identity, adapter,
+    ):
+        argv = ["zzzops.py", "--repo", ".", "goal", "create", "--input", "create.json"]
+        with mock.patch.object(sys, "argv", argv), mock.patch("sys.stdout", new_callable=io.StringIO):
+            self.assertEqual(2, zzzops.main())
+        adapter.assert_not_called()
+
+    @mock.patch.object(zzzops.shutil, "which", return_value="gh")
+    @mock.patch.object(zzzops.subprocess, "run")
+    def test_github_create_adapter_uses_one_json_stdin_post(self, run, _which):
+        payload = {"title": "Create safely", "body": "Unicode — body", "labels": ["zzzops"]}
+        issue = {
+            "number": 42, "title": payload["title"], "body": payload["body"], "state": "open",
+            "html_url": "https://github.com/owner/repo/issues/42", "labels": [{"name": "zzzops"}],
+        }
+        run.side_effect = [
+            SimpleNamespace(returncode=0, stderr="", stdout=json.dumps({
+                "nameWithOwner": "owner/repo", "hasIssuesEnabled": True, "viewerPermission": "ADMIN",
+            })),
+            SimpleNamespace(returncode=0, stderr="", stdout=json.dumps(issue)),
+        ]
+        adapter = zzzops.GitHubGoalTransitionAdapter(Path.cwd(), "owner/repo")
+
+        self.assertEqual(issue, adapter.create_issue(payload))
+
+        self.assertEqual(2, run.call_count)
+        self.assertEqual(
+            ["gh", "api", "--method", "POST", "repos/owner/repo/issues", "--input", "-"],
+            run.call_args_list[1].args[0],
+        )
+        self.assertEqual(payload, json.loads(run.call_args_list[1].kwargs["input"]))
 
 
 class GoalTransitionTests(unittest.TestCase):

--- a/plugins/zzzops/rules/BACKENDS.md
+++ b/plugins/zzzops/rules/BACKENDS.md
@@ -2,17 +2,16 @@
 
 Canonical policy makes GitHub Issues goal authority; `.zzzops/PROJECT.md` summarizes it.
 
-Require checkpoint `complete:true`/`valid:true`; never rerun `portfolio`. Reads stage from minimal number/title/state/labels, to open or selected bodies, to selected history comments only when material. It returns the active graph/human queue and bodyless terminal projections. Re-read only a selected goal and match revision/digest; inspect a closed goal before using its relationships/history. Refresh once after mutation/drift; standalone `portfolio` is only for comparison.
+Require checkpoint `complete:true`/`valid:true`; never rerun `portfolio`. Stage reads from minimal indexes, to selected bodies, then material comments. Re-read only a selected goal and match revision/digest; inspect a closed goal before using its history. Refresh once after mutation/drift; standalone `portfolio` is comparison-only.
 
 Ordinary checkpoints omit `zzzops-feedback`. `--include-feedback` requires one explicit current-session approval covering the whole queue; never persist it or ask per issue.
 
 ## GitHub Issues (`github_issues`)
 
-`checkpoint` uses one paginated process to confirm identity, auth, Issues, and management permission. Use `gh issue`/`gh api` only for targeted operations; the CLI validates structures. Apply INITIALIZATION's authenticated-context rule to every `gh` path.
+`checkpoint` confirms identity, auth, Issues, and management permission in one paginated process. Use `gh` only for targeted operations and apply INITIALIZATION's authenticated-context rule.
 
-- Identity is repository plus issue number/URL. Use a plain human title without ZzzOps/date ID; start with concise human sections, no rendered metadata/frontmatter or repeated title.
-- Explain that goals inherit repository visibility and forbid secrets/raw sensitive data.
-- Append one hidden `<!-- zzzops-goal ... zzzops-goal -->` JSON state block using `render_managed_goal`. GitHub supplies identity/title; inverse edges, human queue, labels, and open/closed are derived. Preserve unmanaged text.
+- Identity is repository plus issue number/URL. Use a plain title and concise human sections without generated IDs, metadata, frontmatter, or repeated title. Goals inherit repository visibility; forbid secrets/raw sensitive data.
+- Create with `<python> <zzzops-cli> --repo . goal create --input FILE`. Its UTF-8 JSON contains exactly `schema_version`, plain human `title`/`body`, optional non-ZzzOps `labels`, and a complete revision-1 `new` `goal` without claim/implementation. The CLI validates, renders/labels, makes one JSON-stdin create, and confirms identity. Preserve unknowns as blockers; derive inverse edges/queue.
 - Parent/dependencies are same-repository positive issue numbers; derive inverse edges portfolio-wide.
 - Keep bodies current-only: active human sections plus relationships, open blockers, next action, and compact managed state. Before replacement, confirm one lossless content-addressed history comment containing the prior body and requested transition. Retries reuse its transition ID and never duplicate confirmed history.
 - Derive `zzzops`, current `zzzops:schema:v*`, one status, and one priority label. New goals start current; `goal inspect` repairs one selected legacy goal and `goal migrate-open` is bounded/open-only.

--- a/plugins/zzzops/zzzops/goals.py
+++ b/plugins/zzzops/zzzops/goals.py
@@ -29,6 +29,8 @@ GOAL_DIFFICULTIES = {"unknown", "XS", "S", "M", "L", "XL"}
 GOAL_CONFIDENCES = {"low", "medium", "high"}
 GOAL_TRANSITION_SCHEMA_VERSION = 1
 GOAL_TRANSITION_FIELDS = {"schema_version", "expected_revision", "expected_digest", "goal"}
+GOAL_CREATE_SCHEMA_VERSION = 1
+GOAL_CREATE_FIELDS = {"schema_version", "title", "body", "labels", "goal"}
 BLOCKER_CATEGORIES = {"specification", "decision", "access-approval", "human-action", "external-dependency", "technical-unknown", "safety-compliance"}
 REDUNDANT_GOAL_TITLE_PREFIX = re.compile(r"^\[G-\d{8}-\d{3}-[^\]]+\]\s*")
 HISTORICAL_HUMAN_SECTIONS = {
@@ -40,7 +42,7 @@ _text_present: Callable[[Any], bool] | None = None
 
 
 class GoalTransitionProviderError(ValueError):
-    """The provider did not produce a safe, confirmed goal transition result."""
+    """The provider did not produce a safe, confirmed goal-operation result."""
 
 def configure_entrypoint(*, normalize_resources: Callable[[Any], list[str]], text_present: Callable[[Any], bool]) -> None:
     global _normalize_resources, _text_present
@@ -393,6 +395,115 @@ def github_archived_goal_record(issue: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def validate_goal_create(request: Any) -> list[str]:
+    if not isinstance(request, dict):
+        return ["goal create request must be an object"]
+    errors = []
+    unknown = sorted(set(request) - GOAL_CREATE_FIELDS)
+    missing = sorted(GOAL_CREATE_FIELDS - set(request))
+    if unknown:
+        errors.append("unknown goal create fields: " + ", ".join(unknown))
+    if missing:
+        errors.append("missing goal create fields: " + ", ".join(missing))
+    if request.get("schema_version") != GOAL_CREATE_SCHEMA_VERSION:
+        errors.append(f"goal create schema_version must be {GOAL_CREATE_SCHEMA_VERSION}")
+    title = request.get("title")
+    if not isinstance(title, str) or not title.strip():
+        errors.append("title is required")
+    elif title != title.strip():
+        errors.append("title must be trimmed")
+    elif len(title) > 256:
+        errors.append("title must be at most 256 characters")
+    elif REDUNDANT_GOAL_TITLE_PREFIX.match(title):
+        errors.append("title must not include a generated goal identifier")
+    body = request.get("body")
+    if not isinstance(body, str) or not body.strip():
+        errors.append("body is required")
+    elif GOAL_BLOCK_START in body or GOAL_BLOCK_END in body:
+        errors.append("body must not contain a managed goal block")
+    labels = request.get("labels")
+    if not isinstance(labels, list):
+        errors.append("labels must be a list")
+    else:
+        invalid_labels = [
+            label for label in labels
+            if not isinstance(label, str) or not label.strip() or label != label.strip() or len(label) > 50
+            or label == "zzzops" or label.startswith("zzzops:")
+        ]
+        if invalid_labels:
+            errors.append("labels must be trimmed non-ZzzOps label names")
+        if len({label.casefold() for label in labels if isinstance(label, str)}) != len(labels):
+            errors.append("labels must be unique")
+    goal = request.get("goal")
+    errors.extend(validate_managed_goal(goal))
+    if isinstance(goal, dict):
+        if goal.get("status") != "new":
+            errors.append("newly created goals must have status new")
+        if goal.get("revision") != 1:
+            errors.append("newly created goals must have revision 1")
+        if goal.get("claim") is not None:
+            errors.append("newly created goals must not have a claim")
+        if goal.get("implementation") is not None:
+            errors.append("newly created goals must not have implementation state")
+    return errors
+
+
+def load_goal_create(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.resolve().read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Could not read goal create request: {type(exc).__name__}") from exc
+
+
+def apply_goal_create(adapter: Any, repository: str, request: dict[str, Any]) -> dict[str, Any]:
+    errors = validate_goal_create(request)
+    if errors:
+        raise ValueError("Invalid goal create request: " + "; ".join(errors))
+    if adapter.repository.casefold() != repository.casefold():
+        raise GoalTransitionProviderError("Repository identity changed; no goal was created.")
+    goal = request["goal"]
+    body = render_managed_goal(goal, request["body"])
+    if len(body) > 65536:
+        raise ValueError("Rendered goal body exceeds GitHub's issue limit")
+    labels = [
+        "zzzops", *request["labels"], current_goal_schema_label(),
+        f"zzzops:status:{goal['status']}", f"zzzops:priority:{goal['priority']}",
+    ]
+    created = adapter.create_issue({"title": request["title"], "body": body, "labels": labels})
+    if not isinstance(created, dict):
+        raise GoalTransitionProviderError(
+            "GitHub returned an unexpected goal-create response; success was not assumed."
+        )
+    number = created.get("number")
+    expected_url = f"https://github.com/{repository}/issues/{number}"
+    returned_label_items = created.get("labels")
+    returned_labels = None if not isinstance(returned_label_items, list) else {
+        label["name"] for label in returned_label_items
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    }
+    try:
+        returned_goal = parse_managed_goal(created.get("body"), number)
+    except (TypeError, ValueError) as exc:
+        raise GoalTransitionProviderError(
+            "GitHub returned an unexpected goal-create response; success was not assumed."
+        ) from exc
+    if (
+        not isinstance(number, int) or isinstance(number, bool) or number < 1
+        or created.get("title") != request["title"]
+        or created.get("body") != body
+        or str(created.get("state", "")).casefold() != "open"
+        or returned_labels != set(labels)
+        or created.get("html_url") != expected_url
+        or returned_goal != goal
+    ):
+        raise GoalTransitionProviderError(
+            "GitHub returned an unexpected goal-create response; success was not assumed."
+        )
+    return {
+        "number": number, "revision": 1, "state": "open", "status": "new", "url": expected_url,
+    }
+
+
 def validate_goal_transition(transition: Any, issue_number: int) -> list[str]:
     if not isinstance(transition, dict):
         return ["transition must be an object"]
@@ -601,4 +712,3 @@ def migrate_open_goal_schemas(
         "migrated": migrated, "already_current": already_current,
         "remaining": remaining, "complete": remaining == 0,
     }
-

--- a/plugins/zzzops/zzzops/zzzops.py
+++ b/plugins/zzzops/zzzops/zzzops.py
@@ -172,6 +172,9 @@ current_goal_schema_label = _goals.current_goal_schema_label
 validate_goal_transition = _goals.validate_goal_transition
 load_goal_transition = _goals.load_goal_transition
 apply_goal_transition = _goals.apply_goal_transition
+validate_goal_create = _goals.validate_goal_create
+load_goal_create = _goals.load_goal_create
+apply_goal_create = _goals.apply_goal_create
 ensure_current_goal_schema = _goals.ensure_current_goal_schema
 migrate_open_goal_schemas = _goals.migrate_open_goal_schemas
 
@@ -224,13 +227,13 @@ class GitHubGoalTransitionAdapter:
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
             raise GoalTransitionProviderError(
-                f"GitHub did not confirm the goal transition ({type(exc).__name__}); success was not assumed."
+                f"GitHub did not confirm the goal operation ({type(exc).__name__}); success was not assumed."
             ) from exc
 
     @staticmethod
     def _provider_error(result: subprocess.CompletedProcess[str]) -> GoalTransitionProviderError:
         detail = sanitize_output((result.stderr.strip() or result.stdout.strip() or "unknown GitHub error").splitlines()[0][:300])
-        return GoalTransitionProviderError(f"GitHub did not confirm the goal transition: {detail}")
+        return GoalTransitionProviderError(f"GitHub did not confirm the goal operation: {detail}")
 
     def ensure_identity(self) -> None:
         if self._identity_checked:
@@ -277,6 +280,26 @@ class GitHubGoalTransitionAdapter:
         if not isinstance(issue, dict):
             raise GoalTransitionProviderError(
                 "GitHub returned an incomplete goal-transition response; success was not assumed."
+            )
+        return issue
+
+    def create_issue(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.ensure_identity()
+        result = self._run(
+            ["api", "--method", "POST", f"repos/{self.repository}/issues", "--input", "-"],
+            input_text=json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        )
+        if result.returncode:
+            raise self._provider_error(result)
+        try:
+            issue = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise GoalTransitionProviderError(
+                "GitHub returned an invalid goal-create response; success was not assumed."
+            ) from exc
+        if not isinstance(issue, dict):
+            raise GoalTransitionProviderError(
+                "GitHub returned an incomplete goal-create response; success was not assumed."
             )
         return issue
 
@@ -1645,8 +1668,10 @@ def main() -> int:
     portfolio_parser.add_argument("--include-done", action="store_true", help="Include terminal goals in summary output")
     portfolio_parser.add_argument("--compare", type=Path, help="Prior JSON snapshot used only to report digest/revision drift")
     portfolio_parser.add_argument("--include-feedback", action="store_true", help="Include specially tagged feedback goals")
-    goal_command = commands.add_parser("goal", help="Apply validated GitHub-backed goal transitions")
+    goal_command = commands.add_parser("goal", help="Create, transition, or inspect validated GitHub-backed goals")
     goal_commands = goal_command.add_subparsers(dest="goal_command", required=True)
+    create_goal_command = goal_commands.add_parser("create", help="Create one goal from a validated UTF-8 request file")
+    create_goal_command.add_argument("--input", type=Path, required=True, help="UTF-8 goal create JSON file")
     transition_command = goal_commands.add_parser("transition", help="Apply one file-backed managed-goal transition")
     transition_command.add_argument("--goal", type=int, required=True)
     transition_command.add_argument("--input", type=Path, required=True, help="UTF-8 transition JSON file")
@@ -1737,7 +1762,14 @@ def main() -> int:
         elif args.command == "goal":
             project = reviewed_project_state(repo)
             repository = _project_repository_identity(project)
-            if args.goal_command == "transition":
+            if args.goal_command == "create":
+                request = load_goal_create(args.input)
+                errors = validate_goal_create(request)
+                if errors:
+                    raise ValueError("Invalid goal create request: " + "; ".join(errors))
+                adapter = GitHubGoalTransitionAdapter(repo, repository)
+                result = apply_goal_create(adapter, repository, request)
+            elif args.goal_command == "transition":
                 transition = load_goal_transition(args.input)
                 adapter = GitHubGoalTransitionAdapter(repo, repository)
                 result = apply_goal_transition(adapter, repository, args.goal, transition)


### PR DESCRIPTION
Tracks #264. Adds a validated UTF-8 goal create request, one JSON-stdin GitHub create call with exact response confirmation, focused Unicode and failure tests, and concise backend guidance.