### PR TITLE
feat(workflow): support verified stacked pull requests

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -2877,7 +2877,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertEqual(list(zzzops.POLICY_SECTION_IDS), project_ids)
         self.assertTrue(all(section["required"] and not section["review"]["approved"] for section in plan["policy"]["sections"]))
 
-    def test_required_pr_validation_includes_chained_targets(self):
+    def test_required_pr_validation_includes_stacked_targets(self):
         workflow = (Path(__file__).parents[1] / ".github" / "workflows" / "validate.yml").read_text(encoding="utf-8")
         trigger = workflow.split("permissions:", 1)[0]
         self.assertIn("pull_request:", trigger)
@@ -2894,6 +2894,13 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertEqual("allowed_before_completion", git_policy["read_only_dependency_investigation"])
         self.assertTrue(git_policy["parent_pseudo_trunk"])
         self.assertEqual("per_goal", git_policy["pull_request_unit"])
+        self.assertEqual("github_stacked_when_verified_else_chained", git_policy["pull_request_mode"])
+        self.assertEqual(
+            "official_gh_stack_extension_with_provider_membership_verification",
+            git_policy["stacked_capability"],
+        )
+        self.assertEqual("explicit_user_approval", git_policy["stacked_tool_installation"])
+        self.assertEqual("chained_prs", git_policy["stacked_unavailable_fallback"])
         self.assertEqual("explicit_reviewed_override", git_policy["shared_pull_request"])
         self.assertEqual("human_at_exhaustion", git_policy["review_gate"])
         self.assertEqual("never_for_goal_progress", git_policy["conversational_approval"])
@@ -2918,6 +2925,29 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertTrue(any(
             "exhaustion review requires" in error for error in zzzops.validate_policy(invalid, True)
         ))
