### PR TITLE
feat(goals): derive effective engineering rigor

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -923,6 +923,25 @@ class ManagedGoalTests(unittest.TestCase):
             candidate[field] = value
             self.assertIn(f"{field} is invalid", zzzops.validate_managed_goal(candidate))
 
+    def test_managed_goal_persists_only_risk_inputs_not_derived_rigor(self):
+        goal = self.goal()
+        goal["engineering_rigor"] = {
+            "risk_categories": ["authentication", "security_sensitive"],
+            "override": {"level": "agentic", "authority": "goal_requirement", "evidence": "Public authentication boundary."},
+        }
+        self.assertEqual([], zzzops.validate_managed_goal(goal))
+        self.assertEqual(goal, zzzops.parse_managed_goal(zzzops.render_managed_goal(goal, "## Outcome\n\nRisky work.\n")))
+
+        for mutation, expected in (
+            (lambda value: value.update({"effective": "agentic"}), "unknown engineering_rigor fields"),
+            (lambda value: value.update({"risk_categories": ["Authentication"]}), "risk_categories entries"),
+            (lambda value: value.update({"risk_categories": ["payments", "payments"]}), "risk_categories must be unique"),
+            (lambda value: value.update({"override": {"level": "extreme", "authority": "goal_requirement", "evidence": "Reason"}}), "override.level"),
+        ):
+            invalid = json.loads(json.dumps(goal))
+            mutation(invalid["engineering_rigor"])
+            self.assertTrue(any(expected in error for error in zzzops.validate_managed_goal(invalid)), expected)
+
 
 class FakeGoalTransitionAdapter:
     def __init__(self, issue):
@@ -1129,6 +1148,10 @@ class GoalTransitionTests(unittest.TestCase):
             "implementation": {"branch": None, "base": None, "target": None, "pr": None,
                                "review": {"status": "not_started", "checkpoint": None}},
             "resources": [],
+            "engineering_rigor": {
+                "risk_categories": ["authentication"],
+                "override": None,
+            },
         }
 
     def issue(self):
@@ -1172,6 +1195,11 @@ class GoalTransitionTests(unittest.TestCase):
         self.assertEqual(issue["body"], history["prior_body"])
         self.assertEqual(["Baseline."], history["requested_goal"]["evidence"])
         self.assertEqual([], zzzops.parse_managed_goal(payload["body"], 42)["evidence"])
+        self.assertEqual(
+            {"risk_categories": ["authentication"], "override": None},
+            zzzops.parse_managed_goal(payload["body"], 42)["engineering_rigor"],
+        )
+        self.assertNotIn("effective", history["requested_goal"]["engineering_rigor"])
 
         adapter = FakeGoalTransitionAdapter(issue)
         transition = self.transition(issue)
@@ -1491,6 +1519,57 @@ class PortfolioTests(unittest.TestCase):
         self.assertEqual(4, snapshot["summary"]["available"])
         self.assertEqual(2, snapshot["summary"]["writable"])
         self.assertEqual(1, snapshot["summary"]["waiting"])
