### PR TITLE
chore(policy): authorize generated Claude support

### DIFF
--- a/.zzzops/POLICY.json
+++ b/.zzzops/POLICY.json
@@ -1,26 +1,26 @@
 {
   "approval": {
-    "date": "2026-08-09",
-    "digest": "sha256:9d0f831aff51b653bdc85f839a5fb2a0f7e2cc54fbaec66c25c0a6c4a5b5f636",
+    "date": "2026-08-24",
+    "digest": "sha256:c7e608653e0503853f51b4500c959f44590c6290bd64da64fc91454c7709a683",
     "reviewer": "user"
   },
   "backend": "github_issues",
   "bindings": {
     "audit": {
-      "digest": "sha256:fe78c07e75ab63cc6fc354a81de6703600787190810b5463b8a5759b3fb94a99",
+      "digest": "sha256:2c2af6b5603056219e5f5b9d30db3c712d45d5e813bec2a89b2274f7020ced13",
       "path": ".zzzops/PROJECT_AUDIT.md"
     },
     "project": {
-      "digest": "sha256:101ae8132983939f5f8806951c6eac21f294a18cd073860850b24658fd3f66d0",
+      "digest": "sha256:c959d713ee58579ff743fbdb537a6d20006fff95da6fcbb3d18018556a0d06dc",
       "path": ".zzzops/PROJECT.md"
     }
   },
   "charter": {
     "acceptance_criteria": [
-      "A clean Codex Agent Plugin installation can be agent-initialized and capture a canonical goal without manual form filling.",
+      "A clean supported Agent Plugin installation can be agent-initialized and capture a canonical goal without manual form filling.",
       "An execution run can prioritize, unblock, verify, checkpoint, and cycle across durable goals without losing state.",
       "Unsupported capabilities and human-only decisions become explicit categorized blockers rather than invented behavior.",
-      "Codex receives concise, discoverable Agent Plugin workflow semantics.",
+      "Supported coding agents receive concise, discoverable Agent Plugin workflow semantics.",
       "Tests prove Agent Plugin packaging and marketplace discovery, backend invariants, fast observable feedback, and prompt-budget accounting."
     ],
     "beneficiaries": [
@@ -30,7 +30,8 @@
       "Remain primarily agent-driven and keep deterministic scripts narrow and cross-platform.",
       "Do not silently dual-write, fail over, invent user decisions, or expose secrets.",
       "Keep installed prompts distilled and prompt counts current.",
-      "Use available subscription capacity to advance evidenced project goals and safe valuable backlog work; do not let quota maximization override value, safety, or user authority."
+      "Use available subscription capacity to advance evidenced project goals and safe valuable backlog work; do not let quota maximization override value, safety, or user authority.",
+      "Keep Codex and Claude Code distributions generated from shared canonical sources; claim platform support only after platform-native validation and install/discovery/workflow acceptance evidence."
     ],
     "kpis": [
       {
@@ -44,9 +45,9 @@
       {
         "baseline": "Not yet measured.",
         "cadence": "Each release",
-        "evidence": "Timed Codex marketplace installation and initialization acceptance run.",
+        "evidence": "Timed supported-platform plugin installation and initialization acceptance run.",
         "name": "Time to usable backlog",
-        "target": "Marketplace install to initialized, capturable backlog in under 10 minutes.",
+        "target": "Supported plugin install to initialized, capturable backlog in under 10 minutes.",
         "why": "Setup friction increases babysitting."
       },
       {
@@ -61,10 +62,10 @@
     "non_goals": [
       "Replace general-purpose project management suites.",
       "Guarantee capabilities that Codex does not expose.",
-      "Maintain v2 compatibility with Claude Code or the retired per-project installer.",
+      "Restore or maintain the retired per-project installer, or maintain divergent Codex and Claude Code workflow implementations.",
       "Spend tokens on work with no evidenced link to project value."
     ],
-    "outcome": "ZzzOps lets Codex manage long-term project work autonomously with durable state, minimal babysitting, and explicit human control.",
+    "outcome": "ZzzOps lets supported coding agents manage long-term project work autonomously with durable state, minimal babysitting, and explicit human control.",
     "precedence": "user authority and safety, correctness, privacy, verified project value, autonomy, then prompt savings",
     "time_horizon": "ongoing, reviewed monthly",
     "unacceptable_tradeoffs": [
@@ -103,6 +104,18 @@
       "change": "Reviewed policy revision 19",
       "date": "2026-08-09",
       "reason": "Approved: automated_design; source digest sha256:334572a80f28915d6759f1cd4c896cc6c7ea5b1f3c37a6d2c7e910d424aed4b8."
+    },
+    {
+      "actor": "ZzzOps initialization",
+      "change": "Created pending revision 20",
+      "date": "2026-08-24",
+      "reason": "Confirmed agent-generated draft; explicit policy review still required."
+    },
+    {
+      "actor": "user",
+      "change": "Reviewed policy revision 21",
+      "date": "2026-08-24",
+      "reason": "Approved: dependencies_tooling; source digest sha256:bba4a1c6f56f647dbf146676e340a481d26b9afc729e3944848b8b3279c75ad6."
     }
   ],
   "initialized": true,
@@ -173,6 +186,12 @@
         "id": "E-011",
         "kind": "proposed",
         "source": "user decision 2026-08-09"
+      },
+      {
+        "finding": "Support generated, acceptance-gated Claude Code plugin artifacts derived from shared canonical sources; preserve removal of the retired per-project installer and prohibit divergent platform implementations.",
+        "id": "E-012",
+        "kind": "proposed",
+        "source": "user decision and goal #300 on 2026-08-24"
       }
     ],
     "schema_version": 1,
@@ -369,17 +388,17 @@
       {
         "applicable": true,
         "confidence": "medium",
-        "decision": "Use project-native tooling; do not hand-edit generated or dependency-owned files.",
+        "decision": "Use project-native tooling; do not hand-edit generated or dependency-owned files; generate supported platform distributions from shared canonical sources and verify them with platform-native validation and acceptance evidence.",
         "default_disposition": "accepted",
         "default_origin": "ZzzOps default",
         "exceptions": [],
         "id": "dependencies_tooling",
-        "rationale": "Keeps deterministic mechanics portable and ownership clear.",
+        "rationale": "Keeps deterministic mechanics portable, ownership clear, and Codex/Claude support aligned without divergent implementations.",
         "required": true,
         "review": {
           "approved": true,
-          "date": "2026-08-02",
-          "reviewed_digest": "sha256:049640647764a6cc2c9834da01fb74a767c6a2efb5652ac34a76954f4b8b134c",
+          "date": "2026-08-24",
+          "reviewed_digest": "sha256:bba4a1c6f56f647dbf146676e340a481d26b9afc729e3944848b8b3279c75ad6",
           "reviewer": "user"
         },
         "settings": {
@@ -388,7 +407,8 @@
           "tooling": "project_native"
         },
         "source_ids": [
-          "E-001"
+          "E-001",
+          "E-012"
         ],
         "title": "Dependencies, tooling, and generated artifacts",
         "unresolved": []
@@ -635,6 +655,6 @@
     "identity": "david-rzepa/zzzops",
     "remote": "https://github.com/david-rzepa/zzzops.git"
   },
-  "revision": 19,
+  "revision": 21,
   "schema_version": 1
 }

--- a/.zzzops/PROJECT.md
+++ b/.zzzops/PROJECT.md
@@ -1,10 +1,10 @@
 # Project success charter
 
 **Status:** complete
-**Last reviewed:** 2026-08-09
+**Last reviewed:** 2026-08-24
 
 ## Overall goal
-- Outcome: ZzzOps lets Codex manage long-term project work autonomously with durable state, minimal babysitting, and explicit human control.
+- Outcome: ZzzOps lets supported coding agents manage long-term project work autonomously with durable state, minimal babysitting, and explicit human control.
 - Primary beneficiaries: developers delegating long-running project work to coding agents
 - Why it matters: Users can stop supervising agents late into the night without losing progress, priorities, blockers, or available work.
 - Time horizon: ongoing, reviewed monthly
@@ -13,14 +13,14 @@
 | KPI | Why it matters | Baseline | Target / threshold | Evidence source | Review cadence |
 | --- | --- | --- | --- | --- | --- |
 | Canonical goal integrity | Lost or duplicated goal truth defeats autonomous execution. | GitHub Issues are the canonical backend. | Zero known lost or duplicated canonical goals. | Backend portfolio and migration/idempotency tests. | Each release |
-| Time to usable backlog | Setup friction increases babysitting. | Not yet measured. | Marketplace install to initialized, capturable backlog in under 10 minutes. | Timed Codex marketplace installation and initialization acceptance run. | Each release |
+| Time to usable backlog | Setup friction increases babysitting. | Not yet measured. | Supported plugin install to initialized, capturable backlog in under 10 minutes. | Timed supported-platform plugin installation and initialization acceptance run. | Each release |
 | Autonomous workflow transitions | Measures whether agents can continue without unscheduled intervention. | Not yet measured. | At least 80% of eligible workflow transitions need no unscheduled human input. | Goal histories and categorized blocker records. | Monthly after at least 20 transitions |
 
 ## Project acceptance criteria
-- [x] A clean Codex Agent Plugin installation can be agent-initialized and capture a canonical goal without manual form filling.
+- [x] A clean supported Agent Plugin installation can be agent-initialized and capture a canonical goal without manual form filling.
 - [x] An execution run can prioritize, unblock, verify, checkpoint, and cycle across durable goals without losing state.
 - [x] Unsupported capabilities and human-only decisions become explicit categorized blockers rather than invented behavior.
-- [x] Codex receives concise, discoverable Agent Plugin workflow semantics.
+- [x] Supported coding agents receive concise, discoverable Agent Plugin workflow semantics.
 - [x] Tests prove Agent Plugin packaging and marketplace discovery, backend invariants, fast observable feedback, and prompt-budget accounting.
 
 ## Value rubric
@@ -37,11 +37,12 @@ When KPIs conflict, prefer: user authority and safety, correctness, privacy, ver
 - Do not silently dual-write, fail over, invent user decisions, or expose secrets.
 - Keep installed prompts distilled and prompt counts current.
 - Use available subscription capacity to advance evidenced project goals and safe valuable backlog work; do not let quota maximization override value, safety, or user authority.
+- Keep Codex and Claude Code distributions generated from shared canonical sources; claim platform support only after platform-native validation and install/discovery/workflow acceptance evidence.
 
 ### Non-goals
 - Replace general-purpose project management suites.
 - Guarantee capabilities that Codex does not expose.
-- Maintain v2 compatibility with Claude Code or the retired per-project installer.
+- Restore or maintain the retired per-project installer, or maintain divergent Codex and Claude Code workflow implementations.
 - Spend tokens on work with no evidenced link to project value.
 
 ### Unacceptable tradeoffs
@@ -58,7 +59,7 @@ When KPIs conflict, prefer: user authority and safety, correctness, privacy, ver
 - `[policy:execution_continuation]` **Execution and work continuation**: Continue across actionable goals under reviewed dependency and resource policy, incorporate newly captured goals at the next safe checkpoint, and persist unanswered questions without live interviewing, notification, polling, or waiting. (default origin unknown)
 - `[policy:verification_testing]` **Verification and testing**: Require artifact-appropriate observable evidence in small chunks; documentation and test cases need no recursive tests, while product behavior and reusable test infrastructure require direct verification. (default origin unknown)
 - `[policy:code_quality]` **Code-quality and refactoring boundaries**: Preserve behavior unless a goal explicitly authorizes a behavior change. (default origin unknown)
-- `[policy:dependencies_tooling]` **Dependencies, tooling, and generated artifacts**: Use project-native tooling; do not hand-edit generated or dependency-owned files. (default origin unknown)
+- `[policy:dependencies_tooling]` **Dependencies, tooling, and generated artifacts**: Use project-native tooling; do not hand-edit generated or dependency-owned files; generate supported platform distributions from shared canonical sources and verify them with platform-native validation and acceptance evidence. (default origin unknown)
 - `[policy:security_privacy_compliance]` **Security, privacy, secrets, and compliance**: Repository policy may tighten but never weaken safety and authority boundaries. (default origin unknown)
 - `[policy:documentation_style]` **Documentation and style**: Follow evidenced repository documentation and style conventions; use outcome-first, low-technical-detail user updates by default while allowing explicit project policy to override the style. (default origin unknown)
 - `[policy:deployment_resources]` **Deployment, environment, and resources**: Do not deploy without authority; choose bounded parallelism from the deterministic tracked-file repository size. (default origin unknown)

--- a/.zzzops/PROJECT_AUDIT.md
+++ b/.zzzops/PROJECT_AUDIT.md
@@ -1,6 +1,6 @@
 # ZzzOps project policy audit
 
-Status: complete. Reviewer: user. Revision: 19.
+Status: complete. Reviewer: user. Revision: 21.
 
 ## Evidence and decisions
 
@@ -50,9 +50,9 @@ Status: complete. Reviewer: user. Revision: 19.
   - Exceptions: none
   - Unresolved: none
 - [x] `[policy:dependencies_tooling]` **Dependencies, tooling, and generated artifacts** (applicable)
-  - Decision: Use project-native tooling; do not hand-edit generated or dependency-owned files.
-  - Rationale: Keeps deterministic mechanics portable and ownership clear.
-  - Sources: E-001: .zzzops/PROJECT.md — The existing confirmed charter defines the outcome, KPIs, acceptance criteria, and value constraints.
+  - Decision: Use project-native tooling; do not hand-edit generated or dependency-owned files; generate supported platform distributions from shared canonical sources and verify them with platform-native validation and acceptance evidence.
+  - Rationale: Keeps deterministic mechanics portable, ownership clear, and Codex/Claude support aligned without divergent implementations.
+  - Sources: E-001: .zzzops/PROJECT.md — The existing confirmed charter defines the outcome, KPIs, acceptance criteria, and value constraints.; E-012: user decision and goal #300 on 2026-08-24 — Support generated, acceptance-gated Claude Code plugin artifacts derived from shared canonical sources; preserve removal of the retired per-project installer and prohibit divergent platform implementations.
   - Confidence/default: medium; ZzzOps default → accepted
   - Provenance: default origin unknown
   - Settings: `{"dependency_changes": "explicit_scope", "generated_files": "source_or_generator_only", "tooling": "project_native"}`
@@ -113,5 +113,7 @@ Status: complete. Reviewer: user. Revision: 19.
 | 2026-08-09 | ZzzOps initialization | Created pending revision 17 | Confirmed agent-generated draft; explicit policy review still required. |
 | 2026-08-09 | ZzzOps initialization | Created pending revision 18 | Confirmed agent-generated draft; explicit policy review still required. |
 | 2026-08-09 | user | Reviewed policy revision 19 | Approved: automated_design; source digest sha256:334572a80f28915d6759f1cd4c896cc6c7ea5b1f3c37a6d2c7e910d424aed4b8. |
+| 2026-08-24 | ZzzOps initialization | Created pending revision 20 | Confirmed agent-generated draft; explicit policy review still required. |
+| 2026-08-24 | user | Reviewed policy revision 21 | Approved: dependencies_tooling; source digest sha256:bba4a1c6f56f647dbf146676e340a481d26b9afc729e3944848b8b3279c75ad6. |
 
 The machine-readable authority is [POLICY.json](POLICY.json); this file is its human audit view.


### PR DESCRIPTION
## Outcome
- broaden the reviewed charter from Codex-only to supported coding agents
- authorize Claude Code artifacts generated from shared canonical sources
- require platform-native validation and install/discovery/workflow acceptance before support claims
- retain the prohibition on the retired per-repository installer and divergent platform implementations

## Verification
- ZzzOps policy revision 21 explicitly approved by the user
- policy checkpoint reports initialized=true with no decision blockers
- git diff --check