+
+        invalid_mode = json.loads(json.dumps(plan["policy"]))
+        invalid_mode_git = next(
+            section for section in invalid_mode["sections"] if section["id"] == "git_review_release"
+        )
+        invalid_mode_git["settings"]["pull_request_mode"] = "pretend_native_stack"
+        self.assertTrue(any(
+            "pull_request_mode" in error for error in zzzops.validate_policy(invalid_mode, True)
+        ))
+
+    def test_branch_review_requires_native_stack_readback_and_named_fallback(self):
+        reference = (
+            PLUGIN_ROOT / "skills" / "execute-zzzops" / "references" / "BRANCH_REVIEW.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("gh stack link", reference)
+        self.assertIn("provider readback", reference)
+        self.assertIn("chained PR", reference)
+        self.assertIn("explicit approval", reference)
+        review_queue = (
+            PLUGIN_ROOT / "skills" / "execute-zzzops" / "references" / "REVIEW_QUEUE.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("gh stack rebase", review_queue)
+        self.assertIn("provider readback", review_queue)
 
     def test_parallel_and_refill_defaults_are_structured(self):
         root = PLUGIN_ROOT / "zzzops"

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -25,7 +25,7 @@ The package checkpoint validates the installed manifest, required surfaces, and 
 
 ## Development and review
 
-Develop on branches created from `dev` and open ordinary PRs against `dev`. PR validation runs for every target branch so chained PRs receive exact-head evidence before retargeting. The read-only **PR validation / dev-required-tests** job must pass before merge.
+Develop on branches created from `dev` and open PRs against `dev`. PR validation runs for every target branch so each stacked layer—or explicitly chained fallback PR—receives exact-head evidence before retargeting. The read-only **PR validation / dev-required-tests** job must pass before merge.
 
 Source-changing goals use one branch and PR per goal, Conventional Commits, human review after checks, and dependency merge order. `main` is reserved for intentional owner releases. See [execution and review](EXECUTION.md) and [branch protection](BRANCH_PROTECTION.md).
 

--- a/plugins/zzzops/skills/execute-zzzops/references/BRANCH_REVIEW.md
+++ b/plugins/zzzops/skills/execute-zzzops/references/BRANCH_REVIEW.md
@@ -10,7 +10,9 @@ Apply PROJECT Git/review policy; capture stays Git-free. Never absorb unrelated 
 
 Create/resume the recorded branch before edits. Stop on unattributable dirt; record authorized topology exceptions.
 
-Compare overlapping PRs to their immediate base; inherited commits are not overlap. Branches stay exclusive. Sibling/chained PRs may share a target; a child may target its reviewed parent/dependency. Before opening a PR and each review checkpoint, inspect immediate-base history and apply `EXECUTION_STRATEGY.md` final-state cleanup.
+Compare overlapping PRs to their immediate base; inherited commits are not overlap. Branches stay exclusive. Sibling PRs may share a target; a child may target its reviewed parent/dependency. Before opening a PR and each review checkpoint, inspect immediate-base history and apply `EXECUTION_STRATEGY.md` final-state cleanup.
+
+Apply PROJECT's PR mode. For native GitHub stacks, first check the documented `gh` minimum and official `gh stack` capability. Installing/upgrading host tooling needs explicit approval. Link ordered same-repository PRs bottom-to-top with noninteractive `gh stack link --base TRUNK ...`; then require provider readback proving one stack identity, trunk, size/positions, and every immediate PR base. Capability absence, denied installation, cross-repository topology, command failure, or unverifiable readback means the PRs are **chained PRs**, never claimed as stacked; follow PROJECT's fallback or block. Preserve branch/PR ownership, exact-head evidence, checks, review, merge, and release authority in either mode.
 
 For verified-checkpoint continuation, exhaustion handoff, or ancestor feedback, follow [the PR review queue](REVIEW_QUEUE.md). Recheck target, mergeability, immediate-base diff, overlap, conflict, and risk before review/integration.
 

--- a/plugins/zzzops/skills/execute-zzzops/references/REVIEW_QUEUE.md
+++ b/plugins/zzzops/skills/execute-zzzops/references/REVIEW_QUEUE.md
@@ -19,7 +19,7 @@ After an ancestor checkpoint changes:
 1. stop writes on affected descendants and read the ancestor feedback/exact head once;
 2. implement only authorized feedback, reverify the ancestor, and record its new checkpoint;
 3. invalidate every affected descendant checkpoint and approval;
-4. update bases and PR targets in dependency order, recompute each immediate-base diff, and resolve conflicts when authorized;
+4. update bases and PR targets in dependency order, using noninteractive `gh stack rebase`/`push` when locally tracked, otherwise guarded Git rebase/push; re-link and require provider readback for native stacks, and keep chained PRs explicit; recompute each immediate-base diff and resolve conflicts only when authorized;
 5. rerun each affected narrow probe and required check, then record replacement checkpoints; and
 6. block only the affected chain when reconciliation is unsafe, unauthorized, ambiguous, or fails, while continuing unrelated work.
 

--- a/plugins/zzzops/zzzops/policy.py
+++ b/plugins/zzzops/zzzops/policy.py
@@ -75,6 +75,10 @@ GIT_REVIEW_SETTING_VALUES = {
     "review_pending_dependency": {"wait_for_completed_dependencies", "stack_from_reviewed_checkpoint"},
     "review_gate": {"human_after_checks", "human_at_exhaustion"},
     "conversational_approval": {"allowed_otherwise", "never_for_goal_progress"},
+    "pull_request_mode": {"github_stacked_when_verified_else_chained", "chained_prs"},
+    "stacked_capability": {"official_gh_stack_extension_with_provider_membership_verification"},
+    "stacked_tool_installation": {"explicit_user_approval"},
+    "stacked_unavailable_fallback": {"chained_prs"},
 }
 DEPENDENCY_IMPLEMENTATION_GATES = {"dependencies_done", "stack_from_reviewed_checkpoint"}
 

--- a/plugins/zzzops/zzzops/templates/project-goals/INIT_PLAN.json
+++ b/plugins/zzzops/zzzops/templates/project-goals/INIT_PLAN.json
@@ -54,13 +54,16 @@
       },
       {
         "id": "git_review_release", "default_id": "zzzops.policy.git_review_release", "title": "Git, review, and release", "required": true, "applicable": true,
-        "decision": "Follow repository rules; otherwise keep one branch and PR per source-changing goal, continue descendants from each exact verified predecessor checkpoint, collect human PR approval at true queue exhaustion, and integrate in dependency order. Policy review remains required before execution; required checks, human merge approval, and release authority are never bypassed.", "rationale": "maximizes safe unattended progress while preserving independently reviewable PR gates and an explicit stricter per-goal alternative",
+        "decision": "Follow repository rules; otherwise keep one branch and PR per source-changing goal, prefer verified GitHub-native stacked PRs, and explicitly use chained PRs when native stacks are unavailable or unverified. Continue descendants from exact verified predecessor checkpoints, collect human PR approval at true queue exhaustion, and integrate in dependency order. Policy review, required checks, human merge approval, and release authority are never bypassed.", "rationale": "uses provider-native stack context when proven while preserving independently reviewable PR gates and a named compatible fallback",
         "source_ids": ["E-002"], "confidence": "medium", "default_origin": "ZzzOps exhaustion-time review fallback", "default_disposition": "accepted",
         "settings": {
           "execution_branch": "per_goal", "branch_base": "nearest_authorized_trunk", "dependency_base": "dependency_branch",
           "review_pending_dependency": "stack_from_reviewed_checkpoint", "read_only_dependency_investigation": "allowed_before_completion",
           "multiple_dependency_base": "reviewed_base_containing_all", "parent_pseudo_trunk": true, "child_target": "nearest_parent_branch",
           "pull_request_unit": "per_goal", "shared_pull_request": "explicit_reviewed_override",
+          "pull_request_mode": "github_stacked_when_verified_else_chained",
+          "stacked_capability": "official_gh_stack_extension_with_provider_membership_verification",
+          "stacked_tool_installation": "explicit_user_approval", "stacked_unavailable_fallback": "chained_prs",
           "commit_unit": "verified_subgoal", "commit_style": "conventional", "review_gate": "human_at_exhaustion",
           "review_state_reads_per_checkpoint": 1,
           "pr_approval": "required_when_repository_requires_pr", "conversational_approval": "never_for_goal_progress", "merge_after_approval": "when_authorized"


### PR DESCRIPTION
## Summary
- prefer GitHub-native stacked PRs only after official capability and provider readback
- keep explicitly named chained PRs as the safe fallback
- validate the new policy contract and preserve per-goal review, checks, and authority

## Verification
- py -3 .agents/test_zzzops.py
- py -3 .agents/test_agent_plugin.py
- py -3 .agents/test_marketplace_bundle.py
- py -3 .agents/policy_default_inventory.py
- py -3 .agents/prompt_stats.py --check

Tracks #345