+
+    def test_snapshot_derives_effective_rigor_and_auditable_provenance(self):
+        plan = json.loads((PLUGIN_ROOT / "zzzops" / "templates" / "project-goals" / "INIT_PLAN.json").read_text(encoding="utf-8"))
+        rigor_policy = next(item for item in plan["policy"]["sections"] if item["id"] == "engineering_rigor")
+        records = [
+            zzzops.github_goal_record(self.issue(1)),
+            zzzops.github_goal_record(self.issue(2, engineering_rigor={"risk_categories": ["authentication"], "override": None})),
+            zzzops.github_goal_record(self.issue(3, engineering_rigor={
+                "risk_categories": ["throwaway_prototypes"],
+                "override": {"level": "vibe", "authority": "explicit_user", "evidence": "User authorized a disposable spike."},
+            })),
+            zzzops.github_goal_record(self.issue(4, engineering_rigor={
+                "risk_categories": ["payments"],
+                "override": {"level": "structured", "authority": "explicit_user", "evidence": "Requested lower rigor."},
+            })),
+            zzzops.github_goal_record(self.issue(5, engineering_rigor={
+                "risk_categories": [],
+                "override": {"level": "agentic", "authority": "goal_requirement", "evidence": "Goal requires stronger evidence."},
+            })),
+            zzzops.github_goal_record(self.issue(6, engineering_rigor={
+                "risk_categories": ["unreviewed_category"], "override": None,
+            })),
+        ]
+        snapshot = zzzops.build_portfolio_snapshot(
+            "github_issues", records, reads=1, raw_bytes=100, rigor_policy=rigor_policy,
+        )
+        by_key = {item["key"]: item["engineering_rigor"] for item in snapshot["goals"]}
+        self.assertEqual("structured", by_key[1]["effective"])
+        self.assertEqual("agentic", by_key[2]["effective"])
+        self.assertEqual({"authentication": "agentic"}, by_key[2]["provenance"]["matched_minimums"])
+        self.assertEqual("vibe", by_key[3]["effective"])
+        self.assertEqual("agentic", by_key[4]["effective"])
+        self.assertFalse(by_key[4]["valid"])
+        self.assertIn("override_below_risk_minimum", by_key[4]["errors"])
+        self.assertEqual("agentic", by_key[5]["effective"])
+        self.assertTrue(by_key[5]["valid"])
+        self.assertEqual("structured", by_key[6]["effective"])
+        self.assertFalse(by_key[6]["valid"])
+        self.assertIn("unknown_risk_categories", by_key[6]["errors"])
+        self.assertEqual(["unreviewed_category"], by_key[6]["provenance"]["unknown_risk_categories"])
+        self.assertIn("engineering_rigor_override_below_risk_minimum", {item["code"] for item in snapshot["findings"]})
+        self.assertIn(
+            "engineering_rigor_unknown_risk_categories",
+            {item["code"] for item in snapshot["findings"]},
+        )
+        self.assertFalse(snapshot["valid"])
+
+        legacy = zzzops.build_portfolio_snapshot("github_issues", records[:1], reads=1, raw_bytes=100)
+        legacy_rigor = legacy["goals"][0]["engineering_rigor"]
+        self.assertIsNone(legacy_rigor["effective"])
+        self.assertEqual("legacy_policy", legacy_rigor["provenance"]["status"])
 
     def test_snapshot_derives_graph_work_state_and_compact_summary(self):
         records = [

--- a/plugins/zzzops/zzzops/goals.py
+++ b/plugins/zzzops/zzzops/goals.py
@@ -20,13 +20,15 @@ GOAL_SCHEMA_LABEL_PREFIX = "zzzops:schema:v"
 GOAL_FIELDS = {
     "schema_version", "status", "priority", "value", "difficulty", "confidence",
     "parent", "depends_on", "claim", "blockers", "evidence", "next_action",
-    "revision", "implementation", "resources",
+    "revision", "implementation", "resources", "engineering_rigor",
 }
 GOAL_STATUSES = {"new", "triaged", "ready", "in_progress", "blocked", "done", "cancelled"}
 GOAL_PRIORITIES = {"P0", "P1", "P2", "P3"}
 GOAL_VALUES = {"critical", "high", "medium", "low"}
 GOAL_DIFFICULTIES = {"unknown", "XS", "S", "M", "L", "XL"}
 GOAL_CONFIDENCES = {"low", "medium", "high"}
+ENGINEERING_RIGOR_LEVELS = {"vibe", "structured", "agentic"}
+ENGINEERING_RIGOR_OVERRIDE_AUTHORITIES = {"explicit_user", "goal_requirement"}
 GOAL_TRANSITION_SCHEMA_VERSION = 1
 GOAL_TRANSITION_FIELDS = {"schema_version", "expected_revision", "expected_digest", "goal"}
 GOAL_CREATE_SCHEMA_VERSION = 1
@@ -118,6 +120,37 @@ def validate_managed_goal(goal: Any, issue_number: int | None = None) -> list[st
                 errors.append(f"blockers[{index}] must be an object")
             elif blocker.get("status") == "open" and blocker.get("category") not in BLOCKER_CATEGORIES:
                 errors.append(f"blockers[{index}].category is invalid or missing")
+    rigor = goal.get("engineering_rigor")
+    if rigor is not None:
+        if not isinstance(rigor, dict):
+            errors.append("engineering_rigor must be an object or null")
+        else:
+            unknown_rigor = sorted(set(rigor) - {"risk_categories", "override"})
+            if unknown_rigor:
+                errors.append("unknown engineering_rigor fields: " + ", ".join(unknown_rigor))
+            categories = rigor.get("risk_categories")
+            if not isinstance(categories, list):
+                errors.append("engineering_rigor.risk_categories must be a list")
+            else:
+                if any(
+                    not isinstance(item, str) or not item or item.casefold() != item
+                    or not item.replace("_", "").isalnum()
+                    for item in categories
+                ):
+                    errors.append("engineering_rigor.risk_categories entries must be lowercase identifiers")
+                if len(categories) != len(set(categories)):
+                    errors.append("engineering_rigor.risk_categories must be unique")
+            override = rigor.get("override")
+            if override is not None:
+                if not isinstance(override, dict) or set(override) != {"level", "authority", "evidence"}:
+                    errors.append("engineering_rigor.override must contain level, authority, and evidence")
+                else:
+                    if override.get("level") not in ENGINEERING_RIGOR_LEVELS:
+                        errors.append("engineering_rigor.override.level is invalid")
+                    if override.get("authority") not in ENGINEERING_RIGOR_OVERRIDE_AUTHORITIES:
+                        errors.append("engineering_rigor.override.authority is invalid")
+                    if not _text_present(override.get("evidence")):
+                        errors.append("engineering_rigor.override.evidence is required")
     if not isinstance(goal.get("revision"), int) or isinstance(goal.get("revision"), bool) or goal.get("revision", 0) < 1:
         errors.append("revision must be a positive integer")
     implementation = goal.get("implementation")
@@ -354,6 +387,7 @@ def github_goal_record(issue: dict[str, Any]) -> dict[str, Any]:
         "next_action": goal["next_action"], "revision": goal["revision"],
         "digest": hashlib.sha256(digest_source.encode("utf-8")).hexdigest(),
         "updated_at": issue.get("updated_at"), "implementation": goal.get("implementation"),
+        "engineering_rigor": goal.get("engineering_rigor"),
         "labels": label_names, "schema_version": schema_versions[0] if len(schema_versions) == 1 else None,
         "state": issue.get("state"), "url": issue.get("html_url"),
     }
@@ -392,6 +426,7 @@ def github_archived_goal_record(issue: dict[str, Any]) -> dict[str, Any]:
         "revision": None, "digest": hashlib.sha256(digest_source.encode("utf-8")).hexdigest(),
         "updated_at": None, "implementation": None, "labels": labels, "state": "closed",
         "url": issue.get("html_url"), "schema_version": issue.get("schema_version"),
+        "engineering_rigor": None,
     }
 
 

