### PR TITLE
feat(release): publish moving latest channel

### DIFF
--- a/.github/scripts/sync_latest_release_branch.cjs
+++ b/.github/scripts/sync_latest_release_branch.cjs
@@ -1,0 +1,73 @@
+const { spawnSync } = require("node:child_process");
+
+function run(command, args, { cwd, env = process.env } = {}) {
+  const result = spawnSync(command, args, { cwd, env, encoding: "utf8" });
+  if (!result.error && result.status === 0) {
+    return result.stdout.trim();
+  }
+  const detail = result.error?.message || result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`;
+  throw new Error(`${command} ${args.join(" ")} failed: ${detail}`);
+}
+
+function releaseTagAtHead(cwd) {
+  const tags = run("git", ["tag", "--points-at", "HEAD", "--sort=-v:refname", "--list", "v[0-9]*"], { cwd });
+  return tags.split(/\r?\n/).find(tag => /^v\d+\.\d+\.\d+$/.test(tag)) || null;
+}
+
+async function githubLatestMatches(tag, { cwd, env }) {
+  const repository = env.GITHUB_REPOSITORY;
+  if (!repository) {
+    throw new Error("GITHUB_REPOSITORY is required to verify the latest published release.");
+  }
+  const latest = run("gh", ["api", `repos/${repository}/releases/latest`, "--jq", ".tag_name"], { cwd, env });
+  return latest === tag;
+}
+
+async function reconcileLatest({
+  cwd = process.cwd(),
+  env = process.env,
+  isLatestPublished = tag => githubLatestMatches(tag, { cwd, env })
+} = {}) {
+  const head = run("git", ["rev-parse", "HEAD"], { cwd, env });
+  const tag = releaseTagAtHead(cwd);
+  if (!tag) {
+    return { outcome: "no-release-tag", tag: null, head };
+  }
+
+  const tagHead = run("git", ["rev-parse", `${tag}^{commit}`], { cwd, env });
+  if (tagHead !== head) {
+    throw new Error(`Release tag ${tag} does not identify workflow HEAD ${head}.`);
+  }
+  if (!(await isLatestPublished(tag))) {
+    return { outcome: "not-latest-release", tag, head };
+  }
+
+  const remote = run("git", ["ls-remote", "--heads", "origin", "refs/heads/latest"], { cwd, env });
+  const remoteHead = remote ? remote.split(/\s+/)[0] : null;
+  if (remoteHead === head) {
+    return { outcome: "unchanged", tag, head };
+  }
+
+  const lease = `--force-with-lease=refs/heads/latest:${remoteHead || ""}`;
+  run("git", ["push", lease, "origin", `${head}:refs/heads/latest`], { cwd, env });
+  return { outcome: "updated", tag, head };
+}
+
+if (require.main === module) {
+  reconcileLatest()
+    .then(result => {
+      if (result.outcome === "updated") {
+        console.log(`Updated latest to ${result.tag} (${result.head}).`);
+      } else if (result.outcome === "unchanged") {
+        console.log(`latest already identifies ${result.tag} (${result.head}).`);
+      } else {
+        console.log(`Did not update latest: ${result.outcome}.`);
+      }
+    })
+    .catch(error => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });
+}
+
+module.exports = { reconcileLatest };

--- a/.github/scripts/test_semantic_release.mjs
+++ b/.github/scripts/test_semantic_release.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { PassThrough } from "node:stream";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -15,6 +15,7 @@ import semanticRelease from "semantic-release";
 const require = createRequire(import.meta.url);
 const releaseConfig = require("../../release.config.cjs");
 const bundlePlugin = require("./semantic_release_bundle.cjs");
+const { reconcileLatest } = require("./sync_latest_release_branch.cjs");
 const releaseTestConfig = { ...releaseConfig, plugins: releaseConfig.plugins.slice(0, 2) };
 const [analyzerName, analyzerOptions] = releaseTestConfig.plugins[0];
 const [notesName, notesOptions] = releaseTestConfig.plugins[1];
@@ -161,4 +162,75 @@ test("semantic-release dry-run honors the latest tag boundary and does not publi
     { stdio: "ignore" }
   );
   assert.notEqual(unpublishedTag.status, 0);
+});
+
+test("main release workflow reconciles latest after semantic-release succeeds", () => {
+  const workflow = readFileSync(".github/workflows/release.yml", "utf8");
+  const publish = workflow.indexOf("run: npx semantic-release");
+  const reconcile = workflow.indexOf("run: node .github/scripts/sync_latest_release_branch.cjs");
+  assert.ok(publish >= 0);
+  assert.ok(reconcile > publish);
+});
+
+test("latest branch advances only to the current published release and retries safely", async () => {
+  const root = mkdtempSync(join(tmpdir(), "zzzops-latest-release-"));
+  const remote = join(root, "remote.git");
+  const work = join(root, "work");
+  const git = (cwd, ...args) => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+  execFileSync("git", ["init", "--bare", "--initial-branch=main", remote], { stdio: "ignore" });
+  execFileSync("git", ["clone", remote, work], { stdio: "ignore" });
+  git(work, "config", "user.name", "ZzzOps test");
+  git(work, "config", "user.email", "test@zzzops.invalid");
+  git(work, "commit", "--allow-empty", "-m", "feat: first release");
+  git(work, "tag", "v1.0.0");
+  git(work, "push", "--follow-tags", "origin", "main");
+
+  const first = await reconcileLatest({ cwd: work, isLatestPublished: async tag => tag === "v1.0.0" });
+  assert.deepEqual(first, { outcome: "updated", tag: "v1.0.0", head: git(work, "rev-parse", "HEAD") });
+  assert.equal(git(remote, "rev-parse", "refs/heads/latest"), git(work, "rev-parse", "HEAD"));
+
+  const retry = await reconcileLatest({ cwd: work, isLatestPublished: async () => true });
+  assert.deepEqual(retry, { outcome: "unchanged", tag: "v1.0.0", head: git(work, "rev-parse", "HEAD") });
+
+  git(work, "commit", "--allow-empty", "-m", "feat: second release");
+  git(work, "tag", "v2.0.0");
+  git(work, "push", "--follow-tags", "origin", "main");
+  const secondHead = git(work, "rev-parse", "HEAD");
+
+  const unpublished = await reconcileLatest({ cwd: work, isLatestPublished: async () => false });
+  assert.deepEqual(unpublished, { outcome: "not-latest-release", tag: "v2.0.0", head: secondHead });
+  assert.notEqual(git(remote, "rev-parse", "refs/heads/latest"), secondHead);
+
+  const second = await reconcileLatest({ cwd: work, isLatestPublished: async tag => tag === "v2.0.0" });
+  assert.deepEqual(second, { outcome: "updated", tag: "v2.0.0", head: secondHead });
+  assert.equal(git(remote, "rev-parse", "refs/heads/latest"), secondHead);
+});
+
+test("latest reconciliation is a no-op when the workflow commit has no release tag", async () => {
+  const root = mkdtempSync(join(tmpdir(), "zzzops-latest-no-release-"));
+  const remote = join(root, "remote.git");
+  const work = join(root, "work");
+  const git = (cwd, ...args) => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+  execFileSync("git", ["init", "--bare", "--initial-branch=main", remote], { stdio: "ignore" });
+  execFileSync("git", ["clone", remote, work], { stdio: "ignore" });
+  git(work, "config", "user.name", "ZzzOps test");
+  git(work, "config", "user.email", "test@zzzops.invalid");
+  git(work, "commit", "--allow-empty", "-m", "docs: no release");
+  git(work, "push", "origin", "main");
+
+  let queried = false;
+  const result = await reconcileLatest({
+    cwd: work,
+    isLatestPublished: async () => {
+      queried = true;
+      return true;
+    }
+  });
+
+  assert.deepEqual(result, { outcome: "no-release-tag", tag: null, head: git(work, "rev-parse", "HEAD") });
+  assert.equal(queried, false);
+  const latest = spawnSync("git", ["--git-dir", remote, "show-ref", "--verify", "refs/heads/latest"]);
+  assert.notEqual(latest.status, 0);
 });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,3 +100,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
         run: npx semantic-release
+      - name: Update latest Git marketplace channel
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node .github/scripts/sync_latest_release_branch.cjs

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Develop on branches created from `dev` and open ordinary PRs against `dev`. PR v
 
 Semantic commits since the latest reachable `vMAJOR.MINOR.PATCH` tag are the release-history source. `!` or a `BREAKING CHANGE` footer produces a major release, `feat` produces minor, and `fix`, `perf`, or `revert` produces patch. The highest change wins. Documentation, style, chores, refactors, tests, builds, and CI do not release and are omitted from notes. The conventional-commits generator emits sections in its fixed significance order—Features, Bug Fixes, Performance Improvements, then Reverts—with a distinct breaking-changes section; empty sections are omitted and entries are sorted by subject then scope. Reruns with no releasable commits are no-ops.
 
+After GitHub publishes a semantic release, CI moves the `latest` branch to that release tag's exact commit. Immutable version tags remain the reproducible installation source. No-release runs leave `latest` unchanged, and an older workflow rerun cannot move it behind GitHub's current latest published release.
+
 Release notes live on the GitHub Release rather than in a versioned `CHANGELOG.md`, avoiding a release-generated commit and duplicate history. The exact Node and semantic-release/plugin versions are pinned in `package-lock.json`; no repository secret is required beyond GitHub's job token.
 
 To diagnose a PR or release, inspect **PR validation / dev-required-tests** or the **Semantic release** run and its failing step. Routine implementation uses the smallest distinct local probe and leaves an exact-equivalent broad command to required CI at the pushed head. When CI fails or is unavailable, reproduce its commands locally with:


### PR DESCRIPTION
## Summary

- Advance a real `latest` branch only after the workflow commit is GitHub's latest published semantic release.
- Preserve immutable version tags and reject stale workflow reruns.
- Test creation, advancement, no-release behavior, unpublished releases, and idempotent retries.

## Verification

- `npm run test:release` (8 passing)
- `git diff --check`

Tracks #318
