### PR TITLE
feat(concepts): validate progressive concept references

### DIFF
--- a/.agents/prompt_stats.py
+++ b/.agents/prompt_stats.py
@@ -116,6 +116,7 @@ def prompt_files(root: Path) -> list[Path]:
         files.extend((skill.parent / "references").glob("*.md"))
     files.extend((root / "plugins" / "zzzops" / "zzzops" / "references" / "bootstrap").glob("*.md"))
     files.extend((root / "plugins" / "zzzops" / "zzzops" / "templates" / "project-goals").glob("*.md"))
+    files.extend((root / "plugins" / "zzzops" / "concepts").glob("*.md"))
     files.extend((root / ".agents" / "skills").glob("*/SKILL.md"))
     files.extend((root / ".agents" / "skills").glob("*/references/*.md"))
     return sorted({path for path in files if path.is_file()}, key=lambda path: path.relative_to(root).as_posix())

--- a/.agents/test_agent_plugin.py
+++ b/.agents/test_agent_plugin.py
@@ -99,6 +99,13 @@ class AgentPluginTests(unittest.TestCase):
         self.assertEqual(SHIPPED_SKILLS, actual)
         self.assertFalse((PLUGIN / "skills" / "run-zzzops-acceptance").exists())
 
+    def test_package_contains_valid_progressively_disclosed_concepts(self) -> None:
+        package = runpy.run_path(str(PLUGIN / "zzzops" / "package.py"))
+        status = package["package_status"]()
+        self.assertTrue(status["ok"], status["detail"])
+        self.assertTrue((PLUGIN / "concepts" / "bounded-commitment.md").is_file())
+        self.assertTrue((PLUGIN / "zzzops" / "concepts.py").is_file())
+
     def test_agentic_coaching_requires_explicit_invocation(self) -> None:
         metadata = (PLUGIN / "skills" / "review-agentic-engineering" / "agents" / "openai.yaml").read_text(encoding="utf-8")
         self.assertIn("allow_implicit_invocation: false", metadata)

