### PR TITLE
feat(bootstrap): define repository analysis contract

### DIFF
--- a/.agents/prompt_stats.py
+++ b/.agents/prompt_stats.py
@@ -80,8 +80,10 @@ def canonical_size(data: bytes) -> int:
 def prompt_files(root: Path) -> list[Path]:
     files = [root / "AGENTS.md"]
     files.extend((root / "plugins" / "zzzops" / "rules").glob("*.md"))
-    files.extend((root / "plugins" / "zzzops" / "skills").glob("*/SKILL.md"))
-    files.extend((root / "plugins" / "zzzops" / "skills").glob("*/references/*.md"))
+    product_skills = list((root / "plugins" / "zzzops" / "skills").glob("*/SKILL.md"))
+    files.extend(product_skills)
+    for skill in product_skills:
+        files.extend((skill.parent / "references").glob("*.md"))
     files.extend((root / "plugins" / "zzzops" / "zzzops" / "templates" / "project-goals").glob("*.md"))
     files.extend((root / ".agents" / "skills").glob("*/SKILL.md"))
     files.extend((root / ".agents" / "skills").glob("*/references/*.md"))

--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -57,6 +57,7 @@ class MarketplaceBundleTests(unittest.TestCase):
                 self.assertIn(".codex-plugin/plugin.json", names)
                 self.assertIn("scripts/cleanup_legacy.py", names)
                 self.assertNotIn("skills/run-zzzops-acceptance/SKILL.md", names)
+                self.assertIn("zzzops/references/bootstrap/ANALYZE.md", names)
                 self.assertFalse(any("__pycache__" in name or name.endswith((".pyc", ".pyo")) for name in names))
                 self.assertEqual("2.0.0", json.loads(archive.read("plugin.json"))["version"])
                 self.assertEqual("2.0.0", json.loads(archive.read(".codex-plugin/plugin.json"))["version"])

--- a/.agents/test_prompt_stats.py
+++ b/.agents/test_prompt_stats.py
@@ -19,6 +19,14 @@ class PromptStatsTests(unittest.TestCase):
         self.assertEqual(prompt_stats.canonical_size(b"one\r\ntwo\r\n"), expected)
         self.assertEqual(prompt_stats.canonical_size(b"one\rtwo\r"), expected)
 
+    def test_unrouted_internal_references_are_not_loaded_prompts(self) -> None:
+        root = SCRIPT.parents[1]
+        paths = {path.relative_to(root).as_posix() for path in prompt_stats.prompt_files(root)}
+        self.assertNotIn(
+            "plugins/zzzops/zzzops/references/bootstrap/ANALYZE.md",
+            paths,
+        )
+
     def test_report_includes_rows_and_total(self) -> None:
         report = prompt_stats.render_report([("AGENTS.md", 8, 2)])
         self.assertIn("| `AGENTS.md` | 8 | 2 |", report)

--- a/plugins/zzzops/zzzops/package.py
+++ b/plugins/zzzops/zzzops/package.py
@@ -27,6 +27,7 @@ REQUIRED_FILES = {
     "rules/EXECUTION_STRATEGY.md", "rules/FEEDBACK.md", "rules/GOAL_SYSTEM.md",
     "rules/INITIALIZATION.md", "zzzops/zzzops.py",
     "scripts/cleanup_legacy.py",
+    "zzzops/references/bootstrap/ANALYZE.md",
     "zzzops/templates/project-goals/INIT_PLAN.json",
 }
 NAME_PATTERN = re.compile(r"^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$")

--- a/plugins/zzzops/zzzops/references/bootstrap/ANALYZE.md
+++ b/plugins/zzzops/zzzops/references/bootstrap/ANALYZE.md
@@ -1,0 +1,46 @@
+# Analyze a repository for bootstrap
+
+This stage is read-only. Establish the minimum evidence needed to classify the repository, resolve consequential architecture choices, and propose a proportionate harness. Do not create goals or modify the target.
+
+## Evidence route
+
+1. Read the supplied specification and reviewed PROJECT policy, especially effective engineering rigor and autonomy. If policy is unreviewed, hand off to `$review-zzzops-policy`, record a resume point, and return here afterward; never initialize policy locally.
+2. Inspect only decision-relevant tree entries, manifests/locks, pinned versions, source/config, instructions, architecture docs, build/test/verify commands, CI, and history or exposed GitHub state when it can change the conclusion.
+3. Classify from evidence, without asking the user to select a mode:
+   - `greenfield`: no meaningful product scaffold or established conventions;
+   - `early_scaffold`: stack or skeleton exists, but architecture/product behavior and harness are minimal;
+   - `brownfield`: active product structure or conventions exist and must outrank generic preferences.
+4. Stop reading when mode, material constraints, and the next consequential decisions are supported. Record contradictory evidence instead of averaging it away.
+
+## Unknowns and interview
+
+Reuse supplied/repository evidence before asking. Classify each unknown as:
+
+- `reversible_assumption`: low-risk, cheap to undo, permitted by reviewed autonomy;
+- `later_goal`: not required to commit the harness architecture;
+- `architecture_blocker`: changes a foundational boundary and must be resolved first.
+
+Use effective rigor as the depth control. Vibe establishes purpose, critical constraints, and a small reversible milestone. Structured also resolves material stack/version, target, public interface, persistence, verification, and architecture boundaries. Agentic additionally covers applicable security, sensitive data, compatibility, failure/recovery, operations, rollout, and deterministic enforcement. Ask 1–3 consequential questions at a time; never turn absent, irrelevant dimensions into ceremony.
+
+## Proposal
+
+When review is consequential, present a concise proposal containing only justified entries:
+
+- mode and decisive evidence;
+- stack and pinned versions;
+- architecture boundaries;
+- harness and one canonical verification path shared by CI;
+- compact static context plus links to dynamic specialist context;
+- initial milestone and explicitly deferred decisions;
+- assumptions, later goals, blockers, and the smallest observable bootstrap proof.
+
+For brownfield work, describe preservation and gaps before additions. Prefer deterministic enforcement for invariants agents must not forget. Do not add a tool because a generic template contains it, and do not begin product implementation.
+
+## Fixtures
+
+| Evidence | Expected result |
+| --- | --- |
+| Empty tree; disposable CLI spike; reviewed vibe | `greenfield`; purpose/constraints plus reversible stack assumption; no CI or enterprise questionnaire unless another risk escalates it. |
+| Manifest, pinned runtime, generated skeleton, no behavior/tests/CI | `early_scaffold`; preserve the selected stack, resolve only architecture-blocking choices, and propose the missing structured harness. |
+| Established source/tests/CI/architecture with one incomplete verify command | `brownfield`; existing conventions win, proposal is a gap audit, and canonical-verification repair is identified without re-scaffolding. |
+| Structured default plus authentication and sensitive data | Effective agentic depth; surface security, data lifecycle, failure/recovery, operations, and enforcement decisions before architecture commitment. |


### PR DESCRIPTION
## Summary
- define a read-only, agent-led repository evidence and classification contract
- scale unknown resolution and architecture proposals by effective rigor
- cover greenfield, early-scaffold, brownfield, and risk-escalated fixtures
- package the internal reference without exposing an incomplete skill or loading unrouted context

## Verification
- python -m unittest discover -s .agents -p 'test_*.py' (172 passed, 1 skipped)
- npm run test:plugin
- npm run test:release
- plugin validation
- python .agents/prompt_stats.py --eval
- python .agents/prompt_stats.py --check
- acceptance coverage and diff checks

Closes #278