### PR TITLE
fix(claude): make repository marketplace-ready

### DIFF
--- a/.agents/claude_plugin_acceptance.py
+++ b/.agents/claude_plugin_acceptance.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 from typing import Any
+from zipfile import ZipFile
 
 
 EXPECTED_SKILLS = {
@@ -81,6 +82,15 @@ def validate_install(records: Any, config: Path, version: str) -> Path:
     return install
 
 
+def extract_archive(archive_path: Path, destination: Path) -> None:
+    with ZipFile(archive_path) as archive:
+        for name in archive.namelist():
+            relative = Path(name)
+            if relative.is_absolute() or ".." in relative.parts:
+                raise AcceptanceError(f"release archive contains an unsafe path: {name}")
+        archive.extractall(destination)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate generated ZzzOps through an isolated Claude installation")
     parser.add_argument("--claude-version", required=True)
@@ -95,21 +105,32 @@ def main(argv: list[str] | None = None) -> int:
         with tempfile.TemporaryDirectory(prefix="zzzops-claude-acceptance-") as directory:
             workspace = Path(directory)
             marketplace = workspace / "marketplace"
+            plugin = workspace / "plugin"
+            artifacts = workspace / "artifacts"
             config = workspace / "config"
             project = workspace / "project"
+            release_notes = workspace / "RELEASE_NOTES.md"
             config.mkdir()
             project.mkdir()
+            release_notes.write_text("Claude release artifact acceptance.\n", encoding="utf-8")
             env = os.environ.copy()
             env["CLAUDE_CONFIG_DIR"] = str(config)
             observed_version = run(["claude", "--version"], env=env).strip()
             if not observed_version.startswith(args.claude_version + " "):
                 raise AcceptanceError(f"Claude CLI version drift: expected {args.claude_version}, observed {observed_version}")
-            run([
-                sys.executable, str(root / ".github" / "scripts" / "build_claude_plugin.py"),
-                "--version", version, "--output", str(marketplace),
+            built = json_output([
+                sys.executable, str(root / ".github" / "scripts" / "build_marketplace_bundle.py"),
+                "--version", version, "--release-notes-file", str(release_notes),
+                "--output", str(artifacts),
             ])
+            claude_plugin = Path(built.get("claude_plugin", "")) if isinstance(built, dict) else Path()
+            claude_submission = Path(built.get("claude_submission", "")) if isinstance(built, dict) else Path()
+            if not claude_plugin.is_file() or not claude_submission.is_file():
+                raise AcceptanceError("release builder did not produce both Claude archives")
+            extract_archive(claude_plugin, plugin)
+            extract_archive(claude_submission, marketplace)
             run(["claude", "plugin", "validate", str(marketplace), "--strict"], env=env)
-            run(["claude", "plugin", "validate", str(marketplace / "zzzops"), "--strict"], env=env)
+            run(["claude", "plugin", "validate", str(plugin), "--strict"], env=env)
             run(["claude", "plugin", "marketplace", "add", str(marketplace), "--scope", "user"], env=env)
             available = json_output(["claude", "plugin", "list", "--available", "--json"], env=env)
             validate_available(available.get("available") if isinstance(available, dict) else None, version)

--- a/.agents/claude_plugin_acceptance.py
+++ b/.agents/claude_plugin_acceptance.py
@@ -42,16 +42,16 @@ def json_output(command: list[str], *, env: dict[str, str] | None = None) -> Any
         raise AcceptanceError(f"command returned invalid JSON: {command[0]} {command[1]}") from exc
 
 
-def validate_available(records: Any, version: str) -> None:
+def validate_available(records: Any, version: str, source: str = "./zzzops") -> None:
     expected = {
         "pluginId": "zzzops@zzzops", "name": "zzzops", "marketplaceName": "zzzops",
-        "version": version, "source": "./zzzops",
+        "version": version, "source": source,
     }
     if (
         not isinstance(records, list) or len(records) != 1 or not isinstance(records[0], dict)
         or any(records[0].get(key) != value for key, value in expected.items())
     ):
-        raise AcceptanceError("available plugin inventory does not match the generated marketplace")
+        raise AcceptanceError("available plugin inventory does not match the expected marketplace")
 
 
 def validate_details(details: str) -> None:
@@ -104,7 +104,6 @@ def main(argv: list[str] | None = None) -> int:
     try:
         with tempfile.TemporaryDirectory(prefix="zzzops-claude-acceptance-") as directory:
             workspace = Path(directory)
-            marketplace = workspace / "marketplace"
             plugin = workspace / "plugin"
             artifacts = workspace / "artifacts"
             config = workspace / "config"
@@ -127,18 +126,15 @@ def main(argv: list[str] | None = None) -> int:
             if not claude_plugin.is_file():
                 raise AcceptanceError("release builder did not produce the Claude plugin archive")
             extract_archive(claude_plugin, plugin)
-            generated = json_output([
-                sys.executable, str(root / ".github" / "scripts" / "build_claude_plugin.py"),
-                "--version", version, "--output", str(marketplace),
-            ])
-            generated_marketplace = Path(generated.get("marketplace", "")) if isinstance(generated, dict) else Path()
-            if generated_marketplace.resolve() != marketplace.resolve() or not marketplace.is_dir():
-                raise AcceptanceError("Claude marketplace generator did not produce the requested temporary layout")
-            run(["claude", "plugin", "validate", str(marketplace), "--strict"], env=env)
+            run(["claude", "plugin", "validate", str(root), "--strict"], env=env)
             run(["claude", "plugin", "validate", str(plugin), "--strict"], env=env)
-            run(["claude", "plugin", "marketplace", "add", str(marketplace), "--scope", "user"], env=env)
+            run(["claude", "plugin", "marketplace", "add", str(root), "--scope", "user"], env=env)
             available = json_output(["claude", "plugin", "list", "--available", "--json"], env=env)
-            validate_available(available.get("available") if isinstance(available, dict) else None, version)
+            validate_available(
+                available.get("available") if isinstance(available, dict) else None,
+                version,
+                "./plugins/zzzops",
+            )
             run(["claude", "plugin", "install", "zzzops@zzzops", "--scope", "user", "--yes"], env=env)
             install = validate_install(json_output(["claude", "plugin", "list", "--json"], env=env), config, version)
             details = run(["claude", "plugin", "details", "zzzops@zzzops"], env=env)

--- a/.agents/claude_plugin_acceptance.py
+++ b/.agents/claude_plugin_acceptance.py
@@ -124,11 +124,16 @@ def main(argv: list[str] | None = None) -> int:
                 "--output", str(artifacts),
             ])
             claude_plugin = Path(built.get("claude_plugin", "")) if isinstance(built, dict) else Path()
-            claude_submission = Path(built.get("claude_submission", "")) if isinstance(built, dict) else Path()
-            if not claude_plugin.is_file() or not claude_submission.is_file():
-                raise AcceptanceError("release builder did not produce both Claude archives")
+            if not claude_plugin.is_file():
+                raise AcceptanceError("release builder did not produce the Claude plugin archive")
             extract_archive(claude_plugin, plugin)
-            extract_archive(claude_submission, marketplace)
+            generated = json_output([
+                sys.executable, str(root / ".github" / "scripts" / "build_claude_plugin.py"),
+                "--version", version, "--output", str(marketplace),
+            ])
+            generated_marketplace = Path(generated.get("marketplace", "")) if isinstance(generated, dict) else Path()
+            if generated_marketplace.resolve() != marketplace.resolve() or not marketplace.is_dir():
+                raise AcceptanceError("Claude marketplace generator did not produce the requested temporary layout")
             run(["claude", "plugin", "validate", str(marketplace), "--strict"], env=env)
             run(["claude", "plugin", "validate", str(plugin), "--strict"], env=env)
             run(["claude", "plugin", "marketplace", "add", str(marketplace), "--scope", "user"], env=env)

--- a/.agents/test_claude_plugin_acceptance.py
+++ b/.agents/test_claude_plugin_acceptance.py
@@ -6,6 +6,7 @@ import importlib.util
 import tempfile
 import unittest
 from pathlib import Path
+from zipfile import ZipFile
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -54,6 +55,14 @@ class ClaudePluginAcceptanceTests(unittest.TestCase):
             record[0]["installPath"] = str(Path(directory) / "source")
             with self.assertRaisesRegex(self.harness.AcceptanceError, "isolated Claude cache"):
                 self.harness.validate_install(record, config, "2.0.0")
+
+    def test_release_archive_extraction_rejects_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive = Path(directory) / "unsafe.zip"
+            with ZipFile(archive, "w") as output:
+                output.writestr("../escape", "unsafe")
+            with self.assertRaisesRegex(self.harness.AcceptanceError, "unsafe path"):
+                self.harness.extract_archive(archive, Path(directory) / "output")
 
 
 if __name__ == "__main__":

--- a/.agents/test_claude_plugin_acceptance.py
+++ b/.agents/test_claude_plugin_acceptance.py
@@ -37,6 +37,8 @@ class ClaudePluginAcceptanceTests(unittest.TestCase):
             "version": "2.0.0", "source": "./zzzops", "description": "ZzzOps",
         }]
         self.harness.validate_available(available, "2.0.0")