--- a/.agents/test_concepts.py
+++ b/.agents/test_concepts.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = ROOT / "plugins" / "zzzops" / "zzzops" / "concepts.py"
+SPEC = importlib.util.spec_from_file_location("zzzops_concepts_test", MODULE)
+assert SPEC and SPEC.loader
+concepts = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = concepts
+SPEC.loader.exec_module(concepts)
+
+
+def definition(identifier: str, term: str, aliases: list[str] | None = None) -> str:
+    metadata = {
+        "aliases": aliases or [],
+        "authority": "informational-only",
+        "id": identifier,
+        "schema_version": 1,
+        "term": term,
+    }
+    sections = {
+        "Meaning": "Concise meaning.",
+        "Decision rule": "Apply one observable test.",
+        "Scope and authority": "This concept grants no authority and cannot weaken higher authority.",
+        "Examples": "A valid example.",
+        "Counterexamples": "An invalid example.",
+        "Parameters and invariants": "Projects configure detail; authority is invariant.",
+        "Aliases and related concepts": "No eager traversal.",
+        "Compatibility": "Review material changes.",
+    }
+    body = "\n\n".join(f"## {name}\n\n{content}" for name, content in sections.items())
+    return (
+        "<!-- zzzops-concept\n" + json.dumps(metadata, sort_keys=True, separators=(",", ":"))
+        + f"\nzzzops-concept -->\n\n# {term}\n\n{body}\n"
+    )
+
+
+class ConceptTests(unittest.TestCase):
+    def test_shipped_definition_and_first_use_resolve_once(self) -> None:
+        plugin = ROOT / "plugins" / "zzzops"
+        catalog = concepts.load_catalog((plugin / "concepts",), require_concepts=True)
+        self.assertEqual({"bounded-commitment"}, set(catalog.by_id))
+        links = concepts.validate_document(
+            plugin / "skills" / "execute-zzzops" / "SKILL.md", catalog, (plugin / "concepts",),
+        )
+        self.assertEqual(["bounded commitment"], [link.display for link in links])
+        resolved = concepts.resolve_document_concepts(
+            plugin / "skills" / "execute-zzzops" / "SKILL.md", (plugin / "concepts",),
+        )
+        self.assertEqual(["bounded-commitment"], [item.identifier for item in resolved])
+
+    def test_unlinked_or_late_first_use_fails_but_later_plain_use_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            concepts_root = root / "concepts"
+            skills = root / "skills" / "example"
+            concepts_root.mkdir()
+            skills.mkdir(parents=True)
+            (concepts_root / "bounded-commitment.md").write_text(
+                definition("bounded-commitment", "bounded commitment"), encoding="utf-8",
+            )
+            catalog = concepts.load_catalog((concepts_root,), require_concepts=True)
+            skill = skills / "SKILL.md"
+            skill.write_text("A bounded commitment is useful.\n", encoding="utf-8")
+            with self.assertRaisesRegex(concepts.ConceptError, "first occurrence"):
+                concepts.validate_document(skill, catalog, (concepts_root,))
+            skill.write_text(
+                "A [[bounded commitment]](../../concepts/bounded-commitment.md) is useful. "
+                "The BOUNDED COMMITMENT remains local.\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(1, len(concepts.validate_document(skill, catalog, (concepts_root,))))
+
+    def test_declared_alias_needs_its_own_first_use_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            concepts_root = root / "concepts"
+            concepts_root.mkdir()
+            path = concepts_root / "bounded-commitment.md"
+            path.write_text(definition("bounded-commitment", "bounded commitment", ["bounded change"]), encoding="utf-8")
+            catalog = concepts.load_catalog((concepts_root,))
+            document = root / "skill.md"
+            document.write_text("A bounded change is useful.\n", encoding="utf-8")
+            with self.assertRaisesRegex(concepts.ConceptError, "first occurrence"):
+                concepts.validate_document(document, catalog, (concepts_root,))
+            document.write_text("A [[bounded change]](concepts/bounded-commitment.md) is useful.\n", encoding="utf-8")
+            self.assertEqual(
+                "bounded-commitment",
+                concepts.validate_document(document, catalog, (concepts_root,))[0].definition.identifier,
+            )
+
+    def test_catalog_rejects_conflicts_and_malformed_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "one.md").write_text(definition("one", "shared term"), encoding="utf-8")
+            (root / "two.md").write_text(definition("two", "other term", ["shared term"]), encoding="utf-8")
+            with self.assertRaisesRegex(concepts.ConceptError, "conflicts"):
+                concepts.load_catalog((root,))
+            unsafe = definition("one", "shared term").replace('"informational-only"', '"policy-override"')
+            (root / "one.md").write_text(unsafe, encoding="utf-8")
+            (root / "two.md").unlink()
+            with self.assertRaisesRegex(concepts.ConceptError, "grant no authority"):
+                concepts.load_catalog((root,))
+
+    def test_project_and_packaged_targets_are_explicit_and_duplicate_ids_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packaged = root / "plugin" / "concepts"
+            project = root / ".zzzops" / "concepts"
+            packaged.mkdir(parents=True)
+            project.mkdir(parents=True)
+            (packaged / "packaged-term.md").write_text(
+                definition("packaged-term", "packaged term"), encoding="utf-8",
+            )
+            (project / "project-term.md").write_text(
+                definition("project-term", "project term"), encoding="utf-8",
+            )
+            catalog = concepts.load_catalog((packaged, project))
+            document = root / "guidance.md"
+            document.write_text(
+                "[[packaged term]](plugin/concepts/packaged-term.md) and "
+                "[[project term]](.zzzops/concepts/project-term.md)\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(2, len(concepts.validate_document(document, catalog, (packaged, project))))
+            (project / "packaged-term.md").write_text(
+                definition("packaged-term", "shadow term"), encoding="utf-8",
+            )
+            with self.assertRaisesRegex(concepts.ConceptError, "duplicate concept id"):
+                concepts.load_catalog((packaged, project))
+
+    def test_definition_requires_every_operational_section(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "incomplete.md"
+            path.write_text(
+                definition("incomplete", "incomplete concept").replace(
+                    "## Counterexamples\n\nAn invalid example.\n\n", "",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(concepts.ConceptError, "Counterexamples"):
+                concepts.parse_definition(path)
+
+    def test_missing_target_traversal_and_repeated_binding_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            concepts_root = root / "concepts"
+            concepts_root.mkdir()
+            (concepts_root / "bounded-commitment.md").write_text(
+                definition("bounded-commitment", "bounded commitment"), encoding="utf-8",
+            )
+            catalog = concepts.load_catalog((concepts_root,))
+            document = root / "skill.md"
+            document.write_text("[[bounded commitment]](missing.md)\n", encoding="utf-8")
+            with self.assertRaisesRegex(concepts.ConceptError, "escapes|missing"):
+                concepts.validate_document(document, catalog, (concepts_root,))
+            document.write_text("[[bounded commitment]](../escape.md)\n", encoding="utf-8")
+            with self.assertRaisesRegex(concepts.ConceptError, "escapes"):
+                concepts.validate_document(document, catalog, (concepts_root,))
+            document.write_text(
+                "[[bounded commitment]](concepts/bounded-commitment.md) and "
+                "[[bounded commitment]](concepts/bounded-commitment.md)\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(concepts.ConceptError, "repeated"):
+                concepts.validate_document(document, catalog, (concepts_root,))
+
+    def test_related_concepts_are_not_eagerly_resolved(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            concepts_root = root / "concepts"
+            concepts_root.mkdir()
+            first = definition("first", "first concept").replace(
+                "No eager traversal.", "See [[missing concept]](missing.md), but do not traverse it.",
+            )
+            (concepts_root / "first.md").write_text(first, encoding="utf-8")
+            document = root / "skill.md"
+            document.write_text("[[first concept]](concepts/first.md)\n", encoding="utf-8")
+            resolved = concepts.resolve_document_concepts(document, (concepts_root,))
+            self.assertEqual(["first"], [item.identifier for item in resolved])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -179,6 +179,10 @@ class MarketplaceBundleTests(unittest.TestCase):
 
     def test_claude_marketplace_is_derived_from_the_canonical_plugin(self) -> None:
         files = self.builder.claude_marketplace_files(ROOT, "2.0.0")
+        self.assertIn("zzzops/concepts/bounded-commitment.md", files)
+        self.assertIn("zzzops/zzzops/concepts.py", files)
+        skill = files["zzzops/skills/execute-zzzops/SKILL.md"].decode("utf-8")
+        self.assertIn("[[bounded commitment]](../../concepts/bounded-commitment.md)", skill)
         manifest = json.loads(files["zzzops/.claude-plugin/plugin.json"])
         marketplace = json.loads(files[".claude-plugin/marketplace.json"])
 

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -193,10 +193,11 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
             raise BundleError(
                 f"canonical development manifest must use {development_version}: {relative}"
             )
-    renderer = runpy.run_path(str(plugin / "zzzops" / "package.py"))["render_skill_metadata"]
+    package = runpy.run_path(str(plugin / "zzzops" / "package.py"))
+    renderer = package["render_skill_metadata"]
     result: dict[str, bytes] = {}
     allowed_top_level = {
-        ".claude-plugin", ".codex-plugin", "assets", "plugin.json", "rules", "scripts", "skills", "zzzops",
+        ".claude-plugin", ".codex-plugin", "assets", "concepts", "plugin.json", "rules", "scripts", "skills", "zzzops",
     }
     for path in sorted(plugin.rglob("*"), key=lambda item: item.relative_to(plugin).as_posix()):
         relative = path.relative_to(plugin).as_posix()
@@ -221,7 +222,8 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
         result[relative] = data
     required = {
         "plugin.json", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json", "assets/logo.png", "assets/logo-dark.png",
-        "assets/composer-icon.png", "assets/composer-icon-dark.png", "scripts/cleanup_legacy.py",
+        "assets/composer-icon.png", "assets/composer-icon-dark.png", "concepts/bounded-commitment.md",
+        "scripts/cleanup_legacy.py", "zzzops/concepts.py",
     }
     missing = sorted(required - set(result))
     if missing:
@@ -246,6 +248,11 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
     )
     if missing_metadata:
         raise BundleError("skill discovery metadata is incomplete: " + ", ".join(missing_metadata))
+    try:
+        concepts = package["_concepts"].load_catalog((plugin / "concepts",), require_concepts=True)
+        package["_concepts"].validate_skill_documents(plugin, concepts)
+    except ValueError as exc:
+        raise BundleError(f"canonical concept package is invalid: {exc}") from exc
     return result
 
 

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -1,0 +1,42 @@
+# ZzzOps concepts
+
+Concept references give stable operational terms precise definitions without loading a glossary into every agent workflow.
+
+## Authoring syntax
+
+Link the first exact occurrence of every canonical concept term or declared alias in each skill document:
+
+```md
+Keep each write a [[bounded commitment]](../../concepts/bounded-commitment.md).
+
+The bounded commitment must be verified before dependent work fans out.
+```
+
+The balanced brackets are ordinary Markdown link text, so standard renderers show a clickable `[bounded commitment]`. Later exact, case-insensitive occurrences in that document remain plain text. Each alias establishes its own first-use binding; fuzzy matching, stemming, inferred synonyms, and cross-document bindings are forbidden.
+
+Package validation scans every skill Markdown file. If a packaged concept's canonical term or alias appears before its matching concept link, validation fails—even when the occurrence is otherwise plain prose. This makes reusable vocabulary explicit instead of relying on an agent to infer which ordinary words have special meaning.
+
+## Definition locations
+
+- Packaged concepts: `plugins/zzzops/concepts/<stable-id>.md`
+- Project concepts: `.zzzops/concepts/<stable-id>.md`
+
+Targets are explicit relative paths; there is no implicit project override or shadowing. A resolved target must remain inside an allowed concept root. Missing files, absolute paths, unsafe traversal, anchors, query strings, duplicate IDs, conflicting terms or aliases, repeated bindings, and labels not declared by the target definition are invalid.
+
+## Definition schema
+
+Each definition is a Markdown file named for its lowercase hyphenated stable ID. It contains one `zzzops-concept` JSON metadata block with exactly:
+
+- `schema_version`: currently `1`;
+- `id`: the filename without `.md`;
+- `term`: the canonical display phrase;
+- `aliases`: explicit alternative phrases; and
+- `authority`: always `informational-only`.
+
+The required non-empty sections are Meaning, Decision rule, Scope and authority, Examples, Counterexamples, Parameters and invariants, Aliases and related concepts, and Compatibility. The scope section must state that the concept grants no authority and cannot weaken higher authority.
+
+## Progressive disclosure
+
+Agents resolve only definitions explicitly linked by the document and load each target once. Related-concept prose is not traversed automatically. Whole-catalog loading is reserved for deterministic authoring and package validation, where it is necessary to detect unlinked first uses and catalog conflicts.
+
+Material definition changes require review of affected policy, prompts, goals, acceptance behavior, and compatibility notes. Concepts explain meaning and decision tests; user and safety authority, repository instructions, reviewed policy, and goal state remain authoritative.

--- a/docs/CONTEXT_ENGINEERING.md
+++ b/docs/CONTEXT_ENGINEERING.md
@@ -1,5 +1,7 @@
 # Repository context-engineering audit
 
+Reusable decision vocabulary uses [progressively disclosed concept references](CONCEPTS.md), keeping definitions precise without adding an eager glossary to routed workflows.
+
 This historical audit applies Anthropic's July 2026 [context-engineering guidance](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) only to the context used by agents maintaining this repository. It does not prescribe Agent Plugin behavior.
 
 | Guideline | Disposition | Repository evidence or decision |

--- a/plugins/zzzops/concepts/bounded-commitment.md
+++ b/plugins/zzzops/concepts/bounded-commitment.md
@@ -1,0 +1,39 @@
+<!-- zzzops-concept
+{"aliases":["bounded change"],"authority":"informational-only","id":"bounded-commitment","schema_version":1,"term":"bounded commitment"}
+zzzops-concept -->
+
+# Bounded commitment
+
+## Meaning
+
+A change whose replacement, verification, and cleanup can be completed within one goal-sized change before dependent work fans out.
+
+## Decision rule
+
+Treat a choice as low commitment only when a credible replacement can be implemented, verified, and cleaned up within one goal-sized change before fan-out. Otherwise treat it as high commitment and preserve the alternatives, assumptions, evidence, and a falsifiable validation signal before committing descendants.
+
+## Scope and authority
+
+This concept classifies engineering change cost. It grants no authority and cannot weaken user, safety, repository, reviewed policy, goal, privacy, security, review, deployment, or external-write boundaries.
+
+## Examples
+
+- A private helper with focused tests and no persisted state or downstream consumers is usually bounded.
+- A branch-local module boundary with one known caller can be bounded when replacement and cleanup fit one verified goal.
+
+## Counterexamples
+
+- A durable-data migration, published interface, foundational project architecture, or change already inherited by stacked descendants is not bounded merely because Git can revert it.
+- A choice requiring long-lived compatibility code, external spending, deployment, or weakened safeguards is not bounded.
+
+## Parameters and invariants
+
+Projects may define what fits one goal-sized change and which structural fan-out signals apply. The recovery bound, complete cleanup requirement, and authority constraints are fixed invariants.
+
+## Aliases and related concepts
+
+`bounded change` is an explicit alias. Related ideas include goal-sized change, fan-out, compatibility burden, and falsifiable validation; they are not loaded or treated as synonyms unless separately defined and linked.
+
+## Compatibility
+
+Introduced with the concept-reference mechanism. Material changes to the recovery bound or authority constraints require compatibility review of affected policy, prompts, goals, acceptance evidence, and stacked work.

--- a/plugins/zzzops/skills/execute-zzzops/SKILL.md
+++ b/plugins/zzzops/skills/execute-zzzops/SKILL.md
@@ -26,7 +26,7 @@ Goals labeled `zzzops-feedback` are excluded by default. Include them only when 
 - Tests, delegation, parallelism, or long commands: `../../rules/EXECUTION_STRATEGY.md`.
 - Exhausted-queue backlog suggestions: `$suggest-zzzops-work` when explicitly enabled by reviewed PROJECT policy.
 
-This is the primary autonomous loop. Apply reviewed PROJECT selection, continuation, blocker, refill, Git, verification, and resource policy. User authority and project rules outrank goals. Persist resumable state before switching/stopping; continue while policy permits safe useful work. Optimize verified value, not item count or limit consumption.
+Apply reviewed PROJECT policy throughout. Assess [[bounded commitment]](../../concepts/bounded-commitment.md) before each write; persist resumable state before switching or stopping; continue while policy permits safe useful work. Optimize verified value, not item count.
 
 Before source work, read PROJECT Git/review/continuation policy and checkpoint only pending local ZzzOps state when required; never absorb unrelated changes or create an empty GitHub-state commit.
 

--- a/plugins/zzzops/zzzops/concepts.py
+++ b/plugins/zzzops/zzzops/concepts.py
@@ -1,0 +1,244 @@
+"""Validate and resolve progressively disclosed ZzzOps concept references."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path, PurePosixPath
+import re
+from typing import Iterable
+
+
+CONCEPT_BLOCK = re.compile(
+    r"<!-- zzzops-concept\s*\n(\{.*?\})\s*\nzzzops-concept -->",
+    re.DOTALL,
+)
+CONCEPT_LINK = re.compile(r"\[\[([^\]\r\n]+)\]\]\(([^)\r\n]+)\)")
+CONCEPT_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+METADATA_FIELDS = {"aliases", "authority", "id", "schema_version", "term"}
+REQUIRED_SECTIONS = (
+    "Meaning",
+    "Decision rule",
+    "Scope and authority",
+    "Examples",
+    "Counterexamples",
+    "Parameters and invariants",
+    "Aliases and related concepts",
+    "Compatibility",
+)
+INFORMATIONAL_AUTHORITY = "informational-only"
+
+
+class ConceptError(ValueError):
+    """A concept definition or document binding is unsafe or ambiguous."""
+
+
+@dataclass(frozen=True)
+class ConceptDefinition:
+    identifier: str
+    term: str
+    aliases: tuple[str, ...]
+    authority: str
+    path: Path
+    text: str
+
+    @property
+    def terms(self) -> tuple[str, ...]:
+        return (self.term, *self.aliases)
+
+
+@dataclass(frozen=True)
+class ConceptCatalog:
+    by_id: dict[str, ConceptDefinition]
+    by_term: dict[str, ConceptDefinition]
+
+
+@dataclass(frozen=True)
+class ConceptLink:
+    display: str
+    target: str
+    display_start: int
+    definition: ConceptDefinition
+
+
+def normalize_term(value: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip() or "\n" in value or "\r" in value:
+        raise ConceptError("concept terms must be non-empty single-line text without surrounding whitespace")
+    return value.casefold()
+
+
+def _section_content(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"(?m)^## ([^\r\n]+)\s*$", text))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        name = match.group(1).strip()
+        if name in sections:
+            raise ConceptError(f"duplicate concept section: {name}")
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections[name] = text[match.end():end].strip()
+    missing = [name for name in REQUIRED_SECTIONS if not sections.get(name)]
+    if missing:
+        raise ConceptError("missing or empty concept sections: " + ", ".join(missing))
+    return sections
+
+
+def parse_definition(path: Path) -> ConceptDefinition:
+    path = path.resolve()
+    try:
+        text = path.read_text(encoding="utf-8-sig").replace("\r\n", "\n").replace("\r", "\n")
+    except (OSError, UnicodeError) as exc:
+        raise ConceptError(f"could not read concept definition {path.name}: {type(exc).__name__}") from exc
+    matches = list(CONCEPT_BLOCK.finditer(text))
+    if len(matches) != 1:
+        raise ConceptError(f"{path.name} must contain exactly one zzzops-concept metadata block")
+    try:
+        metadata = json.loads(matches[0].group(1))
+    except json.JSONDecodeError as exc:
+        raise ConceptError(f"{path.name} concept metadata is invalid JSON") from exc
+    if not isinstance(metadata, dict) or set(metadata) != METADATA_FIELDS:
+        raise ConceptError(f"{path.name} concept metadata fields do not match the schema")
+    if metadata.get("schema_version") != 1:
+        raise ConceptError(f"{path.name} concept schema_version must be 1")
+    identifier = metadata.get("id")
+    if not isinstance(identifier, str) or not CONCEPT_ID.fullmatch(identifier) or path.name != f"{identifier}.md":
+        raise ConceptError(f"{path.name} must match its lowercase hyphenated concept id")
+    term = metadata.get("term")
+    normalized_term = normalize_term(term)
+    aliases = metadata.get("aliases")
+    if not isinstance(aliases, list) or any(not isinstance(alias, str) for alias in aliases):
+        raise ConceptError(f"{path.name} aliases must be a list of terms")
+    normalized_aliases = [normalize_term(alias) for alias in aliases]
+    if len(set(normalized_aliases)) != len(normalized_aliases) or normalized_term in normalized_aliases:
+        raise ConceptError(f"{path.name} aliases must be unique and differ from the canonical term")
+    authority = metadata.get("authority")
+    if authority != INFORMATIONAL_AUTHORITY:
+        raise ConceptError(f"{path.name} concepts must be informational-only and grant no authority")
+    title = re.search(r"(?m)^# ([^\r\n]+)\s*$", text)
+    if title is None or normalize_term(title.group(1).strip()) != normalized_term:
+        raise ConceptError(f"{path.name} H1 must equal its canonical term")
+    sections = _section_content(text)
+    authority_text = sections["Scope and authority"].casefold()
+    if "grants no authority" not in authority_text or "cannot weaken" not in authority_text:
+        raise ConceptError(f"{path.name} must state that it grants no authority and cannot weaken higher authority")
+    return ConceptDefinition(
+        identifier=identifier,
+        term=term,
+        aliases=tuple(aliases),
+        authority=authority,
+        path=path,
+        text=text,
+    )
+
+
+def load_catalog(roots: Iterable[Path], *, require_concepts: bool = False) -> ConceptCatalog:
+    definitions: list[ConceptDefinition] = []
+    for root in roots:
+        resolved = root.resolve()
+        if not resolved.exists():
+            continue
+        if not resolved.is_dir():
+            raise ConceptError(f"concept root is not a directory: {resolved}")
+        definitions.extend(parse_definition(path) for path in sorted(resolved.glob("*.md")))
+    if require_concepts and not definitions:
+        raise ConceptError("concept catalog contains no definitions")
+    by_id: dict[str, ConceptDefinition] = {}
+    by_term: dict[str, ConceptDefinition] = {}
+    for definition in definitions:
+        if definition.identifier in by_id:
+            raise ConceptError(f"duplicate concept id: {definition.identifier}")
+        by_id[definition.identifier] = definition
+        for term in definition.terms:
+            normalized = normalize_term(term)
+            existing = by_term.get(normalized)
+            if existing is not None:
+                raise ConceptError(
+                    f"concept term or alias {term!r} conflicts between {existing.identifier} and {definition.identifier}"
+                )
+            by_term[normalized] = definition
+    return ConceptCatalog(by_id=by_id, by_term=by_term)
+
+
+def _allowed_target(document: Path, target: str, roots: Iterable[Path]) -> Path:
+    if "\\" in target or "?" in target or "#" in target:
+        raise ConceptError(f"concept target must be a plain relative Markdown path: {target}")
+    relative = PurePosixPath(target)
+    if relative.is_absolute() or relative.suffix.casefold() != ".md":
+        raise ConceptError(f"concept target must be a relative Markdown path: {target}")
+    resolved = document.parent.joinpath(*relative.parts).resolve()
+    allowed = [root.resolve() for root in roots]
+    if not any(resolved.is_relative_to(root) for root in allowed):
+        raise ConceptError(f"concept target escapes an allowed concept root: {target}")
+    return resolved
+
+
+def concept_links(document: Path, catalog: ConceptCatalog, roots: Iterable[Path]) -> list[ConceptLink]:
+    document = document.resolve()
+    try:
+        text = document.read_text(encoding="utf-8-sig").replace("\r\n", "\n").replace("\r", "\n")
+    except (OSError, UnicodeError) as exc:
+        raise ConceptError(f"could not read concept-bearing document {document.name}: {type(exc).__name__}") from exc
+    definitions_by_path = {definition.path: definition for definition in catalog.by_id.values()}
+    links: list[ConceptLink] = []
+    seen: dict[str, Path] = {}
+    for match in CONCEPT_LINK.finditer(text):
+        display, target = match.groups()
+        normalized = normalize_term(display)
+        resolved = _allowed_target(document, target, roots)
+        definition = definitions_by_path.get(resolved)
+        if definition is None:
+            raise ConceptError(f"concept target is missing or not catalogued: {target}")
+        if catalog.by_term.get(normalized) != definition:
+            raise ConceptError(f"concept label {display!r} is not declared by {definition.identifier}")
+        prior = seen.get(normalized)
+        if prior is not None:
+            detail = "conflicting" if prior != resolved else "repeated"
+            raise ConceptError(f"{detail} concept binding for {display!r} in {document.name}")
+        seen[normalized] = resolved
+        links.append(ConceptLink(display, target, match.start(1), definition))
+    return links
+
+
+def _first_exact_occurrence(text: str, term: str) -> int | None:
+    pattern = re.compile(rf"(?<![\w-]){re.escape(term)}(?![\w-])", re.IGNORECASE)
+    match = pattern.search(text)
+    return None if match is None else match.start()
+
+
+def validate_document(document: Path, catalog: ConceptCatalog, roots: Iterable[Path]) -> list[ConceptLink]:
+    document = document.resolve()
+    text = document.read_text(encoding="utf-8-sig").replace("\r\n", "\n").replace("\r", "\n")
+    links = concept_links(document, catalog, roots)
+    linked_positions = {normalize_term(link.display): link.display_start for link in links}
+    for normalized, definition in catalog.by_term.items():
+        display = next(term for term in definition.terms if normalize_term(term) == normalized)
+        first = _first_exact_occurrence(text, display)
+        if first is None:
+            continue
+        if linked_positions.get(normalized) != first:
+            raise ConceptError(
+                f"first occurrence of concept term or alias {display!r} in {document.name} must be its concept link"
+            )
+    return links
+
+
+def validate_skill_documents(plugin_root: Path, catalog: ConceptCatalog) -> None:
+    roots = (plugin_root / "concepts",)
+    for document in sorted((plugin_root / "skills").glob("**/*.md")):
+        validate_document(document, catalog, roots)
+
+
+def resolve_document_concepts(document: Path, roots: Iterable[Path]) -> list[ConceptDefinition]:
+    """Load only definitions explicitly linked by one document; do not traverse related concepts."""
+    document = document.resolve()
+    resolved: list[ConceptDefinition] = []
+    seen: set[Path] = set()
+    text = document.read_text(encoding="utf-8-sig").replace("\r\n", "\n").replace("\r", "\n")
+    for match in CONCEPT_LINK.finditer(text):
+        target = _allowed_target(document, match.group(2), roots)
+        if target not in seen:
+            definition = parse_definition(target)
+            if normalize_term(match.group(1)) not in {normalize_term(term) for term in definition.terms}:
+                raise ConceptError(f"concept label {match.group(1)!r} is not declared by {definition.identifier}")
+            resolved.append(definition)
+            seen.add(target)
+    return resolved

--- a/plugins/zzzops/zzzops/package.py
+++ b/plugins/zzzops/zzzops/package.py
@@ -3,10 +3,19 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
 import re
+import sys
 from pathlib import Path
 from typing import Any
+
+_CONCEPTS_MODULE_PATH = Path(__file__).with_name("concepts.py")
+_CONCEPTS_MODULE_SPEC = importlib.util.spec_from_file_location("zzzops_concepts", _CONCEPTS_MODULE_PATH)
+assert _CONCEPTS_MODULE_SPEC and _CONCEPTS_MODULE_SPEC.loader
+_concepts = importlib.util.module_from_spec(_CONCEPTS_MODULE_SPEC)
+sys.modules[_CONCEPTS_MODULE_SPEC.name] = _concepts
+_CONCEPTS_MODULE_SPEC.loader.exec_module(_concepts)
 
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_PATH = PLUGIN_ROOT / "plugin.json"
@@ -24,10 +33,11 @@ SHIPPED_SKILLS = {
 REQUIRED_FILES = {
     ".codex-plugin/plugin.json",
     "assets/legacy_install_fingerprints.json",
+    "concepts/bounded-commitment.md",
     "rules/BACKENDS.md", "rules/BLOCKERS.md", "rules/CONTINUATION.md",
     "rules/EXECUTION_STRATEGY.md", "rules/FEEDBACK.md", "rules/GOAL_SYSTEM.md",
     "rules/INITIALIZATION.md", "zzzops/installation.py", "zzzops/entropy.py", "zzzops/zzzops.py",
-    "zzzops/coaching.py",
+    "zzzops/coaching.py", "zzzops/concepts.py",
     "skills/execute-zzzops/references/ENTROPY_OBSERVATIONS.md",
     "scripts/cleanup_legacy.py",
     "zzzops/references/bootstrap/ANALYZE.md",
@@ -185,8 +195,10 @@ def package_status() -> dict[str, Any]:
             agent_data = (PLUGIN_ROOT / agent_relative).read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
             if render_skill_metadata(agent_relative, agent_data, manifest["version"], channel) != agent_data:
                 raise PluginPackageError(f"skill discovery metadata does not match the plugin build: {agent_relative}")
+        concepts = _concepts.load_catalog((PLUGIN_ROOT / "concepts",), require_concepts=True)
+        _concepts.validate_skill_documents(PLUGIN_ROOT, concepts)
         provenance = package_provenance()
-    except (OSError, UnicodeError, json.JSONDecodeError, PluginPackageError) as exc:
+    except (OSError, UnicodeError, json.JSONDecodeError, PluginPackageError, _concepts.ConceptError) as exc:
         return {
             "available": True, "ok": False, "paths": [], "processes": 0,
             "detail": f"{exc}; reinstall ZzzOps from its Codex marketplace.",


### PR DESCRIPTION
## Outcome

Adds Markdown-native concept definitions and first-use links with strict package validation, on-demand resolution, explicit project/package targets, and deterministic Codex/Claude packaging.

Every canonical concept term or declared alias used in a skill document must be linked on its first exact occurrence; later plain mentions remain valid.

## Verification

- 216 Python tests passed (1 expected skip)
- 4 migration tests passed
- manual acceptance coverage passed
- Agent Plugin schema validation passed
- 11 semantic-release tests passed
- prompt budgets and 10/10 workflow evaluations passed
- Python compilation and diff checks passed

Tracks #333