### PR TITLE
feat(plugin): identify skill build provenance

### DIFF
--- a/.agents/skills/install-zzzops-dev/scripts/install_dev.py
+++ b/.agents/skills/install-zzzops-dev/scripts/install_dev.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import runpy
 import shutil
 import subprocess
 import sys
@@ -67,6 +68,41 @@ def cachebusted_manifest(original: bytes, manifest_path: Path, cachebuster: str)
     return (json.dumps(payload, indent=2) + "\n").encode("utf-8")
 
 
+def development_plugin_files(plugin_path: Path, cachebuster: str) -> dict[Path, bytes]:
+    manifest_paths = [plugin_path / "plugin.json", plugin_path / ".codex-plugin/plugin.json"]
+    originals = {path: path.read_bytes() for path in manifest_paths}
+    bases = set()
+    for path, original in originals.items():
+        version = json.loads(original.decode("utf-8")).get("version")
+        if not isinstance(version, str) or not version:
+            raise RuntimeError(f"missing version in {path}")
+        bases.add(version.split("+", 1)[0])
+    if len(bases) != 1:
+        raise RuntimeError("plugin manifests disagree on the development base version")
+    base_version = bases.pop()
+    package = runpy.run_path(str(plugin_path / "zzzops" / "package.py"))
+    renderer = package["render_skill_metadata"]
+    expected_skills = set(package["SHIPPED_SKILLS"])
+    actual_skills = {
+        path.name for path in (plugin_path / "skills").iterdir()
+        if (path / "SKILL.md").is_file()
+    }
+    if actual_skills != expected_skills:
+        raise RuntimeError("development plugin does not contain the exact shipped skill set")
+    projected = {
+        path: cachebusted_manifest(original, path, cachebuster)
+        for path, original in originals.items()
+    }
+    display_version = base_version if base_version.endswith("-dev") else f"{base_version}-dev"
+    for skill in sorted(actual_skills):
+        for relative in (Path("skills") / skill / "SKILL.md", Path("skills") / skill / "agents" / "openai.yaml"):
+            path = plugin_path / relative
+            if not path.is_file():
+                raise RuntimeError(f"missing development skill metadata: {relative.as_posix()}")
+            projected[path] = renderer(relative.as_posix(), path.read_bytes(), display_version, "development")
+    return projected
+
+
 def main() -> int:
     repo_root = find_repo_root(Path.cwd())
     marketplace_name, plugin_path = load_marketplace(repo_root)
@@ -100,23 +136,20 @@ def main() -> int:
             "remove and re-add it only after confirming the other checkout can be disconnected"
         )
 
-    manifest_paths = [plugin_path / "plugin.json", plugin_path / ".codex-plugin/plugin.json"]
-    originals = {path: path.read_bytes() for path in manifest_paths}
     cachebuster = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    temporary = {
-        path: cachebusted_manifest(originals[path], path, cachebuster) for path in manifest_paths
-    }
+    temporary = development_plugin_files(plugin_path, cachebuster)
+    originals = {path: path.read_bytes() for path in temporary}
     try:
-        for path in manifest_paths:
-            path.write_bytes(temporary[path])
+        for path, data in temporary.items():
+            path.write_bytes(data)
         result = run([codex, "plugin", "add", f"{PLUGIN_NAME}@{marketplace_name}", "--json"], cwd=repo_root)
         if result.stdout.strip():
             print(result.stdout.strip())
     finally:
-        for path in manifest_paths:
-            path.write_bytes(originals[path])
+        for path, data in originals.items():
+            path.write_bytes(data)
 
-    installed_version = json.loads(temporary[manifest_paths[0]].decode("utf-8"))["version"]
+    installed_version = json.loads(temporary[plugin_path / "plugin.json"].decode("utf-8"))["version"]
     print(f"Installed {PLUGIN_NAME}@{marketplace_name} from {plugin_path} as {installed_version}.")
     print("Start a new Codex task to load the refreshed skills.")
     return 0