+        available[0]["source"] = "./plugins/zzzops"
+        self.harness.validate_available(available, "2.0.0", "./plugins/zzzops")
         details = "Skills (9)  " + ", ".join(sorted(EXPECTED_SKILLS)) + "\n  Agents (0)"
         self.harness.validate_details(details)
         with self.assertRaisesRegex(self.harness.AcceptanceError, "skill inventory"):

--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -63,7 +63,11 @@ class MarketplaceBundleTests(unittest.TestCase):
                 self.assertIn(".claude-plugin/plugin.json", names)
                 self.assertIn("zzzops/zzzops.py", names)
                 self.assertNotIn(".claude-plugin/marketplace.json", names)
-                self.assertEqual("2.0.0", json.loads(archive.read(".claude-plugin/plugin.json"))["version"])
+                packaged_manifest = json.loads(archive.read(".claude-plugin/plugin.json"))
+                committed_manifest = json.loads(
+                    (ROOT / "plugins" / "zzzops" / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(committed_manifest, packaged_manifest)
             with ZipFile(one["plugin"]) as archive:
                 names = archive.namelist()
                 self.assertIn("plugin.json", names)
@@ -167,6 +171,27 @@ class MarketplaceBundleTests(unittest.TestCase):
         canonical = self.builder.plugin_files(ROOT, "2.0.0")
         for relative, content in canonical.items():
             self.assertEqual(content, files[f"zzzops/{relative}"], relative)
+
+    def test_committed_claude_marketplace_targets_the_canonical_plugin_tree(self) -> None:
+        canonical = json.loads((ROOT / "plugins" / "zzzops" / "plugin.json").read_text(encoding="utf-8"))
+        marketplace = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
+        manifest = json.loads(
+            (ROOT / "plugins" / "zzzops" / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual("./plugins/zzzops", marketplace["plugins"][0]["source"])
+        self.assertEqual(canonical["name"], marketplace["name"])
+        self.assertEqual(canonical["author"], marketplace["owner"])
+        self.assertEqual(
+            {"description": canonical["description"], "version": canonical["version"]},
+            marketplace["metadata"],
+        )
+        self.assertEqual(canonical["name"], marketplace["plugins"][0]["name"])
+        self.assertEqual(canonical["description"], marketplace["plugins"][0]["description"])
+        self.assertEqual(canonical["version"], marketplace["plugins"][0]["version"])
+        self.assertEqual(canonical["name"], manifest["name"])
+        for field in ("version", "description", "author", "homepage", "repository", "license", "keywords"):
+            self.assertEqual(canonical[field], manifest[field], field)
 
     def test_claude_generation_rejects_missing_or_invalid_canonical_input(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -50,10 +50,27 @@ class MarketplaceBundleTests(unittest.TestCase):
             notes = "Initial skills-only submission.\n"
             one = self.builder.build_bundles(ROOT, Path(first), "2.0.0", notes)
             two = self.builder.build_bundles(ROOT, Path(second), "2.0.0", notes)
-            for key in ("plugin", "submission"):
+            for key in ("plugin", "submission", "claude_plugin", "claude_submission"):
                 self.assertEqual(
                     hashlib.sha256(one[key].read_bytes()).hexdigest(),
                     hashlib.sha256(two[key].read_bytes()).hexdigest(),
+                )
+
+            self.assertEqual("zzzops-claude-plugin-v2.0.0.zip", one["claude_plugin"].name)
+            self.assertEqual("zzzops-claude-submission-v2.0.0.zip", one["claude_submission"].name)
+            with ZipFile(one["claude_plugin"]) as archive:
+                names = archive.namelist()
+                self.assertIn(".claude-plugin/plugin.json", names)
+                self.assertIn("zzzops/zzzops.py", names)
+                self.assertNotIn(".claude-plugin/marketplace.json", names)
+                self.assertEqual("2.0.0", json.loads(archive.read(".claude-plugin/plugin.json"))["version"])
+            with ZipFile(one["claude_submission"]) as archive:
+                names = archive.namelist()
+                self.assertIn(".claude-plugin/marketplace.json", names)
+                self.assertIn("zzzops/.claude-plugin/plugin.json", names)
+                self.assertEqual(
+                    "2.0.0",
+                    json.loads(archive.read(".claude-plugin/marketplace.json"))["metadata"]["version"],
                 )
 
             with ZipFile(one["plugin"]) as archive:
@@ -120,6 +137,28 @@ class MarketplaceBundleTests(unittest.TestCase):
             self.builder.validate_portal_png("assets/logo.png", image.replace(b"\r\n", b"\n"))
         with self.assertRaisesRegex(self.builder.BundleError, "truncated|checksum|decoded"):
             self.builder.validate_portal_png("assets/logo.png", image[:-20])
+
+    def test_stale_release_output_is_rejected_before_any_partial_refresh(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "marketplace"
+            output.mkdir()
+            stale = output / "zzzops-claude-plugin-v1.9.0.zip"
+            stale.write_bytes(b"stale")
+            with self.assertRaisesRegex(self.builder.BundleError, "output directory must be empty"):
+                self.builder.build_bundles(ROOT, output, "2.0.0", "notes")
+            self.assertEqual({stale.name}, {path.name for path in output.iterdir()})
+
+    def test_release_validation_rejects_missing_divergent_and_invalid_archives(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(self.builder.BundleError, "missing or stale"):
+                self.builder.validate_release_artifacts(
+                    Path(directory), {"required.zip": ({"file": b"expected"}, "required")},
+                )
+        divergent = self.builder.zip_bytes({"file": b"observed"})
+        with self.assertRaisesRegex(self.builder.BundleError, "content mismatch"):
+            self.builder.validate_archive(divergent, {"file": b"expected"}, "Claude plugin")
+        with self.assertRaisesRegex(self.builder.BundleError, "not a valid ZIP"):
+            self.builder.validate_archive(b"invalid", {}, "Claude plugin")
 
     def test_claude_marketplace_is_derived_from_the_canonical_plugin(self) -> None:
         files = self.builder.claude_marketplace_files(ROOT, "2.0.0")

--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -50,29 +50,20 @@ class MarketplaceBundleTests(unittest.TestCase):
             notes = "Initial skills-only submission.\n"
             one = self.builder.build_bundles(ROOT, Path(first), "2.0.0", notes)
             two = self.builder.build_bundles(ROOT, Path(second), "2.0.0", notes)
-            for key in ("plugin", "submission", "claude_plugin", "claude_submission"):
+            self.assertEqual({"plugin", "submission", "claude_plugin"}, set(one))
+            for key in ("plugin", "submission", "claude_plugin"):
                 self.assertEqual(
                     hashlib.sha256(one[key].read_bytes()).hexdigest(),
                     hashlib.sha256(two[key].read_bytes()).hexdigest(),
                 )
 
             self.assertEqual("zzzops-claude-plugin-v2.0.0.zip", one["claude_plugin"].name)
-            self.assertEqual("zzzops-claude-submission-v2.0.0.zip", one["claude_submission"].name)
             with ZipFile(one["claude_plugin"]) as archive:
                 names = archive.namelist()
                 self.assertIn(".claude-plugin/plugin.json", names)
                 self.assertIn("zzzops/zzzops.py", names)
                 self.assertNotIn(".claude-plugin/marketplace.json", names)
                 self.assertEqual("2.0.0", json.loads(archive.read(".claude-plugin/plugin.json"))["version"])
-            with ZipFile(one["claude_submission"]) as archive:
-                names = archive.namelist()
-                self.assertIn(".claude-plugin/marketplace.json", names)
-                self.assertIn("zzzops/.claude-plugin/plugin.json", names)
-                self.assertEqual(
-                    "2.0.0",
-                    json.loads(archive.read(".claude-plugin/marketplace.json"))["metadata"]["version"],
-                )
-
             with ZipFile(one["plugin"]) as archive:
                 names = archive.namelist()
                 self.assertIn("plugin.json", names)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "zzzops",
+  "owner": {
+    "name": "David Rzepa",
+    "url": "https://github.com/david-rzepa"
+  },
+  "metadata": {
+    "description": "Durable autonomous project goals for coding agents",
+    "version": "2.0.0"
+  },
+  "plugins": [
+    {
+      "name": "zzzops",
+      "source": "./plugins/zzzops",
+      "description": "Durable autonomous project goals for coding agents",
+      "version": "2.0.0"
+    }
+  ]
+}

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build and validate deterministic OpenAI skills-only submission artifacts."""
+"""Build deterministic, validated OpenAI and Claude release artifacts."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ import struct
 import sys
 import tempfile
 from typing import Any
-from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+from zipfile import BadZipFile, ZIP_DEFLATED, ZipFile, ZipInfo
 import zlib
 
 
@@ -326,13 +326,26 @@ def tests_markdown(tests: dict[str, Any]) -> str:
 
 
 def validate_archive(data: bytes, expected: dict[str, bytes], label: str) -> None:
-    temporary = io.BytesIO(data)
-    with ZipFile(temporary) as archive:
-        if archive.namelist() != sorted(expected):
-            raise BundleError(f"{label} archive file tree is not deterministic")
-        for relative, content in expected.items():
-            if archive.read(relative) != content:
-                raise BundleError(f"{label} archive content mismatch: {relative}")
+    try:
+        temporary = io.BytesIO(data)
+        with ZipFile(temporary) as archive:
+            if archive.namelist() != sorted(expected):
+                raise BundleError(f"{label} archive file tree is not deterministic")
+            for relative, content in expected.items():
+                if archive.read(relative) != content:
+                    raise BundleError(f"{label} archive content mismatch: {relative}")
+    except BadZipFile as exc:
+        raise BundleError(f"{label} archive is not a valid ZIP") from exc
+
+
+def validate_release_artifacts(directory: Path, expected: dict[str, tuple[dict[str, bytes], str]]) -> None:
+    actual = {path.name for path in directory.iterdir() if path.is_file()}
+    if actual != set(expected):
+        missing = sorted(set(expected) - actual)
+        stale = sorted(actual - set(expected))
+        raise BundleError(f"release artifacts are missing or stale: missing={missing}, stale={stale}")
+    for filename, (contents, label) in expected.items():
+        validate_archive((directory / filename).read_bytes(), contents, label)
 
 
 def build_bundles(root: Path, output: Path, version: str, release_notes: str) -> dict[str, Path]:
@@ -340,6 +353,8 @@ def build_bundles(root: Path, output: Path, version: str, release_notes: str) ->
     output = output.resolve()
     if not SEMVER.fullmatch(version):
         raise BundleError("version must be a concrete semantic release version")
+    if output.exists() and any(output.iterdir()):
+        raise BundleError("output directory must be empty before release preparation")
     release_notes = require_text(release_notes, "release notes").replace("\r\n", "\n").rstrip() + "\n"
     listing, tests, attestations = validate_sources(root)
     plugin_contents = plugin_files(root, version)
@@ -382,26 +397,50 @@ def build_bundles(root: Path, output: Path, version: str, release_notes: str) ->
     }
     packet_contents["manifest.json"] = canonical_json(manifest)
     submission_data = zip_bytes(packet_contents)
+    claude_submission_contents = claude_marketplace_files(root, version)
+    claude_plugin_contents = {
+        relative.removeprefix("zzzops/"): data
+        for relative, data in claude_submission_contents.items()
+        if relative.startswith("zzzops/")
+    }
+    claude_plugin_data = zip_bytes(claude_plugin_contents)
+    claude_submission_data = zip_bytes(claude_submission_contents)
     validate_archive(plugin_data, plugin_contents, "plugin")
     validate_archive(submission_data, packet_contents, "submission")
-    output.mkdir(parents=True, exist_ok=True)
+    validate_archive(claude_plugin_data, claude_plugin_contents, "Claude plugin")
+    validate_archive(claude_submission_data, claude_submission_contents, "Claude submission")
+    output.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix="zzzops-marketplace-", dir=output.parent))
     try:
         plugin_path = staging / plugin_name
         submission_path = staging / f"zzzops-openai-submission-v{version}.zip"
+        claude_plugin_path = staging / f"zzzops-claude-plugin-v{version}.zip"
+        claude_submission_path = staging / f"zzzops-claude-submission-v{version}.zip"
         plugin_path.write_bytes(plugin_data)
         submission_path.write_bytes(submission_data)
-        final_plugin = output / plugin_path.name
-        final_submission = output / submission_path.name
-        plugin_path.replace(final_plugin)
-        submission_path.replace(final_submission)
+        claude_plugin_path.write_bytes(claude_plugin_data)
+        claude_submission_path.write_bytes(claude_submission_data)
+        validate_release_artifacts(staging, {
+            plugin_path.name: (plugin_contents, "written plugin"),
+            submission_path.name: (packet_contents, "written submission"),
+            claude_plugin_path.name: (claude_plugin_contents, "written Claude plugin"),
+            claude_submission_path.name: (claude_submission_contents, "written Claude submission"),
+        })
+        if output.exists():
+            output.rmdir()
+        staging.replace(output)
     finally:
         shutil.rmtree(staging, ignore_errors=True)
-    return {"plugin": final_plugin, "submission": final_submission}
+    return {
+        "plugin": output / plugin_path.name,
+        "submission": output / submission_path.name,
+        "claude_plugin": output / claude_plugin_path.name,
+        "claude_submission": output / claude_submission_path.name,
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Build validated OpenAI marketplace submission artifacts")
+    parser = argparse.ArgumentParser(description="Build validated OpenAI and Claude marketplace release artifacts")
     parser.add_argument("--version", required=True)
     parser.add_argument("--release-notes-file", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -397,34 +397,29 @@ def build_bundles(root: Path, output: Path, version: str, release_notes: str) ->
     }
     packet_contents["manifest.json"] = canonical_json(manifest)
     submission_data = zip_bytes(packet_contents)
-    claude_submission_contents = claude_marketplace_files(root, version)
+    claude_marketplace_contents = claude_marketplace_files(root, version)
     claude_plugin_contents = {
         relative.removeprefix("zzzops/"): data
-        for relative, data in claude_submission_contents.items()
+        for relative, data in claude_marketplace_contents.items()
         if relative.startswith("zzzops/")
     }
     claude_plugin_data = zip_bytes(claude_plugin_contents)
-    claude_submission_data = zip_bytes(claude_submission_contents)
     validate_archive(plugin_data, plugin_contents, "plugin")
     validate_archive(submission_data, packet_contents, "submission")
     validate_archive(claude_plugin_data, claude_plugin_contents, "Claude plugin")
-    validate_archive(claude_submission_data, claude_submission_contents, "Claude submission")
     output.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix="zzzops-marketplace-", dir=output.parent))
     try:
         plugin_path = staging / plugin_name
         submission_path = staging / f"zzzops-openai-submission-v{version}.zip"
         claude_plugin_path = staging / f"zzzops-claude-plugin-v{version}.zip"
-        claude_submission_path = staging / f"zzzops-claude-submission-v{version}.zip"
         plugin_path.write_bytes(plugin_data)
         submission_path.write_bytes(submission_data)
         claude_plugin_path.write_bytes(claude_plugin_data)
-        claude_submission_path.write_bytes(claude_submission_data)
         validate_release_artifacts(staging, {
             plugin_path.name: (plugin_contents, "written plugin"),
             submission_path.name: (packet_contents, "written submission"),
             claude_plugin_path.name: (claude_plugin_contents, "written Claude plugin"),
-            claude_submission_path.name: (claude_submission_contents, "written Claude submission"),
         })
         if output.exists():
             output.rmdir()
@@ -435,7 +430,6 @@ def build_bundles(root: Path, output: Path, version: str, release_notes: str) ->
         "plugin": output / plugin_path.name,
         "submission": output / submission_path.name,
         "claude_plugin": output / claude_plugin_path.name,
-        "claude_submission": output / claude_submission_path.name,
     }
 
 

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -188,7 +188,9 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
     plugin = root / "plugins" / "zzzops"
     renderer = runpy.run_path(str(plugin / "zzzops" / "package.py"))["render_skill_metadata"]
     result: dict[str, bytes] = {}
-    allowed_top_level = {".codex-plugin", "assets", "plugin.json", "rules", "scripts", "skills", "zzzops"}
+    allowed_top_level = {
+        ".claude-plugin", ".codex-plugin", "assets", "plugin.json", "rules", "scripts", "skills", "zzzops",
+    }
     for path in sorted(plugin.rglob("*"), key=lambda item: item.relative_to(plugin).as_posix()):
         relative = path.relative_to(plugin).as_posix()
         if PurePosixPath(relative).parts[0] not in allowed_top_level:
@@ -200,7 +202,7 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
         data = path.read_bytes()
         if path.suffix.casefold() in {".json", ".md", ".py", ".yaml", ".yml"}:
             data = data.replace(b"\r\n", b"\n")
-        if relative in {"plugin.json", ".codex-plugin/plugin.json"}:
+        if relative in {"plugin.json", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json"}:
             manifest = json.loads(data.decode("utf-8-sig"))
             manifest["version"] = version
             data = canonical_json(manifest)
@@ -211,7 +213,7 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
         scan_for_secrets(relative, data)
         result[relative] = data
     required = {
-        "plugin.json", ".codex-plugin/plugin.json", "assets/logo.png", "assets/logo-dark.png",
+        "plugin.json", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json", "assets/logo.png", "assets/logo-dark.png",
         "assets/composer-icon.png", "assets/composer-icon-dark.png", "scripts/cleanup_legacy.py",
     }
     missing = sorted(required - set(result))

--- a/.github/scripts/semantic_release_bundle.cjs
+++ b/.github/scripts/semantic_release_bundle.cjs
@@ -27,7 +27,7 @@ async function prepare(_pluginConfig, context) {
       ], { cwd: context.cwd, encoding: "utf8" });
       last = result;
       if (!result.error && result.status === 0) {
-        context.logger.log(`Built validated OpenAI and Claude marketplace bundles for v${version}.`);
+        context.logger.log(`Built validated OpenAI and Claude release bundles for v${version}.`);
         return;
       }
       if (!result.error || result.error.code !== "ENOENT") {

--- a/.github/scripts/semantic_release_bundle.cjs
+++ b/.github/scripts/semantic_release_bundle.cjs
@@ -27,7 +27,7 @@ async function prepare(_pluginConfig, context) {
       ], { cwd: context.cwd, encoding: "utf8" });
       last = result;
       if (!result.error && result.status === 0) {
-        context.logger.log(`Built validated OpenAI marketplace bundles for v${version}.`);
+        context.logger.log(`Built validated OpenAI and Claude marketplace bundles for v${version}.`);
         return;
       }
       if (!result.error || result.error.code !== "ENOENT") {

--- a/.github/scripts/test_semantic_release.mjs
+++ b/.github/scripts/test_semantic_release.mjs
@@ -30,8 +30,7 @@ test("marketplace bundles gate publication and become GitHub release assets", ()
   assert.deepEqual(githubOptions.assets.map(({ path }) => path), [
     "dist/marketplace/zzzops-plugin-v*.zip",
     "dist/marketplace/zzzops-openai-submission-v*.zip",
-    "dist/marketplace/zzzops-claude-plugin-v*.zip",
-    "dist/marketplace/zzzops-claude-submission-v*.zip"
+    "dist/marketplace/zzzops-claude-plugin-v*.zip"
   ]);
 });
 

--- a/.github/scripts/test_semantic_release.mjs
+++ b/.github/scripts/test_semantic_release.mjs
@@ -29,7 +29,9 @@ test("marketplace bundles gate publication and become GitHub release assets", ()
   assert.equal(githubPlugin, "@semantic-release/github");
   assert.deepEqual(githubOptions.assets.map(({ path }) => path), [
     "dist/marketplace/zzzops-plugin-v*.zip",
-    "dist/marketplace/zzzops-openai-submission-v*.zip"
+    "dist/marketplace/zzzops-openai-submission-v*.zip",
+    "dist/marketplace/zzzops-claude-plugin-v*.zip",
+    "dist/marketplace/zzzops-claude-submission-v*.zip"
   ]);
 });
 

