### PR TITLE
build(release): publish only supported marketplace artifact

### DIFF
--- a/.agents/claude_plugin_acceptance.py
+++ b/.agents/claude_plugin_acceptance.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import tempfile
 from typing import Any
-from zipfile import ZipFile
 
 
 EXPECTED_SKILLS = {
@@ -82,15 +81,6 @@ def validate_install(records: Any, config: Path, version: str) -> Path:
     return install
 
 
-def extract_archive(archive_path: Path, destination: Path) -> None:
-    with ZipFile(archive_path) as archive:
-        for name in archive.namelist():
-            relative = Path(name)
-            if relative.is_absolute() or ".." in relative.parts:
-                raise AcceptanceError(f"release archive contains an unsafe path: {name}")
-        archive.extractall(destination)
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate generated ZzzOps through an isolated Claude installation")
     parser.add_argument("--claude-version", required=True)
@@ -104,29 +94,26 @@ def main(argv: list[str] | None = None) -> int:
     try:
         with tempfile.TemporaryDirectory(prefix="zzzops-claude-acceptance-") as directory:
             workspace = Path(directory)
-            plugin = workspace / "plugin"
-            artifacts = workspace / "artifacts"
+            marketplace = workspace / "marketplace"
             config = workspace / "config"
             project = workspace / "project"
-            release_notes = workspace / "RELEASE_NOTES.md"
             config.mkdir()
             project.mkdir()
-            release_notes.write_text("Claude release artifact acceptance.\n", encoding="utf-8")
             env = os.environ.copy()
             env["CLAUDE_CONFIG_DIR"] = str(config)
             observed_version = run(["claude", "--version"], env=env).strip()
             if not observed_version.startswith(args.claude_version + " "):
                 raise AcceptanceError(f"Claude CLI version drift: expected {args.claude_version}, observed {observed_version}")
             built = json_output([
-                sys.executable, str(root / ".github" / "scripts" / "build_marketplace_bundle.py"),
-                "--version", version, "--release-notes-file", str(release_notes),
-                "--output", str(artifacts),
+                sys.executable, str(root / ".github" / "scripts" / "build_claude_plugin.py"),
+                "--version", version, "--output", str(marketplace),
             ])
-            claude_plugin = Path(built.get("claude_plugin", "")) if isinstance(built, dict) else Path()
-            if not claude_plugin.is_file():
-                raise AcceptanceError("release builder did not produce the Claude plugin archive")
-            extract_archive(claude_plugin, plugin)
+            generated = Path(built.get("marketplace", "")) if isinstance(built, dict) else Path()
+            plugin = generated / "zzzops"
+            if generated.resolve() != marketplace.resolve() or not plugin.is_dir():
+                raise AcceptanceError("Claude generator did not produce the expected repository marketplace")
             run(["claude", "plugin", "validate", str(root), "--strict"], env=env)
+            run(["claude", "plugin", "validate", str(generated), "--strict"], env=env)
             run(["claude", "plugin", "validate", str(plugin), "--strict"], env=env)
             run(["claude", "plugin", "marketplace", "add", str(root), "--scope", "user"], env=env)
             available = json_output(["claude", "plugin", "list", "--available", "--json"], env=env)

--- a/.agents/test_claude_plugin_acceptance.py
+++ b/.agents/test_claude_plugin_acceptance.py
@@ -6,7 +6,6 @@ import importlib.util
 import tempfile
 import unittest
 from pathlib import Path
-from zipfile import ZipFile
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -57,15 +56,6 @@ class ClaudePluginAcceptanceTests(unittest.TestCase):
             record[0]["installPath"] = str(Path(directory) / "source")
             with self.assertRaisesRegex(self.harness.AcceptanceError, "isolated Claude cache"):
                 self.harness.validate_install(record, config, "2.0.0")
-
-    def test_release_archive_extraction_rejects_traversal(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            archive = Path(directory) / "unsafe.zip"
-            with ZipFile(archive, "w") as output:
-                output.writestr("../escape", "unsafe")
-            with self.assertRaisesRegex(self.harness.AcceptanceError, "unsafe path"):
-                self.harness.extract_archive(archive, Path(directory) / "output")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -54,28 +54,13 @@ class MarketplaceBundleTests(unittest.TestCase):
 
     def test_fixed_version_build_is_deterministic_and_complete(self) -> None:
         with tempfile.TemporaryDirectory() as first, tempfile.TemporaryDirectory() as second:
-            notes = "Initial skills-only submission.\n"
-            one = self.builder.build_bundles(ROOT, Path(first), "2.0.0", notes)
-            two = self.builder.build_bundles(ROOT, Path(second), "2.0.0", notes)
-            self.assertEqual({"plugin", "submission", "claude_plugin"}, set(one))
-            for key in ("plugin", "submission", "claude_plugin"):
-                self.assertEqual(
-                    hashlib.sha256(one[key].read_bytes()).hexdigest(),
-                    hashlib.sha256(two[key].read_bytes()).hexdigest(),
-                )
-
-            self.assertEqual("zzzops-claude-plugin-v2.0.0.zip", one["claude_plugin"].name)
-            with ZipFile(one["claude_plugin"]) as archive:
-                names = archive.namelist()
-                self.assertIn(".claude-plugin/plugin.json", names)
-                self.assertIn("zzzops/zzzops.py", names)
-                self.assertNotIn(".claude-plugin/marketplace.json", names)
-                packaged_manifest = json.loads(archive.read(".claude-plugin/plugin.json"))
-                committed_manifest = json.loads(
-                    (ROOT / "plugins" / "zzzops" / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
-                )
-                expected_manifest = {**committed_manifest, "version": "2.0.0"}
-                self.assertEqual(expected_manifest, packaged_manifest)
+            one = self.builder.build_bundle(ROOT, Path(first), "2.0.0")
+            two = self.builder.build_bundle(ROOT, Path(second), "2.0.0")
+            self.assertEqual({"plugin"}, set(one))
+            self.assertEqual(
+                hashlib.sha256(one["plugin"].read_bytes()).hexdigest(),
+                hashlib.sha256(two["plugin"].read_bytes()).hexdigest(),
+            )
             with ZipFile(one["plugin"]) as archive:
                 names = archive.namelist()
                 self.assertIn("plugin.json", names)
@@ -106,36 +91,17 @@ class MarketplaceBundleTests(unittest.TestCase):
                     self.builder.validate_portal_png(name, packaged)
                     self.assertEqual((ROOT / "plugins" / "zzzops" / name).read_bytes(), packaged)
 
-            with ZipFile(one["submission"]) as archive:
-                names = set(archive.namelist())
-                self.assertEqual({
-                    "ATTESTATIONS.md", "LISTING.md", "RELEASE_NOTES.md", "TEST_CASES.md",
-                    "assets/composer-icon-dark.png", "assets/composer-icon.png",
-                    "assets/logo-dark.png", "assets/logo.png", "manifest.json", "submission.json",
-                }, names)
-                submission = json.loads(archive.read("submission.json"))
-                manifest = json.loads(archive.read("manifest.json"))
-                self.assertEqual("skills_only", submission["submission_type"])
-                self.assertEqual("2.0.0", submission["version"])
-                self.assertLessEqual(len(submission["listing"]["short_description"]), 30)
-                self.assertEqual("https://github.com/david-rzepa/zzzops", submission["listing"]["website_url"])
-                self.assertGreaterEqual(len(submission["tests"]["positive"]), 5)
-                self.assertGreaterEqual(len(submission["tests"]["negative"]), 3)
-                self.assertEqual(
-                    hashlib.sha256(one["plugin"].read_bytes()).hexdigest(),
-                    submission["plugin_archive"]["sha256"],
-                )
-                self.assertEqual("2.0.0", manifest["version"])
-                self.assertEqual(
-                    hashlib.sha256(archive.read("submission.json")).hexdigest(),
-                    manifest["files"]["submission.json"],
-                )
+            listing, tests, attestations = self.builder.validate_sources(ROOT)
+            self.assertEqual("skills_only", listing["submission_type"])
+            self.assertGreaterEqual(len(tests["positive"]), 5)
+            self.assertGreaterEqual(len(tests["negative"]), 3)
+            self.assertIn("human review gates", attestations)
 
     def test_invalid_version_or_incomplete_sources_fail_before_output(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory)
             with self.assertRaisesRegex(self.builder.BundleError, "version"):
-                self.builder.build_bundles(ROOT, output, "latest", "notes")
+                self.builder.build_bundle(ROOT, output, "latest")
             self.assertEqual([], list(output.iterdir()))
         with self.assertRaisesRegex(self.builder.BundleError, "secret-like"):
             self.builder.scan_for_secrets("config.txt", b"OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz")
@@ -159,10 +125,10 @@ class MarketplaceBundleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory) / "marketplace"
             output.mkdir()
-            stale = output / "zzzops-claude-plugin-v1.9.0.zip"
+            stale = output / "unexpected.zip"
             stale.write_bytes(b"stale")
             with self.assertRaisesRegex(self.builder.BundleError, "output directory must be empty"):
-                self.builder.build_bundles(ROOT, output, "2.0.0", "notes")
+                self.builder.build_bundle(ROOT, output, "2.0.0")
             self.assertEqual({stale.name}, {path.name for path in output.iterdir()})
 
     def test_release_validation_rejects_missing_divergent_and_invalid_archives(self) -> None:
@@ -173,9 +139,9 @@ class MarketplaceBundleTests(unittest.TestCase):
                 )
         divergent = self.builder.zip_bytes({"file": b"observed"})
         with self.assertRaisesRegex(self.builder.BundleError, "content mismatch"):
-            self.builder.validate_archive(divergent, {"file": b"expected"}, "Claude plugin")
+            self.builder.validate_archive(divergent, {"file": b"expected"}, "plugin")
         with self.assertRaisesRegex(self.builder.BundleError, "not a valid ZIP"):
-            self.builder.validate_archive(b"invalid", {}, "Claude plugin")
+            self.builder.validate_archive(b"invalid", {}, "plugin")
 
     def test_claude_marketplace_is_derived_from_the_canonical_plugin(self) -> None:
         files = self.builder.claude_marketplace_files(ROOT, "2.0.0")

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Build deterministic, validated OpenAI and Claude release artifacts."""
+"""Build the deterministic, validated OpenAI portal skills bundle."""
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import io
 import json
 import os
@@ -36,10 +35,6 @@ class BundleError(ValueError):
 
 def canonical_json(value: Any) -> bytes:
     return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
-
-
-def sha256(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
 
 
 def read_json(path: Path) -> Any:
@@ -318,32 +313,6 @@ def zip_bytes(files: dict[str, bytes]) -> bytes:
     return temporary.read()
 
 
-def listing_markdown(listing: dict[str, Any]) -> str:
-    info = listing["listing"]
-    prompts = "\n".join(f"- {prompt}" for prompt in listing["starter_prompts"])
-    return (
-        f"# {info['name']} listing\n\n"
-        f"- Submission type: Skills only\n- Short description: {info['short_description']}\n"
-        f"- Category: {info['category']}\n- Developer: {info['developer_name']}\n"
-        f"- Website: {info['website_url']}\n- Support: {info['support_url']}\n"
-        f"- Privacy: {info['privacy_policy_url']}\n- Terms: {info['terms_url']}\n\n"
-        f"## Long description\n\n{info['long_description']}\n\n## Starter prompts\n\n{prompts}\n\n"
-        f"## Availability\n\n{listing['availability']['choice']}: {listing['availability']['rationale']}\n"
-    )
-
-
-def tests_markdown(tests: dict[str, Any]) -> str:
-    sections = ["# Submission test cases\n"]
-    for label, key in (("Positive", "positive"), ("Negative", "negative")):
-        sections.append(f"## {label}\n")
-        for case in tests[key]:
-            sections.append(f"### {case['id']}\n")
-            for field, value in case.items():
-                if field != "id":
-                    sections.append(f"- {field.replace('_', ' ').title()}: {value}\n")
-    return "\n".join(sections)
-
-
 def validate_archive(data: bytes, expected: dict[str, bytes], label: str) -> None:
     try:
         temporary = io.BytesIO(data)
@@ -367,101 +336,42 @@ def validate_release_artifacts(directory: Path, expected: dict[str, tuple[dict[s
         validate_archive((directory / filename).read_bytes(), contents, label)
 
 
-def build_bundles(root: Path, output: Path, version: str, release_notes: str) -> dict[str, Path]:
+def build_bundle(root: Path, output: Path, version: str) -> dict[str, Path]:
     root = root.resolve()
     output = output.resolve()
     if not SEMVER.fullmatch(version):
         raise BundleError("version must be a concrete semantic release version")
     if output.exists() and any(output.iterdir()):
         raise BundleError("output directory must be empty before release preparation")
-    release_notes = require_text(release_notes, "release notes").replace("\r\n", "\n").rstrip() + "\n"
-    listing, tests, attestations = validate_sources(root)
+    validate_sources(root)
     plugin_contents = plugin_files(root, version)
     plugin_data = zip_bytes(plugin_contents)
     plugin_name = f"zzzops-plugin-v{version}.zip"
-    submission = {
-        "schema_version": 1,
-        "submission_type": "skills_only",
-        "version": version,
-        "listing": listing["listing"],
-        "assets": listing["assets"],
-        "starter_prompts": listing["starter_prompts"],
-        "availability": listing["availability"],
-        "tests": {"positive": tests["positive"], "negative": tests["negative"]},
-        "release_notes": release_notes.strip(),
-        "official_submission_docs": listing["official_submission_docs"],
-        "plugin_archive": {"filename": plugin_name, "sha256": sha256(plugin_data)},
-        "human_actions": ["upload", "review attestations", "submit for review", "publish after approval"],
-    }
-    packet_contents = {
-        "ATTESTATIONS.md": attestations.encode("utf-8"),
-        "LISTING.md": listing_markdown(listing).encode("utf-8"),
-        "RELEASE_NOTES.md": (f"# ZzzOps v{version}\n\n" + release_notes).encode("utf-8"),
-        "TEST_CASES.md": tests_markdown(tests).encode("utf-8"),
-        "submission.json": canonical_json(submission),
-    }
-    for packet_name, source_key in (
-        ("assets/logo.png", "logo_light"), ("assets/logo-dark.png", "logo_dark"),
-        ("assets/composer-icon.png", "composer_icon_light"),
-        ("assets/composer-icon-dark.png", "composer_icon_dark"),
-    ):
-        packet_contents[packet_name] = root.joinpath(*PurePosixPath(listing["assets"][source_key]).parts).read_bytes()
-    for relative, data in packet_contents.items():
-        scan_for_secrets(relative, data)
-    manifest = {
-        "schema_version": 1,
-        "version": version,
-        "plugin_archive": {"filename": plugin_name, "sha256": sha256(plugin_data)},
-        "files": {relative: sha256(data) for relative, data in sorted(packet_contents.items())},
-    }
-    packet_contents["manifest.json"] = canonical_json(manifest)
-    submission_data = zip_bytes(packet_contents)
-    claude_marketplace_contents = claude_marketplace_files(root, version)
-    claude_plugin_contents = {
-        relative.removeprefix("zzzops/"): data
-        for relative, data in claude_marketplace_contents.items()
-        if relative.startswith("zzzops/")
-    }
-    claude_plugin_data = zip_bytes(claude_plugin_contents)
     validate_archive(plugin_data, plugin_contents, "plugin")
-    validate_archive(submission_data, packet_contents, "submission")
-    validate_archive(claude_plugin_data, claude_plugin_contents, "Claude plugin")
     output.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix="zzzops-marketplace-", dir=output.parent))
     try:
         plugin_path = staging / plugin_name
-        submission_path = staging / f"zzzops-openai-submission-v{version}.zip"
-        claude_plugin_path = staging / f"zzzops-claude-plugin-v{version}.zip"
         plugin_path.write_bytes(plugin_data)
-        submission_path.write_bytes(submission_data)
-        claude_plugin_path.write_bytes(claude_plugin_data)
         validate_release_artifacts(staging, {
             plugin_path.name: (plugin_contents, "written plugin"),
-            submission_path.name: (packet_contents, "written submission"),
-            claude_plugin_path.name: (claude_plugin_contents, "written Claude plugin"),
         })
         if output.exists():
             output.rmdir()
         staging.replace(output)
     finally:
         shutil.rmtree(staging, ignore_errors=True)
-    return {
-        "plugin": output / plugin_path.name,
-        "submission": output / submission_path.name,
-        "claude_plugin": output / claude_plugin_path.name,
-    }
+    return {"plugin": output / plugin_path.name}
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Build validated OpenAI and Claude marketplace release artifacts")
+    parser = argparse.ArgumentParser(description="Build the validated OpenAI portal skills bundle")
     parser.add_argument("--version", required=True)
-    parser.add_argument("--release-notes-file", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
     root = Path(__file__).resolve().parents[2]
     try:
-        notes = args.release_notes_file.read_text(encoding="utf-8-sig")
-        result = build_bundles(root, args.output, args.version, notes)
+        result = build_bundle(root, args.output, args.version)
     except (BundleError, OSError, UnicodeError) as exc:
         print(f"Marketplace bundle validation failed: {exc}", file=sys.stderr)
         return 2

--- a/.github/scripts/semantic_release_bundle.cjs
+++ b/.github/scripts/semantic_release_bundle.cjs
@@ -1,6 +1,3 @@
-const { mkdtempSync, rmSync, writeFileSync } = require("node:fs");
-const { tmpdir } = require("node:os");
-const { join } = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 function pythonCandidates() {
@@ -9,36 +6,27 @@ function pythonCandidates() {
 
 async function prepare(_pluginConfig, context) {
   const version = context.nextRelease && context.nextRelease.version;
-  const notes = context.nextRelease && context.nextRelease.notes;
-  if (!version || !notes) {
-    throw new Error("Marketplace bundling requires semantic-release version and release notes.");
+  if (!version) {
+    throw new Error("Marketplace bundling requires a semantic-release version.");
   }
-  const temporary = mkdtempSync(join(tmpdir(), "zzzops-release-notes-"));
-  const notesPath = join(temporary, "RELEASE_NOTES.md");
-  writeFileSync(notesPath, notes, "utf8");
-  try {
-    let last;
-    for (const python of pythonCandidates()) {
-      const result = spawnSync(python, [
-        ".github/scripts/build_marketplace_bundle.py",
-        "--version", version,
-        "--release-notes-file", notesPath,
-        "--output", "dist/marketplace"
-      ], { cwd: context.cwd, encoding: "utf8" });
-      last = result;
-      if (!result.error && result.status === 0) {
-        context.logger.log(`Built validated OpenAI and Claude release bundles for v${version}.`);
-        return;
-      }
-      if (!result.error || result.error.code !== "ENOENT") {
-        break;
-      }
+  let last;
+  for (const python of pythonCandidates()) {
+    const result = spawnSync(python, [
+      ".github/scripts/build_marketplace_bundle.py",
+      "--version", version,
+      "--output", "dist/marketplace"
+    ], { cwd: context.cwd, encoding: "utf8" });
+    last = result;
+    if (!result.error && result.status === 0) {
+      context.logger.log(`Built validated OpenAI portal skills bundle for v${version}.`);
+      return;
     }
-    const detail = (last && (last.stderr || last.stdout || (last.error && last.error.message))) || "Python was unavailable";
-    throw new Error(`Marketplace bundle preparation failed: ${String(detail).trim()}`);
-  } finally {
-    rmSync(temporary, { recursive: true, force: true });
+    if (!result.error || result.error.code !== "ENOENT") {
+      break;
+    }
   }
+  const detail = (last && (last.stderr || last.stdout || (last.error && last.error.message))) || "Python was unavailable";
+  throw new Error(`Marketplace bundle preparation failed: ${String(detail).trim()}`);
 }
 
 module.exports = { prepare };

--- a/.github/scripts/test_semantic_release.mjs
+++ b/.github/scripts/test_semantic_release.mjs
@@ -26,14 +26,12 @@ assert.equal(analyzerName, "@semantic-release/commit-analyzer");
 assert.equal(notesName, "./.github/scripts/semantic_release_notes.cjs");
 assert.equal(notesPlugin.generatorPackage, "@semantic-release/release-notes-generator");
 
-test("marketplace bundles gate publication and become GitHub release assets", () => {
+test("the required OpenAI bundle gates publication and becomes a release asset", () => {
   assert.equal(releaseConfig.plugins[2], "./.github/scripts/semantic_release_bundle.cjs");
   const [githubPlugin, githubOptions] = releaseConfig.plugins[3];
   assert.equal(githubPlugin, "@semantic-release/github");
   assert.deepEqual(githubOptions.assets.map(({ path }) => path), [
-    "dist/marketplace/zzzops-plugin-v*.zip",
-    "dist/marketplace/zzzops-openai-submission-v*.zip",
-    "dist/marketplace/zzzops-claude-plugin-v*.zip"
+    "dist/marketplace/zzzops-plugin-v*.zip"
   ]);
 });
 

--- a/docs/CLAUDE_MARKETPLACE.md
+++ b/docs/CLAUDE_MARKETPLACE.md
@@ -9,7 +9,7 @@ ZzzOps keeps one plugin implementation in `plugins/zzzops`. Claude-specific repo
 - `.claude-plugin/marketplace.json`, which points to `./plugins/zzzops`;
 - `plugins/zzzops/.claude-plugin/plugin.json`, which describes that canonical plugin directory.
 
-Skills, rules, scripts, and the ZzzOps runtime are not copied into a second Claude tree. The release process additionally creates one directly installable `zzzops-claude-plugin-v<version>.zip`; there is no Claude submission archive because Anthropic reviews repository state.
+Skills, rules, scripts, and the ZzzOps runtime are not copied into a second Claude tree or release archive. Anthropic review and normal marketplace installation consume repository state. CI still generates a disposable marketplace to prove strict Claude validation, then performs isolated installation and installed-cache runtime acceptance from the repository marketplace.
 
 ## Direct Claude Code installation
 

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -46,13 +46,11 @@ Open a new Codex task so skill discovery reloads the plugin. The installed manif
 
 Each push to `dev` runs `semantic-release --dry-run` with read-only repository permission. Dry runs skip tag creation and publication. An intended owner update to `main` runs the full product-validation matrix before semantic-release receives `contents: write`.
 
-Every release prepares three validated versioned assets before GitHub publication:
+Every release prepares one validated versioned marketplace asset before GitHub publication:
 
-- `zzzops-plugin-v<version>.zip` — OpenAI portal skills bundle;
-- `zzzops-openai-submission-v<version>.zip` — OpenAI listing copy, assets, tests, availability, notes, manifests, and attestation checklist;
-- `zzzops-claude-plugin-v<version>.zip` — self-contained Claude Code plugin bundle.
+- `zzzops-plugin-v<version>.zip` — OpenAI portal skills bundle.
 
-Canonical repository metadata stays at `0.0.0-dev`. Release preparation renders the semantic release version and official channel into temporary OpenAI and Claude artifacts; CI never commits generated release metadata back to `dev`.
+Canonical repository metadata stays at `0.0.0-dev`. Release preparation renders the semantic release version and official channel into the temporary OpenAI bundle; CI never commits generated release metadata back to `dev`. Claude marketplace validation and installed-cache acceptance run directly from repository state and do not publish a duplicate archive.
 
 A build or validation failure stops publication. Successful artifacts attach to the matching GitHub Release. OpenAI portal upload, attestation, review submission, approval, and final directory publication remain explicit human actions; see the [marketplace sources](../marketplace/README.md). Claude submission guidance lives in [Claude Code marketplace notes](CLAUDE_MARKETPLACE.md), and the shared language and intent map live in [product discovery positioning](DISCOVERY.md).
 

--- a/marketplace/ATTESTATIONS.md
+++ b/marketplace/ATTESTATIONS.md
@@ -1,9 +1,9 @@
 # OpenAI plugin submission attestations
 
-These are human review gates, not declarations made by CI. The publisher checks them in the OpenAI submission portal only after comparing the generated packet with the final draft.
+These are human review gates, not declarations made by CI. The publisher checks them in the OpenAI submission portal only after comparing the canonical repository sources with the final draft.
 
 - [ ] The listing, publisher identity, website, support, privacy, and terms information are accurate and publicly accessible.
-- [ ] The uploaded skills archive is the exact archive identified by `submission.json` and `manifest.json`.
+- [ ] The uploaded skills archive is the exact versioned `zzzops-plugin` asset from the reviewed release.
 - [ ] The final skills were tested locally using the submitted file tree.
 - [ ] Starter prompts and all positive and negative test cases accurately describe current behavior and are reproducible without private context.
 - [ ] Country and region availability was reviewed against the portal's current choices and the publisher's support readiness.

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -1,13 +1,20 @@
 # Marketplace submission sources
 
-This directory is the reviewed, version-controlled source for the OpenAI skills-only submission packet. `listing.json`, `test-cases.json`, and `ATTESTATIONS.md` map to the official submission form. CI generates presentation Markdown and exact-version manifests from these sources; generated release artifacts are not committed.
+This directory is the reviewed, version-controlled source for the OpenAI skills-only submission form. `listing.json`, `test-cases.json`, and `ATTESTATIONS.md` retain listing copy, tests, availability, and human review gates; generated release artifacts are not committed.
 
 Build a fixed-version local probe with:
 
 ```text
-python .github/scripts/build_marketplace_bundle.py --version 2.0.0 --release-notes-file <notes.md> --output <directory>
+python .github/scripts/build_marketplace_bundle.py --version 2.0.0 --output <directory>
 ```
 
-The command emits a portal-upload plugin archive and a separate submission packet. It validates both before making them available. The semantic-release prepare step runs the same builder for the calculated release version; the GitHub plugin attaches both ZIP files to the release.
+The command emits and validates the portal-upload plugin archive. The semantic-release prepare step runs the same builder for the calculated release version and attaches that ZIP to the release. Form materials stay readable and reviewable here instead of being duplicated into a packet the portal does not consume.
 
-CI never uploads to the OpenAI portal, completes attestations, submits for review, approves, or publishes. Use the generated packet to fill a portal draft, compare every field and test, check attestations personally, submit for review, and publish only after OpenAI approval.
+CI never uploads to the OpenAI portal, completes attestations, submits for review, approves, or publishes. Use these canonical sources to fill a portal draft, compare every field and test, check attestations personally, submit for review, and publish only after OpenAI approval.
+
+| Classification | Material | Supported consumer |
+| --- | --- | --- |
+| Release asset | Versioned OpenAI skills bundle | OpenAI portal upload |
+| Repository-only evidence | Listing, test cases, assets, attestations, and semantic release notes | Human portal completion and review |
+| Repository-only validation | Claude manifests, generated marketplace probe, strict validation, and installed-cache acceptance | Git marketplace installation and Anthropic review |
+| Removed | OpenAI submission-packet and Claude plugin release archives | None; current vendor workflows do not consume them |

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -42,9 +42,7 @@ module.exports = {
       "@semantic-release/github",
       {
         assets: [
-          { path: "dist/marketplace/zzzops-plugin-v*.zip", label: "OpenAI portal skills bundle" },
-          { path: "dist/marketplace/zzzops-openai-submission-v*.zip", label: "OpenAI submission packet" },
-          { path: "dist/marketplace/zzzops-claude-plugin-v*.zip", label: "Claude Code plugin bundle" }
+          { path: "dist/marketplace/zzzops-plugin-v*.zip", label: "OpenAI portal skills bundle" }
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- publish only the versioned OpenAI portal skills bundle as a release asset
- retain listing, tests, assets, attestations, and release notes as canonical repository evidence
- validate Claude through a generated repository marketplace and installed-cache acceptance instead of an unsupported release ZIP
- remove dead packet/archive construction and its tests

## Verification
- py -3 .agents/test_marketplace_bundle.py
- py -3 .agents/test_claude_plugin_acceptance.py
- py -3 .agents/test_release_validation.py
- py -3 .agents/test_agent_plugin.py
- npm run test:release
- py -3 .agents/prompt_stats.py --check
- git diff --check

Tracks #343