### PR TITLE
feat(discovery): align public product positioning

### DIFF
--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -167,6 +167,12 @@ class MarketplaceBundleTests(unittest.TestCase):
         self.assertEqual("2.0.0", marketplace["metadata"]["version"])
         self.assertEqual("./zzzops", marketplace["plugins"][0]["source"])
         self.assertEqual("2.0.0", marketplace["plugins"][0]["version"])
+        self.assertEqual(manifest["keywords"], marketplace["plugins"][0]["keywords"])
+        self.assertEqual("development", marketplace["plugins"][0]["category"])
+        self.assertEqual(
+            ["agentic-engineering", "coding-agents", "repository-bootstrap"],
+            marketplace["plugins"][0]["tags"],
+        )
 
         canonical = self.builder.plugin_files(ROOT, "2.0.0")
         for relative, content in canonical.items():
@@ -192,6 +198,38 @@ class MarketplaceBundleTests(unittest.TestCase):
         self.assertEqual(canonical["name"], manifest["name"])
         for field in ("version", "description", "author", "homepage", "repository", "license", "keywords"):
             self.assertEqual(canonical[field], manifest[field], field)
+
+    def test_public_discovery_metadata_keeps_one_truthful_positioning(self) -> None:
+        canonical = json.loads((ROOT / "plugins" / "zzzops" / "plugin.json").read_text(encoding="utf-8"))
+        codex = json.loads(
+            (ROOT / "plugins" / "zzzops" / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        claude = json.loads(
+            (ROOT / "plugins" / "zzzops" / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        claude_marketplace = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
+        openai = json.loads((ROOT / "marketplace" / "listing.json").read_text(encoding="utf-8"))
+        readme_opening = (ROOT / "README.md").read_text(encoding="utf-8")[:1200].casefold()
+
+        expected_keywords = [
+            "agentic-engineering", "coding-agents", "autonomous-development", "repository-bootstrap",
+            "goal-management", "github-issues", "codex", "claude-code",
+        ]
+        self.assertEqual("Agentic engineering with durable goals for autonomous coding agents", canonical["description"])
+        self.assertEqual(expected_keywords, canonical["keywords"])
+        for manifest in (codex, claude):
+            self.assertEqual(canonical["description"], manifest["description"])
+            self.assertEqual(expected_keywords, manifest["keywords"])
+
+        entry = claude_marketplace["plugins"][0]
+        self.assertEqual(expected_keywords, entry["keywords"])
+        self.assertEqual("development", entry["category"])
+        self.assertEqual(["agentic-engineering", "coding-agents", "repository-bootstrap"], entry["tags"])
+        self.assertEqual("Agentic engineering goals", openai["listing"]["short_description"])
+        for phrase in ("agentic engineering", "autonomous coding agents", "repository bootstrapping"):
+            self.assertIn(phrase, openai["listing"]["long_description"].casefold())
+        for phrase in ("agentic-engineering", "autonomous coding agents", "bootstrap repositories"):
+            self.assertIn(phrase, readme_opening)
 
     def test_claude_generation_rejects_missing_or_invalid_canonical_input(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,31 @@
     "url": "https://github.com/david-rzepa"
   },
   "metadata": {
-    "description": "Durable autonomous project goals for coding agents",
+    "description": "Agentic engineering with durable goals for autonomous coding agents",
     "version": "2.0.0"
   },
   "plugins": [
     {
       "name": "zzzops",
       "source": "./plugins/zzzops",
-      "description": "Durable autonomous project goals for coding agents",
-      "version": "2.0.0"
+      "description": "Agentic engineering with durable goals for autonomous coding agents",
+      "version": "2.0.0",
+      "keywords": [
+        "agentic-engineering",
+        "coding-agents",
+        "autonomous-development",
+        "repository-bootstrap",
+        "goal-management",
+        "github-issues",
+        "codex",
+        "claude-code"
+      ],
+      "category": "development",
+      "tags": [
+        "agentic-engineering",
+        "coding-agents",
+        "repository-bootstrap"
+      ]
     }
   ]
 }

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -278,6 +278,9 @@ def claude_marketplace_files(root: Path, version: str) -> dict[str, bytes]:
             "source": "./zzzops",
             "description": canonical_manifest["description"],
             "version": version,
+            "keywords": canonical_manifest["keywords"],
+            "category": "development",
+            "tags": ["agentic-engineering", "coding-agents", "repository-bootstrap"],
         }],
     }
     result = {f"zzzops/{relative}": data for relative, data in canonical.items()}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Infinite backlog for agents. Finite bedtime for token-addicted humans.**
 
