### PR TITLE
test(claude): verify installed plugin cache

### DIFF
--- a/.agents/claude_plugin_acceptance.py
+++ b/.agents/claude_plugin_acceptance.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Run Claude marketplace, cache, discovery, and packaged-runtime acceptance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+EXPECTED_SKILLS = {
+    "add-zzzops-goal", "bootstrap-zzzops-repository", "execute-zzzops", "migrate-to-zzzops",
+    "review-agentic-engineering", "review-zzzops-policy", "send-zzzops-feedback", "suggest-zzzops-work",
+    "validate-zzzops-installation",
+}
+
+
+class AcceptanceError(ValueError):
+    """The generated plugin failed an observable Claude acceptance boundary."""
+
+
+def run(command: list[str], *, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(command, env=env, text=True, capture_output=True, check=False)
+    if result.returncode:
+        detail = (result.stderr.strip() or result.stdout.strip() or "no command output").splitlines()[0]
+        raise AcceptanceError(f"command failed ({command[0]} {command[1]}): {detail[:300]}")
+    return result.stdout
+
+
+def json_output(command: list[str], *, env: dict[str, str] | None = None) -> Any:
+    output = run(command, env=env)
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise AcceptanceError(f"command returned invalid JSON: {command[0]} {command[1]}") from exc
+
+
+def validate_available(records: Any, version: str) -> None:
+    expected = {
+        "pluginId": "zzzops@zzzops", "name": "zzzops", "marketplaceName": "zzzops",
+        "version": version, "source": "./zzzops",
+    }
+    if (
+        not isinstance(records, list) or len(records) != 1 or not isinstance(records[0], dict)
+        or any(records[0].get(key) != value for key, value in expected.items())
+    ):
+        raise AcceptanceError("available plugin inventory does not match the generated marketplace")
+
+
+def validate_details(details: str) -> None:
+    match = re.search(r"Skills \((\d+)\)\s+(.*?)\r?\n\s*Agents \(", details, re.DOTALL)
+    if not match:
+        raise AcceptanceError("Claude details output has no parseable skill inventory")
+    skills = {name.strip() for name in match.group(2).replace("\r", "").replace("\n", " ").split(",")}
+    if int(match.group(1)) != len(EXPECTED_SKILLS) or skills != EXPECTED_SKILLS:
+        raise AcceptanceError("Claude skill inventory differs from the intended ZzzOps surface")
+
+
+def validate_install(records: Any, config: Path, version: str) -> Path:
+    if not isinstance(records, list) or len(records) != 1 or not isinstance(records[0], dict):
+        raise AcceptanceError("installed plugin inventory must contain exactly ZzzOps")
+    record = records[0]
+    if record.get("id") != "zzzops@zzzops" or record.get("version") != version or record.get("enabled") is not True:
+        raise AcceptanceError("installed ZzzOps identity, version, or enabled state is invalid")
+    install_text = record.get("installPath")
+    if not isinstance(install_text, str) or not install_text:
+        raise AcceptanceError("installed ZzzOps has no cache path")
+    install = Path(install_text).resolve()
+    cache = (config / "plugins" / "cache").resolve()
+    if not install.is_relative_to(cache):
+        raise AcceptanceError("installed ZzzOps is not inside the isolated Claude cache")
+    required = (install / ".claude-plugin" / "plugin.json", install / "zzzops" / "zzzops.py")
+    if any(not path.is_file() for path in required):
+        raise AcceptanceError("installed cache copy is missing its manifest or packaged runtime")
+    return install
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate generated ZzzOps through an isolated Claude installation")
+    parser.add_argument("--claude-version", required=True)
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    root = Path(__file__).resolve().parents[1]
+    manifest = json.loads((root / "plugins" / "zzzops" / "plugin.json").read_text(encoding="utf-8-sig"))
+    version = manifest.get("version") if isinstance(manifest, dict) else None
+    if not isinstance(version, str) or not version:
+        print("Claude plugin acceptance failed: canonical plugin version is missing", file=sys.stderr)
+        return 2
+    try:
+        with tempfile.TemporaryDirectory(prefix="zzzops-claude-acceptance-") as directory:
+            workspace = Path(directory)
+            marketplace = workspace / "marketplace"
+            config = workspace / "config"
+            project = workspace / "project"
+            config.mkdir()
+            project.mkdir()
+            env = os.environ.copy()
+            env["CLAUDE_CONFIG_DIR"] = str(config)
+            observed_version = run(["claude", "--version"], env=env).strip()
+            if not observed_version.startswith(args.claude_version + " "):
+                raise AcceptanceError(f"Claude CLI version drift: expected {args.claude_version}, observed {observed_version}")
+            run([
+                sys.executable, str(root / ".github" / "scripts" / "build_claude_plugin.py"),
+                "--version", version, "--output", str(marketplace),
+            ])
+            run(["claude", "plugin", "validate", str(marketplace), "--strict"], env=env)
+            run(["claude", "plugin", "validate", str(marketplace / "zzzops"), "--strict"], env=env)
+            run(["claude", "plugin", "marketplace", "add", str(marketplace), "--scope", "user"], env=env)
+            available = json_output(["claude", "plugin", "list", "--available", "--json"], env=env)
+            validate_available(available.get("available") if isinstance(available, dict) else None, version)
+            run(["claude", "plugin", "install", "zzzops@zzzops", "--scope", "user", "--yes"], env=env)
+            install = validate_install(json_output(["claude", "plugin", "list", "--json"], env=env), config, version)
+            details = run(["claude", "plugin", "details", "zzzops@zzzops"], env=env)
+            validate_details(details)
+            cached_skills = {path.name for path in (install / "skills").iterdir() if path.is_dir()}
+            if cached_skills != EXPECTED_SKILLS:
+                raise AcceptanceError("cached skill directories differ from the intended ZzzOps surface")
+            inspection = json_output([
+                sys.executable, str(install / "zzzops" / "zzzops.py"), "--repo", str(project), "init", "inspect",
+            ])
+            package = inspection.get("capabilities", {}).get("plugin_package", {}) if isinstance(inspection, dict) else {}
+            if package.get("ok") is not True or package.get("version") != version:
+                raise AcceptanceError("packaged ZzzOps runtime cannot validate its installed cache copy")
+    except (AcceptanceError, OSError, UnicodeError, json.JSONDecodeError) as exc:
+        print(f"Claude plugin acceptance failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps({"accepted": True, "claude_version": args.claude_version, "plugin_version": version, "skills": sorted(EXPECTED_SKILLS)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/test_claude_plugin_acceptance.py
+++ b/.agents/test_claude_plugin_acceptance.py
@@ -1,0 +1,60 @@
+"""Regression tests for the reusable Claude installed-cache acceptance harness."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / ".agents" / "claude_plugin_acceptance.py"
+EXPECTED_SKILLS = {
+    "add-zzzops-goal", "bootstrap-zzzops-repository", "execute-zzzops", "migrate-to-zzzops",
+    "review-agentic-engineering", "review-zzzops-policy", "send-zzzops-feedback", "suggest-zzzops-work",
+    "validate-zzzops-installation",
+}
+
+
+def load_harness():
+    spec = importlib.util.spec_from_file_location("claude_plugin_acceptance", HARNESS)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ClaudePluginAcceptanceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.harness = load_harness()
+
+    def test_inventory_requires_exact_marketplace_plugin_and_skills(self) -> None:
+        available = [{
+            "pluginId": "zzzops@zzzops", "name": "zzzops", "marketplaceName": "zzzops",
+            "version": "2.0.0", "source": "./zzzops", "description": "ZzzOps",
+        }]
+        self.harness.validate_available(available, "2.0.0")
+        details = "Skills (9)  " + ", ".join(sorted(EXPECTED_SKILLS)) + "\n  Agents (0)"
+        self.harness.validate_details(details)
+        with self.assertRaisesRegex(self.harness.AcceptanceError, "skill inventory"):
+            self.harness.validate_details(details.replace("validate-zzzops-installation", "unexpected"))
+
+    def test_install_must_resolve_inside_isolated_cache_with_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "config"
+            install = config / "plugins" / "cache" / "zzzops" / "zzzops" / "2.0.0"
+            (install / "zzzops").mkdir(parents=True)
+            (install / "zzzops" / "zzzops.py").write_text("# runtime\n", encoding="utf-8")
+            (install / ".claude-plugin").mkdir()
+            (install / ".claude-plugin" / "plugin.json").write_text("{}\n", encoding="utf-8")
+            record = [{"id": "zzzops@zzzops", "version": "2.0.0", "enabled": True, "installPath": str(install)}]
+            self.assertEqual(install.resolve(), self.harness.validate_install(record, config, "2.0.0"))
+            record[0]["installPath"] = str(Path(directory) / "source")
+            with self.assertRaisesRegex(self.harness.AcceptanceError, "isolated Claude cache"):
+                self.harness.validate_install(record, config, "2.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/test_release_validation.py
+++ b/.agents/test_release_validation.py
@@ -34,7 +34,10 @@ class ReleaseValidationTests(unittest.TestCase):
         workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
         self.assertIn("validate-linux:", workflow)
         self.assertIn("validate-windows:", workflow)
-        self.assertIn("needs: [validate-linux, validate-windows]", workflow)
+        self.assertIn("validate-claude:", workflow)
+        self.assertIn("npm install --global @anthropic-ai/claude-code@2.1.241", workflow)
+        self.assertIn("python .agents/claude_plugin_acceptance.py --claude-version 2.1.241", workflow)
+        self.assertIn("needs: [validate-linux, validate-windows, validate-claude]", workflow)
         self.assertIn("python .github/scripts/run_product_validation.py --platform linux", workflow)
         self.assertIn("python .github/scripts/run_product_validation.py --platform windows", workflow)
         runner = RUNNER_PATH.read_text(encoding="utf-8")
@@ -43,8 +46,16 @@ class ReleaseValidationTests(unittest.TestCase):
         self.assertEqual(2, runner.count('run(sys.executable, ".agents/test_marketplace_bundle.py")'))
         release_job = workflow.split("  release:", 1)[1]
         self.assertIn("actions/setup-python@v5", release_job)
-        self.assertIn("needs: [validate-linux, validate-windows]", release_job)
+        self.assertIn("needs: [validate-linux, validate-windows, validate-claude]", release_job)
         self.assertLess(release_job.index("needs:"), release_job.index("run: npx semantic-release"))
+
+    def test_pr_required_gate_includes_pinned_claude_acceptance(self):
+        workflow = (ROOT / ".github" / "workflows" / "validate.yml").read_text(encoding="utf-8")
+        self.assertIn("validate-claude:", workflow)
+        self.assertIn("npm install --global @anthropic-ai/claude-code@2.1.241", workflow)
+        self.assertIn("python .agents/claude_plugin_acceptance.py --claude-version 2.1.241", workflow)
+        self.assertIn("needs: [validate-linux, validate-windows, validate-macos, validate-claude]", workflow)
+        self.assertIn("claude=${{ needs.validate-claude.result }}", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,25 @@ jobs:
       - name: Run the shared Windows plugin validation leg
         run: python .github/scripts/run_product_validation.py --platform windows
 
+  validate-claude:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.14.0'
+      - name: Install pinned Claude Code
+        run: npm install --global @anthropic-ai/claude-code@2.1.241
+      - name: Test generated marketplace installation and discovery
+        run: python .agents/claude_plugin_acceptance.py --claude-version 2.1.241
+
   release:
     if: github.ref == 'refs/heads/main'
-    needs: [validate-linux, validate-windows]
+    needs: [validate-linux, validate-windows, validate-claude]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,10 +54,26 @@ jobs:
       - name: Test plugin runtime and package contracts
         run: python .github/scripts/run_product_validation.py --platform macos
 
+  validate-claude:
+    name: Claude installed-cache acceptance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.14.0'
+      - name: Install pinned Claude Code
+        run: npm install --global @anthropic-ai/claude-code@2.1.241
+      - name: Test generated marketplace installation and discovery
+        run: python .agents/claude_plugin_acceptance.py --claude-version 2.1.241
+
   required:
     name: dev-required-tests
     if: ${{ always() }}
-    needs: [validate-linux, validate-windows, validate-macos]
+    needs: [validate-linux, validate-windows, validate-macos, validate-claude]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -67,3 +83,4 @@ jobs:
           linux=${{ needs.validate-linux.result }}
           windows=${{ needs.validate-windows.result }}
           macos=${{ needs.validate-macos.result }}
+          claude=${{ needs.validate-claude.result }}

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -4,6 +4,8 @@ Run this plan conversationally: ask for the next item, perform its human action,
 
 This plan, the `run-zzzops-acceptance` skill, and `.agents/manual_acceptance.py` belong only to the ZzzOps base repository's maintenance and release process. The Agent Plugin also ships `validate-zzzops-installation` alongside the goal, bootstrap, execution, migration, coaching, policy, feedback, and suggestion skills.
 
+Claude distribution has a separate automated installed-cache contract. CI installs the exact Claude Code version named in `.github/workflows/validate.yml`, then runs `python .agents/claude_plugin_acceptance.py --claude-version VERSION` in a disposable configuration. The probe strictly validates the generated manifests, adds the local marketplace, installs the plugin into Claude's cache, verifies the nine-skill inventory, and runs the packaged ZzzOps initialization inspection without using the source tree as runtime fallback.
+
 Maintainers must map each shipped user-facing surface to a human item. For ZzzOps that means Codex marketplace/package behavior and the nine plugin skills. Internal control commands, backend mechanics, policy plumbing, reservations, prompt accounting, CI, documentation, and individual test cases are not separate human acceptance surfaces; inspect or automate them proportionately instead. Reusable acceptance-harness behavior needs focused regression coverage, but no human item unless the harness itself ships to users. Run `<python> .agents/manual_acceptance.py coverage` with one resolved Python 3.10 or newer interpreter to report required unmapped user surfaces without changing the plan.
 
 <!-- zzzops-acceptance-plan


### PR DESCRIPTION
## Outcome
- install the generated local marketplace through a disposable Claude configuration
- prove available inventory, cached installation, the exact nine-skill discovery surface, and packaged-runtime self-validation
- pin Claude Code 2.1.241 in both PR and main release gates
- require the Claude acceptance leg in the aggregate PR gate and before publication

## Verification
- python .agents/test_claude_plugin_acceptance.py
- python .agents/test_release_validation.py
- python .agents/claude_plugin_acceptance.py --claude-version 2.1.241
- 
pm view @anthropic-ai/claude-code@2.1.241 version

Tracks #306