### PR TITLE
fix(claude): derive plugin updates from Git revisions

### DIFF
--- a/.agents/claude_plugin_acceptance.py
+++ b/.agents/claude_plugin_acceptance.py
@@ -8,6 +8,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -23,6 +24,9 @@ EXPECTED_SKILLS = {
 
 class AcceptanceError(ValueError):
     """The generated plugin failed an observable Claude acceptance boundary."""
+
+
+NO_VERSION_WARNING = "version: No version specified. Consider adding a version following semver"
 
 
 def run(command: list[str], *, env: dict[str, str] | None = None) -> str:
@@ -41,16 +45,67 @@ def json_output(command: list[str], *, env: dict[str, str] | None = None) -> Any
         raise AcceptanceError(f"command returned invalid JSON: {command[0]} {command[1]}") from exc
 
 
-def validate_available(records: Any, version: str, source: str = "./zzzops") -> None:
+def validate_versionless(path: Path, *, env: dict[str, str]) -> None:
+    """Keep strict validation except for Claude's warning about its documented SHA mode."""
+    command = ["claude", "plugin", "validate", str(path), "--strict"]
+    result = subprocess.run(command, env=env, text=True, capture_output=True, check=False)
+    if result.returncode == 0:
+        return
+    detail = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    if (
+        detail.count(NO_VERSION_WARNING) != 1
+        or "Found 1 warning" not in detail
+        or "Validation failed (--strict treats warnings as errors)" not in detail
+    ):
+        raise AcceptanceError("strict Claude validation failed beyond the documented SHA-version warning")
+    run(["claude", "plugin", "validate", str(path)], env=env)
+
+
+def commit_marketplace(marketplace: Path, marker: str, *, initialize: bool = False) -> str:
+    """Commit one observable marketplace revision and return its Git identity."""
+    if initialize:
+        run(["git", "init", "--initial-branch", "main", str(marketplace)])
+    (marketplace / "zzzops" / ".acceptance-revision").write_text(marker + "\n", encoding="utf-8")
+    run(["git", "-C", str(marketplace), "add", "."])
+    run([
+        "git", "-C", str(marketplace), "-c", "user.name=ZzzOps Acceptance",
+        "-c", "user.email=acceptance@invalid.example", "commit", "-m", f"revision {marker}",
+    ])
+    revision = run(["git", "-C", str(marketplace), "rev-parse", "HEAD"]).strip()
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise AcceptanceError("generated marketplace has no full Git commit identity")
+    return revision
+
+
+def write_repository_marketplace(root: Path, output: Path) -> Path:
+    """Create the repository-native marketplace shape used by the Git revision probe."""
+    output.mkdir()
+    shutil.copytree(
+        root / "plugins" / "zzzops", output / "zzzops",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"),
+    )
+    catalog = json.loads((root / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8-sig"))
+    catalog["plugins"][0]["source"] = "./zzzops"
+    manifest = output / ".claude-plugin" / "marketplace.json"
+    manifest.parent.mkdir()
+    manifest.write_text(json.dumps(catalog, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return output
+
+
+def validate_available(records: Any, version: str | None, source: str = "./zzzops") -> None:
     expected = {
         "pluginId": "zzzops@zzzops", "name": "zzzops", "marketplaceName": "zzzops",
-        "version": version, "source": source,
+        "source": source,
     }
+    if version is not None:
+        expected["version"] = version
     if (
         not isinstance(records, list) or len(records) != 1 or not isinstance(records[0], dict)
         or any(records[0].get(key) != value for key, value in expected.items())
+        or (version is None and "version" in records[0])
     ):
-        raise AcceptanceError("available plugin inventory does not match the expected marketplace")
+        observed = records[0] if isinstance(records, list) and len(records) == 1 else records
+        raise AcceptanceError(f"available plugin inventory mismatch: expected {expected!r}, observed {observed!r}")
 
 
 def validate_details(details: str) -> None:
@@ -67,7 +122,10 @@ def validate_install(records: Any, config: Path, version: str) -> Path:
         raise AcceptanceError("installed plugin inventory must contain exactly ZzzOps")
     record = records[0]
     if record.get("id") != "zzzops@zzzops" or record.get("version") != version or record.get("enabled") is not True:
-        raise AcceptanceError("installed ZzzOps identity, version, or enabled state is invalid")
+        raise AcceptanceError(
+            f"installed ZzzOps identity, version, or enabled state is invalid: "
+            f"expected version {version!r}, observed {record!r}"
+        )
     install_text = record.get("installPath")
     if not isinstance(install_text, str) or not install_text:
         raise AcceptanceError("installed ZzzOps has no cache path")
@@ -87,14 +145,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
     root = Path(__file__).resolve().parents[1]
     manifest = json.loads((root / "plugins" / "zzzops" / "plugin.json").read_text(encoding="utf-8-sig"))
-    version = manifest.get("version") if isinstance(manifest, dict) else None
-    if not isinstance(version, str) or not version:
+    product_version = manifest.get("version") if isinstance(manifest, dict) else None
+    if not isinstance(product_version, str) or not product_version:
         print("Claude plugin acceptance failed: canonical plugin version is missing", file=sys.stderr)
         return 2
     try:
         with tempfile.TemporaryDirectory(prefix="zzzops-claude-acceptance-") as directory:
             workspace = Path(directory)
             marketplace = workspace / "marketplace"
+            generated_marketplace = workspace / "generated"
             config = workspace / "config"
             project = workspace / "project"
             config.mkdir()
@@ -106,24 +165,44 @@ def main(argv: list[str] | None = None) -> int:
                 raise AcceptanceError(f"Claude CLI version drift: expected {args.claude_version}, observed {observed_version}")
             built = json_output([
                 sys.executable, str(root / ".github" / "scripts" / "build_claude_plugin.py"),
-                "--version", version, "--output", str(marketplace),
+                "--version", product_version, "--output", str(generated_marketplace),
             ])
             generated = Path(built.get("marketplace", "")) if isinstance(built, dict) else Path()
-            plugin = generated / "zzzops"
-            if generated.resolve() != marketplace.resolve() or not plugin.is_dir():
+            generated_plugin = generated / "zzzops"
+            if generated.resolve() != generated_marketplace.resolve() or not generated_plugin.is_dir():
                 raise AcceptanceError("Claude generator did not produce the expected repository marketplace")
-            run(["claude", "plugin", "validate", str(root), "--strict"], env=env)
-            run(["claude", "plugin", "validate", str(generated), "--strict"], env=env)
-            run(["claude", "plugin", "validate", str(plugin), "--strict"], env=env)
-            run(["claude", "plugin", "marketplace", "add", str(root), "--scope", "user"], env=env)
+            write_repository_marketplace(root, marketplace)
+            plugin = marketplace / "zzzops"
+            first_revision = commit_marketplace(marketplace, "first", initialize=True)
+            first_cache_version = first_revision[:12]
+            validate_versionless(root, env=env)
+            validate_versionless(generated, env=env)
+            validate_versionless(generated_plugin, env=env)
+            validate_versionless(marketplace, env=env)
+            validate_versionless(plugin, env=env)
+            run(["claude", "plugin", "marketplace", "add", str(marketplace), "--scope", "user"], env=env)
             available = json_output(["claude", "plugin", "list", "--available", "--json"], env=env)
             validate_available(
                 available.get("available") if isinstance(available, dict) else None,
-                version,
-                "./plugins/zzzops",
+                None,
             )
             run(["claude", "plugin", "install", "zzzops@zzzops", "--scope", "user", "--yes"], env=env)
-            install = validate_install(json_output(["claude", "plugin", "list", "--json"], env=env), config, version)
+            install = validate_install(
+                json_output(["claude", "plugin", "list", "--json"], env=env), config, first_cache_version,
+            )
+            if (install / ".acceptance-revision").read_text(encoding="utf-8").strip() != "first":
+                raise AcceptanceError("first installed cache does not contain the first Git revision")
+
+            second_revision = commit_marketplace(marketplace, "second")
+            second_cache_version = second_revision[:12]
+            run(["claude", "plugin", "marketplace", "update", "zzzops"], env=env)
+            run(["claude", "plugin", "update", "zzzops@zzzops", "--scope", "user"], env=env)
+            updated = validate_install(
+                json_output(["claude", "plugin", "list", "--json"], env=env), config, second_cache_version,
+            )
+            if updated == install or (updated / ".acceptance-revision").read_text(encoding="utf-8").strip() != "second":
+                raise AcceptanceError("Claude did not install the second Git-backed plugin revision")
+            install = updated
             details = run(["claude", "plugin", "details", "zzzops@zzzops"], env=env)
             validate_details(details)
             cached_skills = {path.name for path in (install / "skills").iterdir() if path.is_dir()}
@@ -133,12 +212,17 @@ def main(argv: list[str] | None = None) -> int:
                 sys.executable, str(install / "zzzops" / "zzzops.py"), "--repo", str(project), "init", "inspect",
             ])
             package = inspection.get("capabilities", {}).get("plugin_package", {}) if isinstance(inspection, dict) else {}
-            if package.get("ok") is not True or package.get("version") != version:
+            if package.get("ok") is not True or package.get("version") != product_version:
                 raise AcceptanceError("packaged ZzzOps runtime cannot validate its installed cache copy")
     except (AcceptanceError, OSError, UnicodeError, json.JSONDecodeError) as exc:
         print(f"Claude plugin acceptance failed: {exc}", file=sys.stderr)
         return 2
-    print(json.dumps({"accepted": True, "claude_version": args.claude_version, "plugin_version": version, "skills": sorted(EXPECTED_SKILLS)}))
+    print(json.dumps({
+        "accepted": True, "claude_version": args.claude_version,
+        "plugin_version": product_version,
+        "claude_cache_versions": [first_cache_version, second_cache_version],
+        "skills": sorted(EXPECTED_SKILLS),
+    }))
     return 0
 
 

--- a/.agents/test_agent_plugin.py
+++ b/.agents/test_agent_plugin.py
@@ -52,16 +52,17 @@ class AgentPluginTests(unittest.TestCase):
 
     def test_canonical_source_identifies_every_skill_as_development(self) -> None:
         package = runpy.run_path(str(PLUGIN / "zzzops" / "package.py"))
-        manifest_paths = (
+        versioned_manifest_paths = (
             PLUGIN / "plugin.json",
             PLUGIN / ".codex-plugin" / "plugin.json",
-            PLUGIN / ".claude-plugin" / "plugin.json",
         )
-        for path in manifest_paths:
+        for path in versioned_manifest_paths:
             self.assertEqual("0.0.0-dev", json.loads(path.read_text(encoding="utf-8"))["version"])
+        claude = json.loads((PLUGIN / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+        self.assertNotIn("version", claude)
         marketplace = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
-        self.assertEqual("0.0.0-dev", marketplace["metadata"]["version"])
-        self.assertEqual("0.0.0-dev", marketplace["plugins"][0]["version"])
+        self.assertNotIn("version", marketplace["metadata"])
+        self.assertNotIn("version", marketplace["plugins"][0])
         for skill in SHIPPED_SKILLS:
             skill_path = PLUGIN / "skills" / skill / "SKILL.md"
             agent_path = PLUGIN / "skills" / skill / "agents" / "openai.yaml"

--- a/.agents/test_claude_plugin_acceptance.py
+++ b/.agents/test_claude_plugin_acceptance.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -43,6 +45,12 @@ class ClaudePluginAcceptanceTests(unittest.TestCase):
         with self.assertRaisesRegex(self.harness.AcceptanceError, "skill inventory"):
             self.harness.validate_details(details.replace("validate-zzzops-installation", "unexpected"))
 
+        del available[0]["version"]
+        self.harness.validate_available(available, None, "./plugins/zzzops")
+        available[0]["version"] = "stale"
+        with self.assertRaisesRegex(self.harness.AcceptanceError, "inventory mismatch"):
+            self.harness.validate_available(available, None, "./plugins/zzzops")
+
     def test_install_must_resolve_inside_isolated_cache_with_runtime(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             config = Path(directory) / "config"
@@ -56,6 +64,22 @@ class ClaudePluginAcceptanceTests(unittest.TestCase):
             record[0]["installPath"] = str(Path(directory) / "source")
             with self.assertRaisesRegex(self.harness.AcceptanceError, "isolated Claude cache"):
                 self.harness.validate_install(record, config, "2.0.0")
+
+    def test_versionless_validation_allows_only_claudes_documented_sha_warning(self) -> None:
+        warning = (
+            "Found 1 warning\nplugins[0] plugin.json → " + self.harness.NO_VERSION_WARNING
+            + "\nValidation failed (--strict treats warnings as errors)\n"
+        )
+        strict = subprocess.CompletedProcess(["claude"], 1, warning, "")
+        accepted = subprocess.CompletedProcess(["claude"], 0, "valid\n", "")
+        with mock.patch.object(self.harness.subprocess, "run", side_effect=[strict, accepted]) as run:
+            self.harness.validate_versionless(Path("marketplace"), env={})
+        self.assertEqual(2, run.call_count)
+
+        extra = subprocess.CompletedProcess(["claude"], 1, warning.replace("Found 1 warning", "Found 2 warnings"), "")
+        with mock.patch.object(self.harness.subprocess, "run", return_value=extra):
+            with self.assertRaisesRegex(self.harness.AcceptanceError, "beyond"):
+                self.harness.validate_versionless(Path("marketplace"), env={})
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/test_marketplace_bundle.py
+++ b/.agents/test_marketplace_bundle.py
@@ -121,6 +121,16 @@ class MarketplaceBundleTests(unittest.TestCase):
             with self.assertRaisesRegex(self.builder.BundleError, "canonical development manifest"):
                 self.builder.plugin_files(root, "2.0.0")
 
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            shutil.copytree(ROOT / "plugins" / "zzzops", root / "plugins" / "zzzops")
+            manifest_path = root / "plugins" / "zzzops" / ".claude-plugin" / "plugin.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["version"] = "0.0.0-dev"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(self.builder.BundleError, "Claude manifest must omit version"):
+                self.builder.plugin_files(root, "2.0.0")
+
     def test_stale_release_output_is_rejected_before_any_partial_refresh(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory) / "marketplace"
@@ -153,12 +163,12 @@ class MarketplaceBundleTests(unittest.TestCase):
         marketplace = json.loads(files[".claude-plugin/marketplace.json"])
 
         self.assertEqual("zzzops", manifest["name"])
-        self.assertEqual("2.0.0", manifest["version"])
+        self.assertNotIn("version", manifest)
         self.assertEqual("zzzops", marketplace["name"])
         self.assertEqual(manifest["description"], marketplace["metadata"]["description"])
-        self.assertEqual("2.0.0", marketplace["metadata"]["version"])
+        self.assertNotIn("version", marketplace["metadata"])
         self.assertEqual("./zzzops", marketplace["plugins"][0]["source"])
-        self.assertEqual("2.0.0", marketplace["plugins"][0]["version"])
+        self.assertNotIn("version", marketplace["plugins"][0])
         self.assertEqual(manifest["keywords"], marketplace["plugins"][0]["keywords"])
         self.assertEqual("development", marketplace["plugins"][0]["category"])
         self.assertEqual(
@@ -180,15 +190,13 @@ class MarketplaceBundleTests(unittest.TestCase):
         self.assertEqual("./plugins/zzzops", marketplace["plugins"][0]["source"])
         self.assertEqual(canonical["name"], marketplace["name"])
         self.assertEqual(canonical["author"], marketplace["owner"])
-        self.assertEqual(
-            {"description": canonical["description"], "version": canonical["version"]},
-            marketplace["metadata"],
-        )
+        self.assertEqual({"description": canonical["description"]}, marketplace["metadata"])
         self.assertEqual(canonical["name"], marketplace["plugins"][0]["name"])
         self.assertEqual(canonical["description"], marketplace["plugins"][0]["description"])
-        self.assertEqual(canonical["version"], marketplace["plugins"][0]["version"])
+        self.assertNotIn("version", marketplace["plugins"][0])
         self.assertEqual(canonical["name"], manifest["name"])
-        for field in ("version", "description", "author", "homepage", "repository", "license", "keywords"):
+        self.assertNotIn("version", manifest)
+        for field in ("description", "author", "homepage", "repository", "license", "keywords"):
             self.assertEqual(canonical[field], manifest[field], field)
 
     def test_public_discovery_metadata_keeps_one_truthful_positioning(self) -> None:

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,13 @@
     "url": "https://github.com/david-rzepa"
   },
   "metadata": {
-    "description": "Agentic engineering with durable goals for autonomous coding agents",
-    "version": "0.0.0-dev"
+    "description": "Agentic engineering with durable goals for autonomous coding agents"
   },
   "plugins": [
     {
       "name": "zzzops",
       "source": "./plugins/zzzops",
       "description": "Agentic engineering with durable goals for autonomous coding agents",
-      "version": "0.0.0-dev",
       "keywords": [
         "agentic-engineering",
         "coding-agents",

--- a/.github/scripts/build_marketplace_bundle.py
+++ b/.github/scripts/build_marketplace_bundle.py
@@ -182,12 +182,15 @@ def scan_for_secrets(relative: str, data: bytes) -> None:
 def plugin_files(root: Path, version: str) -> dict[str, bytes]:
     plugin = root / "plugins" / "zzzops"
     development_version = "0.0.0-dev"
-    for relative in ("plugin.json", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json"):
+    for relative in ("plugin.json", ".codex-plugin/plugin.json"):
         manifest = read_json(plugin / relative)
         if not isinstance(manifest, dict) or manifest.get("version") != development_version:
             raise BundleError(
                 f"canonical development manifest must use {development_version}: {relative}"
             )
+    claude_manifest = read_json(plugin / ".claude-plugin" / "plugin.json")
+    if not isinstance(claude_manifest, dict) or "version" in claude_manifest:
+        raise BundleError("canonical Claude manifest must omit version so Git commits drive updates")
     package = runpy.run_path(str(plugin / "zzzops" / "package.py"))
     renderer = package["render_skill_metadata"]
     result: dict[str, bytes] = {}
@@ -207,7 +210,8 @@ def plugin_files(root: Path, version: str) -> dict[str, bytes]:
             data = data.replace(b"\r\n", b"\n")
         if relative in {"plugin.json", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json"}:
             manifest = json.loads(data.decode("utf-8-sig"))
-            manifest["version"] = version
+            if relative != ".claude-plugin/plugin.json":
+                manifest["version"] = version
             data = canonical_json(manifest)
         try:
             data = renderer(relative, data, version, "official")
@@ -274,19 +278,16 @@ def claude_marketplace_files(root: Path, version: str) -> dict[str, bytes]:
         "name", "description", "author", "homepage", "repository", "license", "keywords",
     )
     manifest = {field: canonical_manifest[field] for field in manifest_fields}
-    manifest["version"] = version
     marketplace = {
         "name": canonical_manifest["name"],
         "owner": canonical_manifest["author"],
         "metadata": {
             "description": canonical_manifest["description"],
-            "version": version,
         },
         "plugins": [{
             "name": canonical_manifest["name"],
             "source": "./zzzops",
             "description": canonical_manifest["description"],
-            "version": version,
             "keywords": canonical_manifest["keywords"],
             "category": "development",
             "tags": ["agentic-engineering", "coding-agents", "repository-bootstrap"],

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ See [advanced installation options](docs/ADVANCED.md#alternative-installations) 
 Claude Code users can install from this repository:
 
 ```powershell
-claude plugin marketplace add david-rzepa/zzzops
+claude plugin marketplace add david-rzepa/zzzops@latest
 claude plugin install zzzops@zzzops
 ```
 
-Claude and Codex use the same canonical implementation. See the [Claude Code installation and submission notes](docs/CLAUDE_MARKETPLACE.md).
+The release-only `latest` branch gives each Claude update a new Git-derived cache version. Claude and Codex use the same canonical implementation. See the [Claude Code installation and submission notes](docs/CLAUDE_MARKETPLACE.md).
 
 ### 2. Bootstrap the repository
 

--- a/docs/CLAUDE_MARKETPLACE.md
+++ b/docs/CLAUDE_MARKETPLACE.md
@@ -9,14 +9,16 @@ ZzzOps keeps one plugin implementation in `plugins/zzzops`. Claude-specific repo
 - `.claude-plugin/marketplace.json`, which points to `./plugins/zzzops`;
 - `plugins/zzzops/.claude-plugin/plugin.json`, which describes that canonical plugin directory.
 
-Skills, rules, scripts, and the ZzzOps runtime are not copied into a second Claude tree or release archive. Anthropic review and normal marketplace installation consume repository state. CI still generates a disposable marketplace to prove strict Claude validation, then performs isolated installation and installed-cache runtime acceptance from the repository marketplace.
+Skills, rules, scripts, and the ZzzOps runtime are not copied into a second Claude tree or release archive. Anthropic review and normal marketplace installation consume repository state. CI still generates a disposable marketplace, applies the strict validator with the documented SHA-version warning isolated, then performs installed-cache runtime acceptance from a disposable Git-backed repository marketplace.
+
+Claude's cache version comes from the plugin source Git commit. The Claude plugin manifest and marketplace entry intentionally omit `version`; Anthropic documents that `plugin.json` otherwise wins and an unchanged explicit value suppresses updates. Users follow the release-only `latest` branch, so semantic-release remains the product release authority while each published commit naturally has a distinct Claude cache identity. CI does not write or commit a second semantic version.
 
 ## Direct Claude Code installation
 
 After the release containing Claude support reaches the repository's default branch, users can install directly from this repository:
 
 ```powershell
-claude plugin marketplace add david-rzepa/zzzops
+claude plugin marketplace add david-rzepa/zzzops@latest
 claude plugin install zzzops@zzzops
 ```
 
@@ -24,6 +26,7 @@ Refresh the repository marketplace without uninstalling the plugin:
 
 ```powershell
 claude plugin marketplace update zzzops
+claude plugin update zzzops@zzzops --scope user
 ```
 
 These commands use ZzzOps's own marketplace and do not imply Anthropic review or directory placement.
@@ -57,7 +60,8 @@ Use these repository-derived values when the live form requests them:
 | Marketplace manifest | `.claude-plugin/marketplace.json` |
 | Plugin source | `./plugins/zzzops` |
 | Plugin manifest | `plugins/zzzops/.claude-plugin/plugin.json` |
-| Canonical source version | `0.0.0-dev` (release artifacts render the semantic release version) |
+| Claude cache version | Git source commit (Claude displays its 12-character abbreviation) |
+| Canonical Agent Plugin version | `0.0.0-dev` (`latest` and immutable tags define published repository revisions) |
 | Description | Agentic engineering with durable goals for autonomous coding agents |
 | License | Apache-2.0 |
 | Homepage | `https://github.com/david-rzepa/zzzops` |
@@ -76,7 +80,9 @@ python .agents/claude_plugin_acceptance.py --claude-version 2.1.241
 python .agents/test_marketplace_bundle.py
 ```
 
-The installed-cache acceptance adds the committed repository marketplace in an isolated Claude configuration, installs `zzzops@zzzops`, verifies exactly nine skills, and runs ZzzOps initialization from Claude's cache. The marketplace-bundle tests require committed Claude metadata to agree with the canonical Agent Plugin manifest and require the released Claude ZIP to contain the same Claude plugin manifest. Required CI repeats the contract on Linux, Windows, and macOS before review.
+The installed-cache acceptance creates a disposable Git-backed marketplace in an isolated Claude configuration, installs revision A, advances the repository to revision B, refreshes and updates the plugin, and proves Claude uses a new cache path and the second revision's contents. It also verifies exactly nine skills and runs ZzzOps initialization from Claude's cache.
+
+Claude's strict validator currently warns when `version` is omitted even though Anthropic documents omission as the commit-SHA mode. The acceptance harness allows exactly that one warning, requires the same artifact to pass native non-strict validation, and rejects every additional strict-validation warning or error. Required CI repeats the complete contract with a pinned Claude CLI before review.
 
 ## Owner checklist
 
@@ -86,7 +92,7 @@ Before submitting:
 - [ ] Confirm parent goal #300 is integrated and all required checks pass at the exact candidate commit.
 - [ ] Confirm the public repository and candidate commit contain both Claude manifests and the complete canonical plugin tree.
 - [ ] Run the verification commands above and retain links to the exact-head CI evidence.
-- [ ] Verify the repository, homepage, privacy, support, license, description, and version values against the live files.
+- [ ] Verify the repository, homepage, privacy, support, license, description, and Git-derived cache version behavior against the live files.
 - [ ] Read every identity, ownership, security, licensing, privacy, and legal attestation in the live form and personally confirm only statements the owner can support.
 - [ ] Map every required form field to reviewed repository evidence; preserve unknown fields rather than inventing answers.
 - [ ] Review the exact payload and attestations before pressing submit.

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -50,7 +50,7 @@ Every release prepares one validated versioned marketplace asset before GitHub p
 
 - `zzzops-plugin-v<version>.zip` — OpenAI portal skills bundle.
 
-Canonical repository metadata stays at `0.0.0-dev`. Release preparation renders the semantic release version and official channel into the temporary OpenAI bundle; CI never commits generated release metadata back to `dev`. Claude marketplace validation and installed-cache acceptance run directly from repository state and do not publish a duplicate archive.
+Canonical Agent Plugin and Codex metadata stays at `0.0.0-dev`. Release preparation renders the semantic release version and official channel into the temporary OpenAI bundle; CI never commits generated release metadata back to `dev`. Claude metadata omits an explicit plugin version so Claude derives its cache identity from the Git source commit. The release-only `latest` branch controls update cadence, and installed-cache acceptance proves a real two-commit update without publishing a duplicate archive or writing release metadata back to the repository.
 
 A build or validation failure stops publication. Successful artifacts attach to the matching GitHub Release. OpenAI portal upload, attestation, review submission, approval, and final directory publication remain explicit human actions; see the [marketplace sources](../marketplace/README.md). Claude submission guidance lives in [Claude Code marketplace notes](CLAUDE_MARKETPLACE.md), and the shared language and intent map live in [product discovery positioning](DISCOVERY.md).
 

--- a/plugins/zzzops/.claude-plugin/plugin.json
+++ b/plugins/zzzops/.claude-plugin/plugin.json
@@ -17,6 +17,5 @@
     "github-issues",
     "codex",
     "claude-code"
-  ],
-  "version": "0.0.0-dev"
+  ]
 }


### PR DESCRIPTION
## Summary
- remove explicit Claude plugin and marketplace version pins so Claude falls back to the Git source commit
- direct Claude users to the release-only latest branch, preserving semantic-release cadence without CI-authored version commits
- extend installed-cache acceptance from a static install to a real Git revision A-to-B marketplace and plugin update
- isolate Claude's documented no-version strict-validator warning while rejecting every other warning or error
- preserve semantic versions in the OpenAI and Codex release artifacts

## Verification
- py -3 .agents/claude_plugin_acceptance.py --claude-version 2.1.251
- py -3 .agents/test_claude_plugin_acceptance.py
- py -3 .agents/test_marketplace_bundle.py
- py -3 .agents/test_agent_plugin.py
- py -3 .agents/test_release_validation.py
- py -3 .agents/test_zzzops.py
- npm run test:release
- py -3 .agents/prompt_stats.py --check
- git diff --check

Tracks #351