-ZzzOps is an agentic-engineering workflow for developers who want coding agents to handle substantial work without constant supervision. It turns project policy, specifications, TODOs, dependencies, verification evidence, and blockers into a durable goal graph backed by GitHub Issues—then gives agents a reliable loop for working through it.
+ZzzOps is an agentic-engineering workflow for developers who want autonomous coding agents to bootstrap repositories and handle substantial work without constant supervision. It turns project policy, specifications, TODOs, dependencies, verification evidence, and blockers into a durable goal graph backed by GitHub Issues—then gives agents a reliable loop for working through it.
 
 Use ZzzOps when a task is too important or too long-lived to exist only in one chat. The goal is simple: make the repository and its feedback loops clear enough that agents can keep moving, stop safely, and resume without you reconstructing the plan.
 

--- a/docs/CLAUDE_MARKETPLACE.md
+++ b/docs/CLAUDE_MARKETPLACE.md
@@ -58,7 +58,7 @@ Use these repository-derived values when the live form requests them:
 | Plugin source | `./plugins/zzzops` |
 | Plugin manifest | `plugins/zzzops/.claude-plugin/plugin.json` |
 | Current manifest version | `2.0.0` |
-| Description | Durable autonomous project goals for coding agents |
+| Description | Agentic engineering with durable goals for autonomous coding agents |
 | License | Apache-2.0 |
 | Homepage | `https://github.com/david-rzepa/zzzops` |
 | Privacy | `https://github.com/david-rzepa/zzzops/blob/main/PRIVACY.md` |

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -1,0 +1,36 @@
+# Product discovery positioning
+
+ZzzOps uses one truthful positioning across repository and plugin surfaces:
+
+> Agentic engineering with durable goals for autonomous coding agents.
+
+The language is descriptive, not a ranking promise. GitHub recommends a concise README that explains what a project does, why it is useful, and how to start, while repository topics classify purpose and improve discovery. OpenAI recommends testing metadata against direct, indirect, and negative prompts and prioritizing precision over marginal recall. Anthropic exposes plugin descriptions, keywords, categories, and tags as discovery metadata.
+
+## Intent map
+
+| High-intent query | User intent | Best destination | Why it fits |
+| --- | --- | --- | --- |
+| `agentic engineering` | Replace ad-hoc prompting with a governed software-agent workflow | README, plugin descriptions, marketplace listings | ZzzOps combines policy, context, durable goals, execution, and verification. |
+| `autonomous coding agents` | Delegate substantial implementation with less babysitting | README and long descriptions | ZzzOps preserves dependencies, blockers, evidence, and resumability across sessions. |
+| `repository bootstrap for AI agents` | Make a greenfield or brownfield repository agent-ready | README bootstrap step and manifest keywords | The bootstrap skill creates ordinary harness goals and verifies their execution. |
+| `durable AI agent goals` | Keep agent work outside ephemeral chat state | Plugin descriptions and OpenAI listing | GitHub Issues hold canonical goals, dependencies, blockers, and next actions. |
+| `Codex project management` / `Claude Code workflow` | Find a coding-agent workflow for a supported host | Manifest keywords and installation sections | One canonical plugin supports Codex and Claude Code without divergent workflows. |
+
+## Surface map
+
+- README opening: explain the product and audience once, then preserve the getting-started path.
+- Agent Plugin and host manifests: use the shared description and eight specific discovery keywords.
+- OpenAI listing: use a short product category phrase and a natural long description; skill routing remains governed by direct, indirect, and negative tests rather than generic keywords.
+- Claude marketplace: carry the canonical description and keywords plus the `development` category and three search tags.
+- GitHub repository metadata: use `Agentic engineering for autonomous coding agents: bootstrap agent-ready repositories, manage durable goals in GitHub Issues, and execute verified work.` with topics `agentic-engineering`, `coding-agents`, `autonomous-agents`, `ai-agents`, `repository-bootstrap`, `github-issues`, `project-management`, `developer-tools`, `codex`, and `claude-code`.
+
+Individual skill descriptions are intentionally unchanged. They already route on concrete workflow verbs and nouns; adding broad discovery phrases there would increase always-loaded context and risk false invocation without evidence of better routing.
+
+## Evidence sources
+
+- [GitHub: About READMEs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)
+- [GitHub: Classifying a repository with topics](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics)
+- [OpenAI: Optimize metadata](https://developers.openai.com/plugins/guides/optimize-metadata)
+- [OpenAI: Submit plugins](https://developers.openai.com/plugins/deploy/submission)
+- [Claude Code: Plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Claude Code: Plugins reference](https://code.claude.com/docs/en/plugins-reference)

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -38,7 +38,7 @@ Every release prepares three validated versioned assets before GitHub publicatio
 - `zzzops-openai-submission-v<version>.zip` — OpenAI listing copy, assets, tests, availability, notes, manifests, and attestation checklist;
 - `zzzops-claude-plugin-v<version>.zip` — self-contained Claude Code plugin bundle.
 
-A build or validation failure stops publication. Successful artifacts attach to the matching GitHub Release. OpenAI portal upload, attestation, review submission, approval, and final directory publication remain explicit human actions; see the [marketplace sources](../marketplace/README.md). Claude submission guidance lives in [Claude Code marketplace notes](CLAUDE_MARKETPLACE.md).
+A build or validation failure stops publication. Successful artifacts attach to the matching GitHub Release. OpenAI portal upload, attestation, review submission, approval, and final directory publication remain explicit human actions; see the [marketplace sources](../marketplace/README.md). Claude submission guidance lives in [Claude Code marketplace notes](CLAUDE_MARKETPLACE.md), and the shared language and intent map live in [product discovery positioning](DISCOVERY.md).
 
 Semantic commits since the latest reachable `vMAJOR.MINOR.PATCH` tag are the release-history source. A breaking marker produces a major release, `feat` produces minor, and `fix`, `perf`, or `revert` produces patch. Documentation, style, chores, refactors, tests, builds, and CI do not release and are omitted from notes. The highest change wins.
 

--- a/marketplace/listing.json
+++ b/marketplace/listing.json
@@ -4,8 +4,8 @@
   "official_submission_docs": "https://developers.openai.com/plugins/deploy/submission",
   "listing": {
     "name": "ZzzOps",
-    "short_description": "Durable autonomous goals",
-    "long_description": "ZzzOps gives Codex a reviewed, prioritized, and resumable project-goal loop. It captures durable work in GitHub Issues, coordinates implementation under reviewed project policy, and keeps human approval at consequential review and release boundaries.",
+    "short_description": "Agentic engineering goals",
+    "long_description": "ZzzOps is an agentic engineering workflow for autonomous coding agents. It supports repository bootstrapping, captures durable goals in GitHub Issues, and executes prioritized work under reviewed project policy with verification, resumability, explicit blockers, and human approval at consequential boundaries.",
     "category": "Developer Tools",
     "developer_name": "David Rzepa",
     "website_url": "https://github.com/david-rzepa/zzzops",

--- a/plugins/zzzops/.claude-plugin/plugin.json
+++ b/plugins/zzzops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zzzops",
-  "description": "Durable autonomous project goals for coding agents",
+  "description": "Agentic engineering with durable goals for autonomous coding agents",
   "author": {
     "name": "David Rzepa",
     "url": "https://github.com/david-rzepa"
@@ -9,10 +9,14 @@
   "repository": "https://github.com/david-rzepa/zzzops",
   "license": "Apache-2.0",
   "keywords": [
+    "agentic-engineering",
+    "coding-agents",
+    "autonomous-development",
+    "repository-bootstrap",
+    "goal-management",
+    "github-issues",
     "codex",
-    "goals",
-    "automation",
-    "project-management"
+    "claude-code"
   ],
   "version": "2.0.0"
 }

--- a/plugins/zzzops/.codex-plugin/plugin.json
+++ b/plugins/zzzops/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zzzops",
   "version": "2.0.0",
-  "description": "Durable autonomous project goals for Codex",
+  "description": "Agentic engineering with durable goals for autonomous coding agents",
   "author": {
     "name": "David Rzepa",
     "url": "https://github.com/david-rzepa"
@@ -9,12 +9,12 @@
   "homepage": "https://github.com/david-rzepa/zzzops",
   "repository": "https://github.com/david-rzepa/zzzops",
   "license": "Apache-2.0",
-  "keywords": ["codex", "goals", "automation", "project-management"],
+  "keywords": ["agentic-engineering", "coding-agents", "autonomous-development", "repository-bootstrap", "goal-management", "github-issues", "codex", "claude-code"],
   "skills": "./skills/",
   "interface": {
     "displayName": "ZzzOps",
-    "shortDescription": "Durable autonomous goals",
-    "longDescription": "ZzzOps gives Codex a reviewed, prioritized, and resumable project-goal loop. It reads and writes GitHub Issues through your existing GitHub authentication and coordinates implementation only under reviewed project policy.",
+    "shortDescription": "Agentic engineering goals",
+    "longDescription": "ZzzOps gives autonomous coding agents a reviewed, prioritized, and resumable agentic-engineering loop for repository bootstrapping and durable goals in GitHub Issues. It coordinates implementation only under reviewed project policy.",
     "developerName": "David Rzepa",
     "category": "Developer Tools",
     "capabilities": ["Write"],

--- a/plugins/zzzops/plugin.json
+++ b/plugins/zzzops/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "zzzops",
   "version": "2.0.0",
-  "description": "Durable autonomous project goals for coding agents",
+  "description": "Agentic engineering with durable goals for autonomous coding agents",
   "author": {
     "name": "David Rzepa",
     "url": "https://github.com/david-rzepa"
@@ -10,5 +10,5 @@
   "homepage": "https://github.com/david-rzepa/zzzops",
   "repository": "https://github.com/david-rzepa/zzzops",
   "license": "Apache-2.0",
-  "keywords": ["codex", "goals", "automation", "project-management"]
+  "keywords": ["agentic-engineering", "coding-agents", "autonomous-development", "repository-bootstrap", "goal-management", "github-issues", "codex", "claude-code"]
 }


### PR DESCRIPTION
## Summary

- align README, Agent Plugin, Codex, Claude, and OpenAI listing copy around truthful agentic-engineering positioning
- add high-intent manifest keywords and Claude marketplace discovery metadata
- record the evidence-backed intent/surface map without adding broad SEO terms to skill-routing descriptions
- keep generated Claude metadata synchronized and cover cross-surface drift
- update the public GitHub description and ten repository topics to the same positioning

## Evidence

- GitHub documents README purpose and repository topics as discovery surfaces
- OpenAI recommends direct, indirect, and negative metadata evaluation with precision prioritized over marginal recall
- Claude documents description, keywords, category, and tags as marketplace metadata

## Verification

- `python .agents/test_marketplace_bundle.py`
- `npm run test:plugin`
- `claude plugin validate . --strict`
- `python .agents/prompt_stats.py --check`
- `python .agents/prompt_stats.py --eval`
- `git diff --check`
- GitHub description and topics read back exactly after update

Tracks #301
