### PR TITLE
feat(acceptance): focus human checks on UX journey

### DIFF
--- a/.agents/manual_acceptance.py
+++ b/.agents/manual_acceptance.py
@@ -53,10 +53,30 @@ def main() -> int:
             "plugins/zzzops/skills/send-zzzops-feedback",
             "plugins/zzzops/skills/validate-zzzops-installation",
         ]
-        mapped = {path for item in items for path in item["paths"]}
+        mapped = {
+            surface
+            for item in items
+            for surface in item.get("surfaces", item["paths"])
+        }
+        automated_without_evidence = []
+        for contract in data.get("automated_surfaces", []):
+            evidence = contract.get("evidence", [])
+            missing_evidence = [
+                path for path in evidence if not (repo / path).is_file()
+            ]
+            if not evidence or missing_evidence:
+                automated_without_evidence.append({
+                    "surface": contract["surface"],
+                    "missing": missing_evidence,
+                })
+            else:
+                mapped.add(contract["surface"])
         missing = [path for path in required if not any(entry == path or entry.startswith(path + "/") for entry in mapped)]
-        print(json.dumps({"unmapped_required_surfaces": missing}))
-        return 1 if missing else 0
+        print(json.dumps({
+            "unmapped_required_surfaces": missing,
+            "automated_surfaces_without_evidence": automated_without_evidence,
+        }))
+        return 1 if missing or automated_without_evidence else 0
     if args.command == "audit":
         changed = []
         for item in items:

--- a/.agents/skills/run-zzzops-acceptance/SKILL.md
+++ b/.agents/skills/run-zzzops-acceptance/SKILL.md
@@ -5,12 +5,12 @@ description: Run/guide/resume/check tests: "manual test", "acceptance test", "ru
 
 # Acceptance
 
-`audit`, `next`; present exactly one active item: ID, prerequisites, human action, expected result.
+`audit`, `next`; present exactly one active item: ID, prerequisites, human action, expected result, and its focused UX questions.
 
 Read the acceptance ledger, never goal bodies/history.
 
 Only explicit same task `check ID` checks it. Never infer an ID. Failures/skips/blockers unchecked; separate tasks `next`.
 
-Use plain language and show only what the user must do now, the expected outcome, and whether it passed. Keep plan fingerprints and harness bookkeeping internal unless requested or needed to diagnose a failure.
+Use plain language and show only what the user must do now, the expected outcome, what UX friction to notice, and whether it passed. Do not turn automated assertions or optional spot checks into mandatory human work unless the plan's risk trigger applies. Keep plan fingerprints and harness bookkeeping internal unless requested or needed to diagnose a failure.
 
 Before stopping or handing off, apply `plugins/zzzops/rules/FEEDBACK.md`.

--- a/.agents/test_manual_acceptance.py
+++ b/.agents/test_manual_acceptance.py
@@ -75,6 +75,65 @@ class ManualAcceptanceTests(unittest.TestCase):
             self.assertEqual(0, result.returncode, result.stdout + result.stderr)
             self.assertEqual([], json.loads(result.stdout)["unmapped_required_surfaces"])
 