--- a/plugins/zzzops/zzzops/portfolio.py
+++ b/plugins/zzzops/zzzops/portfolio.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 PORTFOLIO_SCHEMA_VERSION = 2
 AVAILABLE_WORK_STATES = {"triage", "prepare", "write"}
+ENGINEERING_RIGOR_LEVELS = ("vibe", "structured", "agentic")
 _exclusive_resources: Callable[[list[str], Any], list[str]] | None = None
 _normalize_resource_policy: Callable[[Any], dict[str, Any]] | None = None
 _text_present: Callable[[Any], bool] | None = None
@@ -59,6 +60,66 @@ def _cycle_nodes(records: list[dict[str, Any]], relation: str) -> set[Any]:
 
 def _portfolio_key(value: Any) -> tuple[int, Any]:
     return (0, value) if isinstance(value, int) and not isinstance(value, bool) else (1, str(value))
+
+
+def derive_engineering_rigor(persisted: Any, policy: Any) -> dict[str, Any]:
+    inputs = persisted if isinstance(persisted, dict) else {}
+    raw_categories = inputs.get("risk_categories", [])
+    categories = list(raw_categories) if isinstance(raw_categories, list) else []
+    override = inputs.get("override") if isinstance(inputs.get("override"), dict) else None
+    errors: list[str] = []
+    if persisted is not None and not isinstance(persisted, dict):
+        errors.append("metadata_invalid")
+    elif isinstance(persisted, dict):
+        if not isinstance(raw_categories, list):
+            errors.append("risk_categories_invalid")
+        if persisted.get("override") is not None and override is None:
+            errors.append("override_invalid")
+    projection = {
+        "risk_categories": categories, "override": override, "effective": None,
+        "valid": not errors, "errors": errors,
+    }
+    if not isinstance(policy, dict) or policy.get("decision") not in ENGINEERING_RIGOR_LEVELS:
+        projection["provenance"] = {"status": "legacy_policy", "project_default": None, "matched_minimums": {}}
+        return projection
+    settings = policy.get("settings") if isinstance(policy.get("settings"), dict) else {}
+    minimums = settings.get("minimums") if isinstance(settings.get("minimums"), dict) else {}
+    overrides = settings.get("overrides") if isinstance(settings.get("overrides"), dict) else {}
+    rank = {level: index for index, level in enumerate(ENGINEERING_RIGOR_LEVELS)}
+    unknown_categories = sorted({category for category in categories if category not in minimums})
+    if unknown_categories:
+        errors.append("unknown_risk_categories")
+    matched = {category: minimums[category] for category in categories if minimums.get(category) in rank}
+    default = policy["decision"]
+    risk_floor = max(matched.values(), key=rank.get) if matched else None
+    floor = max((default, risk_floor), key=rank.get) if risk_floor else default
+    effective = floor
+    if override is not None and override.get("level") in rank:
+        requested = override["level"]
+        if overrides.get("per_goal") is not True:
+            errors.append("per_goal_override_disabled")
+        elif rank[requested] >= rank[floor]:
+            if rank[requested] > rank[floor] and overrides.get("raising") != "allowed":
+                errors.append("override_raising_disabled")
+            else:
+                effective = requested
+        elif risk_floor is not None and rank[requested] < rank[risk_floor]:
+            errors.append("override_below_risk_minimum")
+        elif overrides.get("lowering") != "explicit_user_authority":
+            errors.append("override_lowering_disabled")
+        elif override.get("authority") != "explicit_user":
+            errors.append("override_authority_required")
+        else:
+            effective = requested
+    projection.update({
+        "effective": effective, "valid": not errors, "errors": errors,
+        "provenance": {
+            "status": "derived", "project_default": default, "matched_minimums": matched,
+            "unknown_risk_categories": unknown_categories,
+            "rule": "reviewed_default_risk_minimum_and_authorized_override",
+        },
+    })
+    return projection
 
 
 def _review_ready_dependency(record: dict[str, Any]) -> bool:
@@ -186,6 +247,14 @@ def audit_portfolio(
             terminal = record["status"] in {"done", "cancelled"}
             if terminal != (record.get("state") == "closed"):
                 findings.append({"code": "issue_state_drift", "goal": key, "detail": f"goal={record['status']}; issue={record.get('state')}"})
+        rigor = record.get("engineering_rigor")
+        if isinstance(rigor, dict):
+            for error in rigor.get("errors", []):
+                detail = error
+                if error == "unknown_risk_categories":
+                    unknown = rigor.get("provenance", {}).get("unknown_risk_categories", [])
+                    detail = "unknown risk categories: " + ", ".join(unknown)
+                findings.append({"code": f"engineering_rigor_{error}", "goal": key, "detail": detail})
     for relation in ("depends_on", "parent"):
         for key in sorted(_cycle_nodes(records, relation), key=_portfolio_key):
             findings.append({"code": f"{relation}_cycle", "goal": key, "detail": "cycle member"})
@@ -195,7 +264,7 @@ def audit_portfolio(
 def build_portfolio_snapshot(
     backend: str, records: list[dict[str, Any]], *, reads: int, raw_bytes: int,
     ignored: int = 0, as_of: datetime | None = None, git_policy: dict[str, Any] | None = None,
-    resource_policy: Any = None,
+    resource_policy: Any = None, rigor_policy: Any = None,
 ) -> dict[str, Any]:
     _, normalize_resource_policy, _ = _require_configured()
     for record in records:
@@ -211,6 +280,7 @@ def build_portfolio_snapshot(
     for record in records:
         record["children"].sort(key=_portfolio_key)
         record["blocks"].sort(key=_portfolio_key)
+        record["engineering_rigor"] = derive_engineering_rigor(record.get("engineering_rigor"), rigor_policy)
     resource_policy = normalize_resource_policy(resource_policy)
     findings = audit_portfolio(records, backend, as_of, resource_policy)
     terminal = {"done", "cancelled"}
@@ -226,6 +296,7 @@ def build_portfolio_snapshot(
         (
             "git_policy:" + json.dumps(git_policy, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
             + "resource_policy:" + json.dumps(resource_policy, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+            + "rigor_policy:" + json.dumps(rigor_policy, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
             + "\n".join(
                 f"{record['key']}:{record['revision']}:{record['digest']}"
                 for record in sorted(records, key=lambda item: _portfolio_key(item["key"]))

--- a/plugins/zzzops/zzzops/zzzops.py
+++ b/plugins/zzzops/zzzops/zzzops.py
@@ -77,11 +77,7 @@ policy_default_catalog = _policy.policy_default_catalog
 policy_content_digest = _policy.policy_content_digest
 prepare_policy_defaults = _policy.prepare_policy_defaults
 compare_policy_defaults = _policy.compare_policy_defaults
-GOAL_FIELDS = {
-    "schema_version", "status", "priority", "value", "difficulty", "confidence",
-    "parent", "depends_on", "claim", "blockers",
-    "evidence", "next_action", "revision", "implementation", "resources",
-}
+GOAL_FIELDS = _goals.GOAL_FIELDS
 GOAL_TRANSITION_FIELDS = {"schema_version", "expected_revision", "expected_digest", "goal"}
 BLOCKER_CATEGORIES = {
     "specification", "decision", "access-approval", "human-action",
@@ -154,6 +150,7 @@ _portfolio_key = _portfolio._portfolio_key
 audit_portfolio = _portfolio.audit_portfolio
 build_portfolio_snapshot = _portfolio.build_portfolio_snapshot
 compact_portfolio_output = _portfolio.compact_portfolio_output
+derive_engineering_rigor = _portfolio.derive_engineering_rigor
 
 parse_managed_goal = _goals.parse_managed_goal
 validate_managed_goal = _goals.validate_managed_goal
@@ -853,6 +850,14 @@ def github_repository_portfolio_snapshot(
             {},
         ),
         resource_policy=project_resource_policy(project),
+        rigor_policy=next(
+            (
+                section for section in ((project.get("policy") or {}).get("sections") or [])
+                if isinstance(section, dict) and section.get("id") == "engineering_rigor"
+                and isinstance(section.get("review"), dict) and section["review"].get("approved") is True
+            ),
+            None,
+        ),
     )
     snapshot["findings"] = sorted(snapshot["findings"] + findings, key=lambda item: (item["code"], str(item["goal"])))
     snapshot["summary"]["findings"] = len(snapshot["findings"])


### PR DESCRIPTION
## Summary
- persist goal risk inputs and permitted overrides without storing derived completion state
- derive effective rigor and auditable provenance from reviewed project policy
- fail closed on unknown risk categories and forbidden de-escalation
- preserve legacy goals and policies until policy review

## Verification
- python -m unittest discover -s .agents -p 'test_*.py' (169 passed, 1 skipped)
- python .agents/prompt_stats.py --check
- python -m py_compile plugins/zzzops/zzzops/goals.py plugins/zzzops/zzzops/portfolio.py plugins/zzzops/zzzops/zzzops.py
- git diff --check

Closes #275