### PR TITLE
feat(claude): generate canonical plugin marketplace

### DIFF
--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import shutil
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 from zipfile import ZipFile
 
 
 ROOT = Path(__file__).resolve().parents[1]
 BUILDER = ROOT / ".github" / "scripts" / "build_marketplace_bundle.py"
+CLAUDE_BUILDER = ROOT / ".github" / "scripts" / "build_claude_plugin.py"
 SHIPPED_SKILLS = {
     "add-zzzops-goal", "bootstrap-zzzops-repository", "execute-zzzops", "migrate-to-zzzops",
     "review-agentic-engineering", "review-zzzops-policy", "send-zzzops-feedback", "suggest-zzzops-work",
@@ -27,8 +30,8 @@ def quoted_yaml_value(data: bytes, field: str) -> str:
     return json.loads(line.split(":", 1)[1].strip())
 
 
-def load_builder():
-    spec = importlib.util.spec_from_file_location("build_marketplace_bundle", BUILDER)
+def load_builder(path: Path = BUILDER, name: str = "build_marketplace_bundle"):
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -40,6 +43,7 @@ class MarketplaceBundleTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.builder = load_builder()
+        cls.claude_builder = load_builder(CLAUDE_BUILDER, "build_claude_plugin")
 
     def test_fixed_version_build_is_deterministic_and_complete(self) -> None:
         with tempfile.TemporaryDirectory() as first, tempfile.TemporaryDirectory() as second:
@@ -116,6 +120,58 @@ class MarketplaceBundleTests(unittest.TestCase):
             self.builder.validate_portal_png("assets/logo.png", image.replace(b"\r\n", b"\n"))
         with self.assertRaisesRegex(self.builder.BundleError, "truncated|checksum|decoded"):
             self.builder.validate_portal_png("assets/logo.png", image[:-20])
+
+    def test_claude_marketplace_is_derived_from_the_canonical_plugin(self) -> None:
+        files = self.builder.claude_marketplace_files(ROOT, "2.0.0")
+        manifest = json.loads(files["zzzops/.claude-plugin/plugin.json"])
+        marketplace = json.loads(files[".claude-plugin/marketplace.json"])
+
+        self.assertEqual("zzzops", manifest["name"])
+        self.assertEqual("2.0.0", manifest["version"])
+        self.assertEqual("zzzops", marketplace["name"])
+        self.assertEqual(manifest["description"], marketplace["metadata"]["description"])
+        self.assertEqual("2.0.0", marketplace["metadata"]["version"])
+        self.assertEqual("./zzzops", marketplace["plugins"][0]["source"])
+        self.assertEqual("2.0.0", marketplace["plugins"][0]["version"])
+
+        canonical = self.builder.plugin_files(ROOT, "2.0.0")
+        for relative, content in canonical.items():
+            self.assertEqual(content, files[f"zzzops/{relative}"], relative)
+
+    def test_claude_generation_rejects_missing_or_invalid_canonical_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            shutil.copytree(ROOT / "plugins" / "zzzops", root / "plugins" / "zzzops")
+            (root / "plugins" / "zzzops" / "skills" / "add-zzzops-goal" / "SKILL.md").unlink()
+            with self.assertRaisesRegex(self.builder.BundleError, "skill discovery metadata"):
+                self.builder.claude_marketplace_files(root, "2.0.0")
+        with self.assertRaisesRegex(self.builder.BundleError, "version"):
+            self.builder.claude_marketplace_files(ROOT, "latest")
+
+    def test_claude_marketplace_writer_is_deterministic_and_refuses_overwrite(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            first = Path(directory) / "first"
+            second = Path(directory) / "second"
+            self.claude_builder.write_marketplace(ROOT, first, "2.0.0")
+            self.claude_builder.write_marketplace(ROOT, second, "2.0.0")
+            first_files = {
+                path.relative_to(first).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+                for path in first.rglob("*") if path.is_file()
+            }
+            second_files = {
+                path.relative_to(second).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+                for path in second.rglob("*") if path.is_file()
+            }
+            self.assertEqual(first_files, second_files)
+            with self.assertRaisesRegex(self.builder.BundleError, "must not already exist"):
+                self.claude_builder.write_marketplace(ROOT, first, "2.0.0")
+            with mock.patch.object(
+                self.claude_builder.bundles,
+                "claude_marketplace_files",
+                return_value={"../escape": b"unsafe"},
+            ):
+                with self.assertRaisesRegex(self.builder.BundleError, "unsafe generated path"):
+                    self.claude_builder.write_marketplace(ROOT, Path(directory) / "unsafe", "2.0.0")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/build_claude_plugin.py
+++ b/.github/scripts/build_claude_plugin.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Generate a self-contained Claude Code marketplace from canonical ZzzOps sources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import shutil
+import sys
+
+import build_marketplace_bundle as bundles
+
+
+def write_marketplace(root: Path, output: Path, version: str) -> Path:
+    root = root.resolve()
+    output = output.resolve()
+    if output in {root, output.parent}:
+        raise bundles.BundleError("output must be a dedicated child directory")
+    if output.exists():
+        raise bundles.BundleError("output must not already exist")
+    files = bundles.claude_marketplace_files(root, version)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    owns_output = False
+    try:
+        output.mkdir()
+        owns_output = True
+        for relative, data in sorted(files.items()):
+            path = PurePosixPath(relative)
+            if path.is_absolute() or ".." in path.parts:
+                raise bundles.BundleError(f"unsafe generated path: {relative}")
+            destination = output.joinpath(*path.parts)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(data)
+    except Exception:
+        if owns_output and output.exists():
+            shutil.rmtree(output)
+        raise
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a generated Claude Code marketplace")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    root = Path(__file__).resolve().parents[2]
+    try:
+        result = write_marketplace(root, args.output, args.version)
+    except (bundles.BundleError, OSError, UnicodeError) as exc:
+        print(f"Claude plugin generation failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps({"marketplace": str(result)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -240,6 +240,52 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
     return result
 
 
+def claude_marketplace_files(root: Path, version: str) -> dict[str, bytes]:
+    """Render a self-contained Claude marketplace from the canonical plugin."""
+    if not SEMVER.fullmatch(version):
+        raise BundleError("version must be a concrete semantic release version")
+    canonical_manifest = read_json(root / "plugins" / "zzzops" / "plugin.json")
+    required_manifest = {
+        "name", "description", "author", "homepage", "repository", "license", "keywords",
+    }
+    if not isinstance(canonical_manifest, dict) or not required_manifest.issubset(canonical_manifest):
+        raise BundleError("canonical plugin manifest is incomplete for Claude generation")
+    for field in ("name", "description", "homepage", "repository", "license"):
+        require_text(canonical_manifest[field], f"plugin.{field}")
+    author = canonical_manifest["author"]
+    if not isinstance(author, dict) or not require_text(author.get("name"), "plugin.author.name"):
+        raise BundleError("plugin.author is incomplete")
+    keywords = canonical_manifest["keywords"]
+    if not isinstance(keywords, list) or not keywords or any(not require_text(item, "plugin.keywords") for item in keywords):
+        raise BundleError("plugin.keywords must contain non-empty text")
+    canonical = plugin_files(root, version)
+    manifest_fields = (
+        "name", "description", "author", "homepage", "repository", "license", "keywords",
+    )
+    manifest = {field: canonical_manifest[field] for field in manifest_fields}
+    manifest["version"] = version
+    marketplace = {
+        "name": canonical_manifest["name"],
+        "owner": canonical_manifest["author"],
+        "metadata": {
+            "description": canonical_manifest["description"],
+            "version": version,
+        },
+        "plugins": [{
+            "name": canonical_manifest["name"],
+            "source": "./zzzops",
+            "description": canonical_manifest["description"],
+            "version": version,
+        }],
+    }
+    result = {f"zzzops/{relative}": data for relative, data in canonical.items()}
+    result["zzzops/.claude-plugin/plugin.json"] = canonical_json(manifest)
+    result[".claude-plugin/marketplace.json"] = canonical_json(marketplace)
+    for relative, data in result.items():
+        scan_for_secrets(relative, data)
+    return result
+
+
 def zip_bytes(files: dict[str, bytes]) -> bytes:
     temporary = io.BytesIO()
     with ZipFile(temporary, "w", compression=ZIP_DEFLATED, compresslevel=9) as archive:

--- a/plugins/zzzops/plugin.json
+++ b/plugins/zzzops/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "zzzops",
   "version": "2.0.0",
-  "description": "Durable autonomous project goals for Codex",
+  "description": "Durable autonomous project goals for coding agents",
   "author": {
     "name": "David Rzepa",
     "url": "https://github.com/david-rzepa"


### PR DESCRIPTION
## Outcome
- generate a self-contained Claude Code plugin and local marketplace from the canonical ZzzOps plugin
- add Claude-native manifests while preserving byte-identical shared skill, rule, runtime, script, and asset surfaces
- reject missing canonical surfaces, invalid versions, unsafe paths, nondeterminism, and overwrite attempts
- make the canonical plugin description platform-neutral

## Verification
- python .agents/test_marketplace_bundle.py
- 
ode .github/scripts/validate_agent_plugin.mjs
- generated marketplace: claude plugin validate PATH --strict
- generated plugin: claude plugin validate PATH/zzzops --strict

Tracks #305