+    def test_coverage_accepts_automated_contracts_only_with_present_evidence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            (repo / "docs").mkdir()
+            evidence = repo / "tests" / "test_marketplace.py"
+            evidence.parent.mkdir()
+            evidence.write_text("# automated contract\n", encoding="utf-8")
+            plan = {
+                "version": 2,
+                "items": [{
+                    "id": "UX-1", "status": "unchecked",
+                    "paths": ["plugins/zzzops/plugin.json"],
+                    "surfaces": ["plugins/zzzops/plugin.json"],
+                    "fingerprint": None, "notes": "",
+                }],
+                "automated_surfaces": [{
+                    "surface": ".agents/plugins/marketplace.json",
+                    "evidence": ["tests/test_marketplace.py"],
+                }],
+            }
+            plan_path = repo / "docs" / "ACCEPTANCE_TEST_PLAN.md"
+            plan_path.write_text(
+                "<!-- zzzops-acceptance-plan\n" + json.dumps(plan) + "\nzzzops-acceptance-plan -->\n",
+                encoding="utf-8",
+            )
+
+            def coverage():
+                return subprocess.run(
+                    [sys.executable, str(SCRIPT), "coverage", "--repo", str(repo)],
+                    text=True, capture_output=True,
+                )
+
+            present = coverage()
+            present_data = json.loads(present.stdout)
+            self.assertNotIn(".agents/plugins/marketplace.json", present_data["unmapped_required_surfaces"])
+            self.assertEqual([], present_data["automated_surfaces_without_evidence"])
+
+            evidence.unlink()
+            missing = coverage()
+            missing_data = json.loads(missing.stdout)
+            self.assertEqual(1, missing.returncode)
+            self.assertIn(".agents/plugins/marketplace.json", missing_data["unmapped_required_surfaces"])
+            self.assertEqual(
+                [{"surface": ".agents/plugins/marketplace.json", "missing": ["tests/test_marketplace.py"]}],
+                missing_data["automated_surfaces_without_evidence"],
+            )
+
+            plan["automated_surfaces"][0]["evidence"] = []
+            plan_path.write_text(
+                "<!-- zzzops-acceptance-plan\n" + json.dumps(plan) + "\nzzzops-acceptance-plan -->\n",
+                encoding="utf-8",
+            )
+            undeclared = coverage()
+            self.assertEqual(1, undeclared.returncode)
+            self.assertEqual(
+                [{"surface": ".agents/plugins/marketplace.json", "missing": []}],
+                json.loads(undeclared.stdout)["automated_surfaces_without_evidence"],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -1,58 +1,74 @@
-# Human acceptance plan
+# Human acceptance journey
 
-Run this plan conversationally: ask for the next item, perform its human action, then explicitly say `check A-001`. A checked item becomes stale when one of its mapped paths changes.
+Use this release check to experience ZzzOps as a new user would, not to repeat CI by hand. The mandatory path is one four-checkpoint journey in a disposable private GitHub repository. Target at most 20 minutes of human attention; autonomous implementation and CI wait time are excluded. If the journey exceeds that target, record the excess ceremony or repetition as UX evidence instead of silently extending the estimate.
 
-This plan, the `run-zzzops-acceptance` skill, and `.agents/manual_acceptance.py` belong only to the ZzzOps base repository's maintenance and release process. The Agent Plugin also ships `validate-zzzops-installation` alongside the goal, bootstrap, execution, migration, coaching, policy, feedback, and suggestion skills.
+Ask for the next test, perform only that action, and explicitly say `check UX-001` when its expected result is satisfied. Report confusion, repetition, surprising writes, or unclear next steps before marking a checkpoint. A checked checkpoint becomes stale when behavior mapped to it changes.
 
-Claude distribution has a separate automated installed-cache contract. CI installs the exact Claude Code version named in `.github/workflows/validate.yml`, then runs `python .agents/claude_plugin_acceptance.py --claude-version VERSION` in a disposable configuration. The probe strictly validates the committed repository marketplace and the generated release ZIP, adds the repository marketplace, installs the canonical plugin tree into Claude's cache, verifies the nine-skill inventory, and runs the packaged ZzzOps initialization inspection without using the source tree as runtime fallback.
+## What the human judges
 
-Maintainers must map each shipped user-facing surface to a human item. For ZzzOps that means Codex marketplace/package behavior and the nine plugin skills. Internal control commands, backend mechanics, policy plumbing, reservations, prompt accounting, CI, documentation, and individual test cases are not separate human acceptance surfaces; inspect or automate them proportionately instead. Reusable acceptance-harness behavior needs focused regression coverage, but no human item unless the harness itself ships to users. Run `<python> .agents/manual_acceptance.py coverage` with one resolved Python 3.10 or newer interpreter to report required unmapped user surfaces without changing the plan.
+Pay attention to whether skills are easy to discover, questions feel consequential, summaries are comprehensible, approvals and side effects are obvious, progress is proportionate, recovery guidance is actionable, and a fresh task can explain what happens next. Exact inventories, policy matrices, idempotence, file preservation, cleanup safety, and exhaustive failure cases belong to automated validation.
+
+## Canonical setup and input
+
+Prerequisites: a current Codex CLI, authenticated `gh`, Python 3.10 or newer for the local runner, and clean disposable Codex marketplace/plugin state. Create a new private GitHub repository with Issues enabled and a single README commit, then open Codex at its root. Do not reuse a real project or put secrets in the fixture.
+
+Use this exact project specification when prompted:
+
+> Bootstrap a Python 3.12 command-line application supported on Linux and Windows. Its first product milestone will print a greeting for a supplied name. Use structured engineering rigor. It has no authentication, persistence, network access, deployment target, or compatibility commitment. Establish only the proportionate agent-ready harness and leave greeting behavior unimplemented.
+
+Accept the recommended structured policy and automatic risk escalation. Retain explicit human approval before PR merges. Routine reversible implementation choices may remain agent-led.
 
 <!-- zzzops-acceptance-plan
-{"version":1,"items":[{"id":"A-001","title":"Codex discovers the ZzzOps marketplace package","status":"checked","paths":[".agents/plugins/marketplace.json","plugins/zzzops/plugin.json"],"fingerprint":"16e5661d44a08b415d4ddf1e7ca48b0ac61d1cf855fe03135126be12210f1381","notes":""},{"id":"A-002","title":"Codex installs and discovers the complete Agent Plugin","status":"unchecked","paths":[".agents/plugins/marketplace.json","plugins/zzzops/plugin.json","plugins/zzzops/skills"],"fingerprint":null,"notes":""},{"id":"A-003","title":"Review and initialize project policy","status":"unchecked","paths":["plugins/zzzops/skills/review-zzzops-policy/SKILL.md","plugins/zzzops/rules/INITIALIZATION.md"],"fingerprint":null,"notes":""},{"id":"A-006","title":"Migrate TODOs with approval","status":"unchecked","paths":["plugins/zzzops/skills/migrate-to-zzzops/SKILL.md","plugins/zzzops/rules/BACKENDS.md"],"fingerprint":null,"notes":""},{"id":"A-008","title":"Capture a durable goal","status":"unchecked","paths":["plugins/zzzops/skills/add-zzzops-goal/SKILL.md","plugins/zzzops/rules/BACKENDS.md"],"fingerprint":null,"notes":""},{"id":"A-009","title":"Suggest work in dry-run mode","status":"unchecked","paths":["plugins/zzzops/skills/suggest-zzzops-work/SKILL.md","plugins/zzzops/rules/BACKENDS.md"],"fingerprint":null,"notes":""},{"id":"A-010","title":"Execute goals through review and resume","status":"unchecked","paths":["plugins/zzzops/skills/execute-zzzops/SKILL.md","plugins/zzzops/skills/execute-zzzops/references/EXECUTE.md","plugins/zzzops/skills/execute-zzzops/references/UNBLOCK.md","plugins/zzzops/skills/execute-zzzops/references/BRANCH_REVIEW.md","plugins/zzzops/rules/BACKENDS.md","plugins/zzzops/rules/GOAL_SYSTEM.md"],"fingerprint":null,"notes":""},{"id":"A-011","title":"Send feedback with exact confirmation and safe report cleanup","status":"unchecked","paths":["plugins/zzzops/skills/send-zzzops-feedback/SKILL.md","plugins/zzzops/rules/FEEDBACK.md"],"fingerprint":null,"notes":""},{"id":"A-012","title":"Codex reinstalls and updates the plugin cleanly","status":"unchecked","paths":[".agents/plugins/marketplace.json","plugins/zzzops/plugin.json","plugins/zzzops/zzzops/package.py"],"fingerprint":null,"notes":""},{"id":"A-013","title":"Bootstrap a repository into an agent-ready harness","status":"unchecked","paths":["plugins/zzzops/skills/bootstrap-zzzops-repository/SKILL.md","plugins/zzzops/zzzops/references/bootstrap"],"fingerprint":null,"notes":""},{"id":"A-014","title":"Review effective software-agent use on demand","status":"unchecked","paths":["plugins/zzzops/skills/review-agentic-engineering/SKILL.md","plugins/zzzops/skills/review-agentic-engineering/references/ATTRIBUTION.md"],"fingerprint":null,"notes":""},{"id":"A-015","title":"Validate a repository once after plugin installation or upgrade","status":"unchecked","paths":["plugins/zzzops/skills/validate-zzzops-installation/SKILL.md","plugins/zzzops/rules/INITIALIZATION.md","plugins/zzzops/zzzops/installation.py","plugins/zzzops/scripts/cleanup_legacy.py"],"fingerprint":null,"notes":""}]}
+{"version":2,"items":[{"id":"UX-001","title":"Install ZzzOps and begin onboarding","status":"unchecked","paths":[".agents/plugins/marketplace.json","plugins/zzzops/plugin.json","plugins/zzzops/skills/validate-zzzops-installation/SKILL.md","plugins/zzzops/zzzops/installation.py",".agents/skills/run-zzzops-acceptance/SKILL.md"],"surfaces":["plugins/zzzops/plugin.json",".agents/plugins/marketplace.json","plugins/zzzops/skills/validate-zzzops-installation"],"fingerprint":null,"notes":""},{"id":"UX-002","title":"Review policy and bootstrap the agent-ready factory","status":"unchecked","paths":["plugins/zzzops/skills/bootstrap-zzzops-repository/SKILL.md","plugins/zzzops/zzzops/references/bootstrap","plugins/zzzops/skills/review-zzzops-policy/SKILL.md","plugins/zzzops/rules/INITIALIZATION.md",".agents/skills/run-zzzops-acceptance/SKILL.md"],"surfaces":["plugins/zzzops/skills/bootstrap-zzzops-repository","plugins/zzzops/skills/review-zzzops-policy"],"fingerprint":null,"notes":""},{"id":"UX-003","title":"Capture a realistic follow-up goal","status":"unchecked","paths":["plugins/zzzops/skills/add-zzzops-goal/SKILL.md","plugins/zzzops/rules/BACKENDS.md",".agents/skills/run-zzzops-acceptance/SKILL.md"],"surfaces":["plugins/zzzops/skills/add-zzzops-goal"],"fingerprint":null,"notes":""},{"id":"UX-004","title":"Execute, review, interrupt, and resume","status":"unchecked","paths":["plugins/zzzops/skills/execute-zzzops/SKILL.md","plugins/zzzops/skills/execute-zzzops/references/EXECUTE.md","plugins/zzzops/skills/execute-zzzops/references/UNBLOCK.md","plugins/zzzops/skills/execute-zzzops/references/BRANCH_REVIEW.md","plugins/zzzops/rules/GOAL_SYSTEM.md","plugins/zzzops/rules/BACKENDS.md",".agents/skills/run-zzzops-acceptance/SKILL.md"],"surfaces":["plugins/zzzops/skills/execute-zzzops"],"fingerprint":null,"notes":""}],"automated_surfaces":[{"surface":"plugins/zzzops/skills/migrate-to-zzzops","evidence":[".agents/test_zzzops.py"]},{"surface":"plugins/zzzops/skills/suggest-zzzops-work","evidence":[".agents/test_zzzops.py"]},{"surface":"plugins/zzzops/skills/review-agentic-engineering","evidence":[".agents/test_zzzops.py"]},{"surface":"plugins/zzzops/skills/send-zzzops-feedback","evidence":[".agents/test_zzzops.py"]}]}
 zzzops-acceptance-plan -->
 
-## A-001 - Codex discovers the ZzzOps marketplace package
+## UX-001 — Install ZzzOps and begin onboarding
 
-Prerequisite: use a current Codex CLI and a clean Codex marketplace state.
+Prerequisite: complete the canonical setup through creation of the disposable repository.
 
-Human action: add this repository as a local marketplace with `codex plugin marketplace add . --json`, then run `codex plugin list`.
+Human action: add this checkout as a local Codex marketplace, install or refresh `zzzops@zzzops`, open a fresh Codex task in the disposable repository, and invoke `bootstrap-zzzops-repository` with the canonical specification above.
 
-Expected: Codex reports a marketplace named `zzzops` and offers `zzzops@zzzops`; the repository worktree and project state are unchanged.
+Expected: Codex discovers the release-candidate plugin; first-use installation validation runs once if required and resumes bootstrap; no legacy cleanup or repository change occurs without a specific preview and confirmation.
 
-## A-002 - Codex installs and discovers the complete Agent Plugin
+UX questions: Was the correct plugin/version obvious? Did the transition from installation validation into bootstrap feel continuous? Were side effects and any confirmation request understandable?
 
-Prerequisite: complete A-001 in the same disposable repository.
+## UX-002 — Review policy and bootstrap the agent-ready factory
 
-Human action: run `codex plugin add zzzops@zzzops --json`, inspect the installed cache, then open a fresh Codex task.
+Prerequisite: continue the same bootstrap invocation from UX-001.
 
-Expected: the installed package contains `plugin.json`, nine skills, `rules/`, and `zzzops/`; Codex discovers the nine skills in the new task. Installation does not modify the target repository or initialize project policy.
+Human action: answer only consequential policy or architecture questions using the canonical answers, approve the concise policy/harness proposal, and allow bootstrap to create and execute its ordinary harness goals. Approve exact reviewed PR checkpoints as requested until bootstrap reports the harness complete.
 
-## A-012 - Codex reinstalls and updates the plugin cleanly
+Expected: ZzzOps classifies the empty repository as greenfield, avoids irrelevant enterprise questions, creates a proportionate verified harness through ordinary goals, and leaves the greeting milestone unimplemented and dependent on that harness. The canonical verification command actually passes, CI uses the same contract, and a repeated bootstrap invocation is a no-op.
 
-Human action: remove and re-add `zzzops@zzzops`, inspect the refreshed package, and leave the local development marketplace installed.
+UX questions: Did every question earn the interruption? Could you understand the proposed architecture, goal DAG, progress, review boundaries, and final handoff without reading internal machinery? Did the number of approvals or amount of ceremony feel disproportionate?
 
-Expected: Codex controls the cache lifecycle without target-repository changes; re-add restores a complete package, and the local development marketplace remains available for subsequent ZzzOps tasks.
+## UX-003 — Capture a realistic follow-up goal
 
-## A-003 - Review and initialize project policy
+Prerequisite: the bootstrap harness and its review gates from UX-002 are complete.
 
-Prerequisite: A-002 completed in the disposable repository.
+Human action: invoke `add-zzzops-goal` with: `Add an optional --uppercase flag to the greeting command; when supplied, the complete greeting is uppercase.` Answer only consequential clarification and accept the proposed goal.
 
-Human action: open a fresh Codex task, invoke `review-zzzops-policy`, answer consequential setup questions, approve the proposed policy, then invoke it again.
+Expected: capture recognizes the relationship to the seeded greeting milestone, produces observable examples and scope without an exhaustive interview, creates one durable goal, and makes no Git change.
 
-Expected: the installed skill is discovered; it proposes overridable project defaults, including outcome-first communication, and waits for explicit approval before continuing. The second invocation re-summarizes the meaningful current policy and invites adjustments rather than reporting only that setup is complete.
+UX questions: Were the questions and examples useful? Was the relationship to existing work obvious? Did the final goal accurately express intent without feeling like a form-filling exercise?
 
-## Installed skill workflows
+## UX-004 — Execute, review, interrupt, and resume
 
-Run each in a disposable repository and record the result in the matching ledger item.
+Prerequisite: UX-003 is complete and no task is holding an unrecorded user decision.
 
-| ID | Human action | Expected observable result |
-| --- | --- | --- |
-| A-006 | Preview a TODO migration, approve it, and inspect the resulting queue. | Existing TODOs are summarized before approval, then become durable GitHub goals with nothing silently omitted. |
-| A-008 | Under a structured project default, capture one reversible low-risk goal and one authentication goal from similarly brief requests. | Capture uses standard depth for the first goal, escalates authentication to agentic/thorough, records auditable risk inputs rather than a derived value, asks only consequential extra questions, and creates no Git state. |
-| A-009 | In dry-run mode, audit an agentic fixture lacking CI and containing a prose-only invariant, incomplete canonical verification, and unverified security-sensitive behavior. | ZzzOps credits existing harness evidence, proposes distinct evidence-backed gap goals for all four mismatches, makes no source/backlog changes, and does not add tools merely to satisfy a template. |
-| A-010 | Execute comparable vibe, structured, and risk-escalated agentic fixtures through their verification and review boundaries; include an unanswered authority gate and later resume it. | Vibe may finish from policy-permitted observed behavior; structured runs targeted checks plus canonical verification; agentic requires relevant deterministic, regression, architecture, and risk evidence. Created-but-unrun checks never count, unanswered gates persist without live questions, and no PR merges before approval. |
-| A-011 | With one archived synthetic report, invoke `send-zzzops-feedback` with innocuous user feedback. Inspect the exact public payload, then separately cancel, enter a wrong digest, and force one provider failure before restoring authentication and confirming the current digest. | Every preview is human-readable and labels the public issue `zzzops-feedback`. Cancellation, digest mismatch, and provider failure retain the immutable report. The successful confirmed submission creates exactly the previewed issue and deletes only its confirmed report. |
-| A-013 | Invoke `bootstrap-zzzops-repository` once with the documented disposable greenfield specification and once against the brownfield fixture, then repeat both invocations. | Policy handoff resumes cleanly; evidence selects the mode; ordinary goals establish and verify the proportionate harness; eligible unstarted product goals depend on it; existing structure and policy-owned agent instructions survive brownfield reconciliation; seeded product behavior remains unimplemented; repeat runs are no-ops. |
-| A-014 | Explicitly invoke `review-agentic-engineering` over three substantial completed fixtures: one genuine specification gap, one repeated repository fact, and one implementation defect. Also try one insufficient and one ambiguous fixture. | The skill gives at most two concise observations, coaches only the genuine specification gap, routes repository context to `AGENTS.md` or enforcement, labels the defect as agent correction, gives no advice for insufficient/ambiguous evidence, retains no raw prompt content, and makes no repository or GitHub write. It never appears without explicit invocation. |
-| A-015 | In a disposable repository, invoke any ZzzOps workflow with no validation record, repeat it unchanged, project a changed package digest, and exercise both refusal and confirmation against a fingerprinted v1 fixture. | First use routes through validation and resumes once; unchanged use is a cheap no-op; a changed package reruns once; refusal preserves every file and records `declined`; confirmation removes only the exact preview while preserving durable state and Git index; unsafe or modified candidates fail closed. |
+Human action: invoke `execute-zzzops`. At the first human review boundary, leave the PR unapproved and end the task. Open a fresh task, invoke `execute-zzzops` again, inspect the explanation of the pending state, then approve and continue until the greeting and uppercase goals reach their next policy-permitted terminal state. Run the documented canonical verification command once at the final reviewed checkpoint.
+
+Expected: execution prioritizes dependencies, provides proportionate progress, persists the unanswered approval without guessing, resumes from durable state in the fresh task, never merges before approval, and presents observable verification and a clear final handoff.
+
+UX questions: Could the fresh task explain exactly where work stopped and why? Were verification evidence, approval consequences, failures, and next actions understandable? Did any repetition, latency, or ceremony make you want to bypass ZzzOps?
+
+## Optional risk-triggered spot checks
+
+These are not part of every human pass. Run the relevant short exploratory check when its workflow changed materially or before a release whose risk warrants it:
+
+- Brownfield bootstrap: confirm existing architecture and agent instructions are preserved.
+- TODO migration: judge preview clarity and confidence that nothing is silently omitted.
+- Feedback submission: judge the exact-payload confirmation and recovery from cancellation/provider failure.
+- Agent-use coaching: judge whether advice is concise, evidence-based, and aimed at the correct cause.
+
+Run `python .agents/manual_acceptance.py coverage` to ensure every shipped surface still has either a core human checkpoint or an automated contract with present evidence. Automated CI remains authoritative for the mechanical behavior named above.


### PR DESCRIPTION
## Outcome

- replace twelve heavyweight manual scenarios with one four-checkpoint installed-plugin journey
- focus human observation on discoverability, interview quality, approvals, progress, interruption, and resumption
- let coverage accept automated-only workflow contracts only when their cited test evidence exists

## Verification

- `python .agents/test_manual_acceptance.py`
- `python .agents/manual_acceptance.py coverage`
- `python .agents/manual_acceptance.py audit`
- `python .agents/manual_acceptance.py next`
- `python .agents/prompt_stats.py --check`
- `git diff --check`

Tracks #326