--- a/plugins/zzzops/.claude-plugin/plugin.json
+++ b/plugins/zzzops/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "zzzops",
+  "description": "Durable autonomous project goals for coding agents",
+  "author": {
+    "name": "David Rzepa",
+    "url": "https://github.com/david-rzepa"
+  },
+  "homepage": "https://github.com/david-rzepa/zzzops",
+  "repository": "https://github.com/david-rzepa/zzzops",
+  "license": "Apache-2.0",
+  "keywords": [
+    "codex",
+    "goals",
+    "automation",
+    "project-management"
+  ],
+  "version": "2.0.0"
+}

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -43,7 +43,9 @@ module.exports = {
       {
         assets: [
           { path: "dist/marketplace/zzzops-plugin-v*.zip", label: "OpenAI portal skills bundle" },
-          { path: "dist/marketplace/zzzops-openai-submission-v*.zip", label: "OpenAI submission packet" }
+          { path: "dist/marketplace/zzzops-openai-submission-v*.zip", label: "OpenAI submission packet" },
+          { path: "dist/marketplace/zzzops-claude-plugin-v*.zip", label: "Claude Code plugin bundle" },
+          { path: "dist/marketplace/zzzops-claude-submission-v*.zip", label: "Claude community submission bundle" }
         ]
       }
     ]

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -44,8 +44,7 @@ module.exports = {
         assets: [
           { path: "dist/marketplace/zzzops-plugin-v*.zip", label: "OpenAI portal skills bundle" },
           { path: "dist/marketplace/zzzops-openai-submission-v*.zip", label: "OpenAI submission packet" },
-          { path: "dist/marketplace/zzzops-claude-plugin-v*.zip", label: "Claude Code plugin bundle" },
-          { path: "dist/marketplace/zzzops-claude-submission-v*.zip", label: "Claude community submission bundle" }
+          { path: "dist/marketplace/zzzops-claude-plugin-v*.zip", label: "Claude Code plugin bundle" }
         ]
       }
     ]


### PR DESCRIPTION
## Outcome

- commit the two thin Claude manifests required for repository/commit marketplace review
- point the marketplace directly at the shared canonical `plugins/zzzops` implementation
- build one deterministic versioned Claude plugin ZIP beside the OpenAI release artifacts
- reject stale, missing, divergent, invalid, or partially prepared release output
- validate and install the committed marketplace through pinned Claude Code acceptance
- leave form completion and owner attestations to the submission handoff tracked by #308

Tracks #307

## Verification

- `py -3 .agents/claude_plugin_acceptance.py --claude-version 2.1.241`
- `py -3 .agents/test_marketplace_bundle.py`
- `py -3 .agents/test_claude_plugin_acceptance.py`
- `py -3 .agents/test_release_validation.py`
- `npm.cmd run test:plugin`
- `npm.cmd run test:release`
- `git diff --check`

There is no Claude submission ZIP and no duplicate plugin implementation. Anthropic can review the committed marketplace manifest, which resolves directly to `plugins/zzzops`; the release ZIP remains available for direct installation.