--- a/.agents/test_agent_plugin.py
+++ b/.agents/test_agent_plugin.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import importlib.util
+import runpy
+import sys
 import unittest
 from pathlib import Path
 
@@ -16,9 +19,55 @@ SHIPPED_SKILLS = {
     "suggest-zzzops-work",
 }
 SUPPORT_EMAIL = "zzzops.support@gmail.com"
+DEV_INSTALLER = ROOT / ".agents" / "skills" / "install-zzzops-dev" / "scripts" / "install_dev.py"
+
+
+def load_dev_installer():
+    spec = importlib.util.spec_from_file_location("install_zzzops_dev", DEV_INSTALLER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def quoted_yaml_value(data: bytes, field: str) -> str:
+    prefix = field + ":"
+    line = next(line for line in data.decode("utf-8").splitlines() if line.lstrip().startswith(prefix))
+    return json.loads(line.split(":", 1)[1].strip())
 
 
 class AgentPluginTests(unittest.TestCase):
+    def test_skill_provenance_replaces_stale_values_idempotently(self) -> None:
+        render = runpy.run_path(str(PLUGIN / "zzzops" / "package.py"))["render_skill_metadata"]
+        stale = '---\nname: example\ndescription: "ZzzOps v1.0.0 — official plugin. Purpose"\n---\n'.encode("utf-8")
+        expected = "ZzzOps v2.1.0 — official plugin. Purpose"
+        rendered = render("skills/example/SKILL.md", stale, "2.1.0", "official")
+        self.assertEqual(expected, quoted_yaml_value(rendered, "description"))
+        self.assertEqual(rendered, render("skills/example/SKILL.md", rendered, "2.1.0", "official"))
+
+    def test_development_projection_versions_every_skill_description(self) -> None:
+        projected = load_dev_installer().development_plugin_files(PLUGIN, "local-20260824-010203")
+        manifest_paths = (PLUGIN / "plugin.json", PLUGIN / ".codex-plugin" / "plugin.json")
+        for path in manifest_paths:
+            self.assertEqual("2.0.0+codex.local-20260824-010203", json.loads(projected[path])["version"])
+        for skill in SHIPPED_SKILLS:
+            skill_path = PLUGIN / "skills" / skill / "SKILL.md"
+            agent_path = PLUGIN / "skills" / skill / "agents" / "openai.yaml"
+            self.assertTrue(
+                quoted_yaml_value(projected[skill_path], "description").startswith(
+                    "ZzzOps v2.0.0-dev — development plugin. "
+                ),
+                skill,
+            )
+            self.assertTrue(
+                quoted_yaml_value(projected[agent_path], "short_description").startswith(
+                    "ZzzOps v2.0.0-dev [development] · "
+                ),
+                skill,
+            )
+            self.assertNotIn(b"ZzzOps v2.0.0-dev", skill_path.read_bytes())
+
     def test_open_and_codex_manifests_describe_the_same_release(self) -> None:
         open_manifest = json.loads((PLUGIN / "plugin.json").read_text(encoding="utf-8"))
         codex_manifest = json.loads((PLUGIN / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8"))

--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -14,6 +14,16 @@ from zipfile import ZipFile
 
 ROOT = Path(__file__).resolve().parents[1]
 BUILDER = ROOT / ".github" / "scripts" / "build_marketplace_bundle.py"
+SHIPPED_SKILLS = {
+    "add-zzzops-goal", "execute-zzzops", "migrate-to-zzzops",
+    "review-zzzops-policy", "send-zzzops-feedback", "suggest-zzzops-work",
+}
+
+
+def quoted_yaml_value(data: bytes, field: str) -> str:
+    prefix = field + ":"
+    line = next(line for line in data.decode("utf-8").splitlines() if line.lstrip().startswith(prefix))
+    return json.loads(line.split(":", 1)[1].strip())
 
 
 def load_builder():
@@ -50,6 +60,11 @@ class MarketplaceBundleTests(unittest.TestCase):
                 self.assertFalse(any("__pycache__" in name or name.endswith((".pyc", ".pyo")) for name in names))
                 self.assertEqual("2.0.0", json.loads(archive.read("plugin.json"))["version"])
                 self.assertEqual("2.0.0", json.loads(archive.read(".codex-plugin/plugin.json"))["version"])
+                for skill in SHIPPED_SKILLS:
+                    description = quoted_yaml_value(archive.read(f"skills/{skill}/SKILL.md"), "description")
+                    short = quoted_yaml_value(archive.read(f"skills/{skill}/agents/openai.yaml"), "short_description")
+                    self.assertTrue(description.startswith("ZzzOps v2.0.0 — official plugin. "), skill)
+                    self.assertTrue(short.startswith("ZzzOps v2.0.0 [official] · "), skill)
                 for name in (
                     "assets/composer-icon-dark.png", "assets/composer-icon.png",
                     "assets/logo-dark.png", "assets/logo.png",

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -10,6 +10,7 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
+import runpy
 import shutil
 import struct
 import sys
@@ -185,6 +186,7 @@ def scan_for_secrets(relative: str, data: bytes) -> None:
 
 def plugin_files(root: Path, version: str) -> dict[str, bytes]:
     plugin = root / "plugins" / "zzzops"
+    renderer = runpy.run_path(str(plugin / "zzzops" / "package.py"))["render_skill_metadata"]
     result: dict[str, bytes] = {}
     allowed_top_level = {".codex-plugin", "assets", "plugin.json", "rules", "scripts", "skills", "zzzops"}
     for path in sorted(plugin.rglob("*"), key=lambda item: item.relative_to(plugin).as_posix()):
@@ -202,6 +204,10 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
             manifest = json.loads(data.decode("utf-8-sig"))
             manifest["version"] = version
             data = canonical_json(manifest)
+        try:
+            data = renderer(relative, data, version, "official")
+        except ValueError as exc:
+            raise BundleError(f"invalid skill discovery metadata in {relative}: {exc}") from exc
         scan_for_secrets(relative, data)
         result[relative] = data
     required = {
@@ -222,6 +228,14 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
         "review-zzzops-policy", "send-zzzops-feedback", "suggest-zzzops-work",
     }:
         raise BundleError("plugin archive must contain exactly the six product skills")
+    missing_metadata = sorted(
+        f"skills/{skill}/{relative}"
+        for skill in shipped_skills
+        for relative in ("SKILL.md", "agents/openai.yaml")
+        if f"skills/{skill}/{relative}" not in result
+    )
+    if missing_metadata:
+        raise BundleError("skill discovery metadata is incomplete: " + ", ".join(missing_metadata))
     return result
 
 

--- a/plugins/zzzops/zzzops/package.py
+++ b/plugins/zzzops/zzzops/package.py
@@ -36,6 +36,74 @@ class PluginPackageError(ValueError):
     """The loaded package is incomplete or not the supported Agent Plugin."""
 
 
+SKILL_PROVENANCE = re.compile(r"^ZzzOps v\S+ — (?:official|development) plugin\. ")
+SHORT_PROVENANCE = re.compile(r"^ZzzOps v\S+ \[(?:official|development)\] · ")
+
+
+def _yaml_text_value(value: str, field: str) -> str:
+    if value.startswith('"'):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise PluginPackageError(f"{field} is not valid quoted text") from exc
+        if not isinstance(parsed, str):
+            raise PluginPackageError(f"{field} must be text")
+        return parsed
+    if value.startswith("'") and value.endswith("'"):
+        return value[1:-1].replace("''", "'")
+    if value:
+        return value
+    raise PluginPackageError(f"{field} must be non-empty text")
+
+
+def _replace_yaml_text(data: bytes, field: str, prefix: str, prior: re.Pattern[str]) -> bytes:
+    try:
+        text = data.decode("utf-8-sig").replace("\r\n", "\n").replace("\r", "\n")
+    except UnicodeError as exc:
+        raise PluginPackageError(f"{field} metadata is not UTF-8") from exc
+    trailing = text.endswith("\n")
+    lines = text.splitlines()
+    index = next((i for i, line in enumerate(lines) if line.lstrip().startswith(field + ":")), None)
+    if index is None:
+        raise PluginPackageError(f"{field} metadata is missing")
+    line = lines[index]
+    indent = line[:len(line) - len(line.lstrip())]
+    value = line.split(":", 1)[1].strip()
+    end = index + 1
+    if value in {">", ">-", "|", "|-"}:
+        continuation = []
+        while end < len(lines) and (not lines[end].strip() or lines[end][:1].isspace()):
+            if lines[end].strip():
+                continuation.append(lines[end].strip())
+            end += 1
+        original = " ".join(continuation)
+        if not original:
+            raise PluginPackageError(f"{field} must be non-empty text")
+    else:
+        original = _yaml_text_value(value, field)
+    rendered = prefix + prior.sub("", original)
+    lines[index:end] = [f"{indent}{field}: {json.dumps(rendered, ensure_ascii=False)}"]
+    return ("\n".join(lines) + ("\n" if trailing else "")).encode("utf-8")
+
+
+def render_skill_metadata(relative: str, data: bytes, version: str, channel: str) -> bytes:
+    """Project build provenance into discovery metadata without changing source prompts."""
+    if not isinstance(version, str) or not version or any(character.isspace() for character in version):
+        raise PluginPackageError("skill metadata version must be non-empty text without whitespace")
+    if channel not in {"official", "development"}:
+        raise PluginPackageError("skill metadata channel must be official or development")
+    parts = Path(relative).as_posix().split("/")
+    if len(parts) == 3 and parts[0] == "skills" and parts[2] == "SKILL.md":
+        return _replace_yaml_text(
+            data, "description", f"ZzzOps v{version} — {channel} plugin. ", SKILL_PROVENANCE,
+        )
+    if len(parts) == 4 and parts[0] == "skills" and parts[2:] == ["agents", "openai.yaml"]:
+        return _replace_yaml_text(
+            data, "short_description", f"ZzzOps v{version} [{channel}] · ", SHORT_PROVENANCE,
+        )
+    return data
+
+
 def read_plugin_manifest() -> dict[str, Any]:
     try:
         manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8-sig"))
@@ -88,6 +156,10 @@ def package_status() -> dict[str, Any]:
         missing.extend(
             f"skills/{name}/SKILL.md" for name in sorted(SHIPPED_SKILLS)
             if not (PLUGIN_ROOT / "skills" / name / "SKILL.md").is_file()
+        )
+        missing.extend(
+            f"skills/{name}/agents/openai.yaml" for name in sorted(SHIPPED_SKILLS)
+            if not (PLUGIN_ROOT / "skills" / name / "agents" / "openai.yaml").is_file()
         )
         if missing:
             raise PluginPackageError("missing package files: " + ", ".join(missing))


### PR DESCRIPTION
## Summary
- stamp every packaged skill description with the authoritative release version and official channel
- stamp temporary development installs with the manifest-derived -dev version and development channel
- use one shared, idempotent transformer for SKILL.md and agents/openai.yaml metadata
- preserve source prompts and restore every temporarily projected development file

## Verification
- python -m unittest discover -s .agents -p 'test_*.py' (171 passed, 1 skipped)
- npm run test:plugin
- npm run test:release
- plugin and all six skill schema validators
- python .agents/prompt_stats.py --eval
- python .agents/prompt_stats.py --check
- Python compilation and git diff checks

Closes #273