### PR TITLE
feat: apply communication policy across ZzzOps skills

### DIFF
--- a/.agents/prompt_stats.py
+++ b/.agents/prompt_stats.py
@@ -13,6 +13,8 @@ HARNESS_PROMPTS = {
     "codex": ("AGENTS.md",),
 }
 
+COMMUNICATION_PROMPT = "plugins/zzzops/rules/COMMUNICATION.md"
+
 # These limits protect context paid on every Codex turn and the two frequent ZzzOps paths. At the
 # goal #297 baseline, always-loaded/codex is 625 tokens. Goal #302 reduced capture/execution to
 # 3,324/8,452 tokens; their ceilings retain only the measured 13-token execution margin. Cold
@@ -27,14 +29,14 @@ WORKFLOW_PROMPTS = {
     "agentic-coaching": (
         "plugins/zzzops/skills/review-agentic-engineering/SKILL.md",
         "plugins/zzzops/skills/review-agentic-engineering/references/ATTRIBUTION.md",
-        "plugins/zzzops/rules/FEEDBACK.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/FEEDBACK.md",
     ),
     "bootstrap-greenfield": (
         "plugins/zzzops/skills/bootstrap-zzzops-repository/SKILL.md",
         "plugins/zzzops/zzzops/references/bootstrap/ANALYZE.md",
         "plugins/zzzops/zzzops/references/bootstrap/PLAN.md",
         "plugins/zzzops/zzzops/references/bootstrap/GREENFIELD.md",
-        "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
         "plugins/zzzops/rules/FEEDBACK.md",
     ),
     "bootstrap-brownfield": (
@@ -42,12 +44,12 @@ WORKFLOW_PROMPTS = {
         "plugins/zzzops/zzzops/references/bootstrap/ANALYZE.md",
         "plugins/zzzops/zzzops/references/bootstrap/PLAN.md",
         "plugins/zzzops/zzzops/references/bootstrap/BROWNFIELD.md",
-        "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
         "plugins/zzzops/rules/FEEDBACK.md",
     ),
     "capture": (
         "plugins/zzzops/skills/add-zzzops-goal/SKILL.md",
-        "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
         "plugins/zzzops/rules/CONTINUATION.md", "plugins/zzzops/rules/FEEDBACK.md",
     ),
     "execution": (
@@ -55,22 +57,22 @@ WORKFLOW_PROMPTS = {
         "plugins/zzzops/skills/execute-zzzops/references/EXECUTE.md",
         "plugins/zzzops/skills/execute-zzzops/references/BRANCH_REVIEW.md",
         "plugins/zzzops/skills/execute-zzzops/references/SELF_REVIEW.md",
-        "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
         "plugins/zzzops/rules/GOAL_SYSTEM.md", "plugins/zzzops/rules/CONTINUATION.md",
         "plugins/zzzops/rules/EXECUTION_STRATEGY.md", "plugins/zzzops/rules/FEEDBACK.md",
     ),
     "policy-review": (
         "plugins/zzzops/skills/review-zzzops-policy/SKILL.md",
-        "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/FEEDBACK.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/FEEDBACK.md",
     ),
     "migration": (
         "plugins/zzzops/skills/migrate-to-zzzops/SKILL.md",
-        "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
         "plugins/zzzops/rules/FEEDBACK.md",
     ),
     "suggestion": (
         "plugins/zzzops/skills/suggest-zzzops-work/SKILL.md",
-        "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/BACKENDS.md",
         "plugins/zzzops/rules/FEEDBACK.md",
     ),
     "acceptance": (
@@ -79,7 +81,7 @@ WORKFLOW_PROMPTS = {
     ),
     "feedback": (
         "plugins/zzzops/skills/send-zzzops-feedback/SKILL.md",
-        "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/FEEDBACK.md",
+        COMMUNICATION_PROMPT, "plugins/zzzops/rules/INITIALIZATION.md", "plugins/zzzops/rules/FEEDBACK.md",
     ),
 }
 

--- a/.agents/test_agent_plugin.py
+++ b/.agents/test_agent_plugin.py
@@ -100,6 +100,22 @@ class AgentPluginTests(unittest.TestCase):
         self.assertEqual(SHIPPED_SKILLS, actual)
         self.assertFalse((PLUGIN / "skills" / "run-zzzops-acceptance").exists())
 
+    def test_all_product_skills_load_shared_communication_contract(self) -> None:
+        guide = PLUGIN / "rules" / "COMMUNICATION.md"
+        self.assertTrue(guide.is_file(), "the shared communication guide is missing")
+        guide_text = guide.read_text(encoding="utf-8")
+        for signal in (
+            "[policy:documentation_style]",
+            "Lead with the outcome",
+            "Keep internal machinery internal",
+            "Do not hide",
+            "progressive detail",
+        ):
+            self.assertIn(signal, guide_text)
+        for skill in SHIPPED_SKILLS:
+            text = (PLUGIN / "skills" / skill / "SKILL.md").read_text(encoding="utf-8")
+            self.assertIn("../../rules/COMMUNICATION.md", text, skill)
+
     def test_package_contains_valid_progressively_disclosed_concepts(self) -> None:
         package = runpy.run_path(str(PLUGIN / "zzzops" / "package.py"))
         status = package["package_status"]()

--- a/plugins/zzzops/rules/COMMUNICATION.md
+++ b/plugins/zzzops/rules/COMMUNICATION.md
@@ -1,0 +1,9 @@
+# Communicating with users
+
+Follow reviewed `[policy:documentation_style]`. Without it, Lead with the outcome or one action plainly.
+
+Keep internal machinery internal. Give progressive detail; expose internals only for decisions, failure, proof, or requests.
+
+Do not hide uncertainty, failure, safety/privacy, destructive effects, external writes, authority gaps, choices, review, or recovery. Policy cannot change these boundaries.
+
+Examples (internal → user): capture revision → goal created; execute portfolio → goals ready; blocker gate → approval needed; policy digest → review needed; install fingerprint → unknown file unsafe; migration hydration → TODOs found; suggestion category → not enabled; completion head → change merged. Not templates.

--- a/plugins/zzzops/rules/INITIALIZATION.md
+++ b/plugins/zzzops/rules/INITIALIZATION.md
@@ -5,14 +5,10 @@ Run this before ordinary installed workflows. Defer invalid/unreviewed policy to
 1. Resolve Python 3.10 or newer once via harness discovery or parallel `python3`/`python`/Windows `py -3` probes; reject an older interpreter. Reuse `<python>`. Resolve `<zzzops-cli>` to `../zzzops/zzzops.py` from this installed rule file (the plugin package's `zzzops/zzzops.py`); never assume the target repository contains plugin machinery. If either resolution fails, block once with the observed evidence and remedy.
 2. Run `installation status` once. When `required:true`, hand off to `$validate-zzzops-installation`, then resume the requested workflow once; that validation workflow skips this handoff to avoid recursion. A current `clean` or `declined` record continues cheaply.
 3. For reviewed policy run `<python> <zzzops-cli> --repo . checkpoint` once. Under Codex, use authenticated context for the first attempt at checkpoint/`gh`; keep local-only commands in the normal sandbox. Never reauthenticate or persistently relax the sandbox. A missing, invalid, or changed plugin package requires reinstalling or updating it through Codex. Continue only on `ready:true` and reuse its complete portfolio.
-4. `$review-zzzops-policy` owns reconciliation. Inspect evidence, settings/tools, capability, and size. Build ignored `.zzzops/init/plan.json` from the package's `zzzops/templates/project-goals/INIT_PLAN.json`; safety/authority stays invariant.
-5. Show `policy_review_table` once before detail/action each review; never filter rows. Report evidence, conflicts, changes, unknowns, and privacy-safe execution reports. Keep mechanics progressive. Interview once; evidence wins; unavailable decisions block.
-6. If canonical artifacts have a current approval digest and every required section is approved, say `The policy is already approved.` Do not ask for approval or run `init confirm`; invite adjustments, then checkpoint.
-7. Otherwise, after proposal approval run `init validate` and `init apply`, summarize pending policy, and invite adjustment. Changed/stale state, a pending required section, or a proposal requires explicit confirmation, then `init confirm --policy-digest DIGEST --reviewer NAME --all` (or `--section ID`). Bound changes stale approval; hide digests unless needed.
-8. Run `checkpoint`. Initialization makes no Git/GitHub writes; ordinary execution may commit approved policy without another gate. Later reviews resummarize.
+4. `$review-zzzops-policy` owns reconciliation. Inspect evidence, tools, capability, and size. Build ignored `.zzzops/init/plan.json` from `zzzops/templates/project-goals/INIT_PLAN.json`; preserve safety/authority.
+5. Show the complete `policy_review_table` once before detail/action. Report conflicts, changes, unknowns, and privacy-safe execution reports progressively; evidence wins and unavailable decisions block.
+6. With a current approval digest and every required section approved, say `The policy is already approved.` Do not ask for approval or run `init confirm`; invite adjustments, then checkpoint.
+7. Otherwise, after proposal approval run `init validate` and `init apply`. Changed/stale, pending required, or proposed state needs `init confirm --policy-digest DIGEST --reviewer NAME --all` (or `--section ID`). Bound changes stale approval; hide digests unless needed.
+8. Run `checkpoint`. Initialization makes no Git/GitHub writes; execution may commit approved policy. Later reviews resummarize.
 
 Unsupported state, identity drift, or policy-evidence conflict stops affected work. Never reset or invent fallback authority.
-
-## User-facing communication
-
-Apply PROJECT communication policy. Lead with outcome and one needed action; keep mechanics internal. Name uncertainty, safety, destructive effects, authority, and consequential tradeoffs.

--- a/plugins/zzzops/skills/add-zzzops-goal/SKILL.md
+++ b/plugins/zzzops/skills/add-zzzops-goal/SKILL.md
@@ -5,16 +5,14 @@ description: ZzzOps v0.0.0-dev — development plugin. Capture, add, create, or 
 
 # Add Goal
 
-Run `../../rules/INITIALIZATION.md`, then `../../rules/BACKENDS.md`. Hydrate likely duplicate/relationship matches and needed comments. Persist risk/overrides; interview at [[effective engineering rigor]](../../concepts/effective-engineering-rigor.md): `vibe → light`, `structured → standard`, `agentic → thorough`. This controls depth; legacy policy uses reviewed `requirements_interview.capture_depth` or `standard`. Escalate as required; never silently de-escalate below a risk minimum.
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
 
-Reuse request, repository, goal, and answer evidence. Ask 1–3 consequential gaps; recommend answers. `light`: outcome, observable acceptance, critical constraints. `standard` adds scope/non-goals, examples, dependencies, risks, authority, verification. `thorough` adds architecture, security, data lifecycle, recovery, operations, rollout, accessibility, compatibility, governance. Challenge subjective success/contradictions. Current user owns requirements/acceptance; no multi-party sign-off.
+Run `../../rules/INITIALIZATION.md`, then `../../rules/BACKENDS.md`; hydrate likely duplicate/relationship matches and needed comments.
 
-When unfamiliarity/risk could change architecture, scope, acceptance, or quality, run a bounded blind-spot pass for known unknowns, tacit criteria, and blind spots using the cheapest useful reference, research, alternative, or disposable prototype. Skip well-understood work and fixed ceremony.
+Then interview at [[effective engineering rigor]](../../concepts/effective-engineering-rigor.md): `vibe → light`, `structured → standard`, `agentic → thorough`; use legacy reviewed depth or `standard`. Persist risks/overrides and never silently de-escalate. Reuse request, repository, goal, and answer evidence. Ask 1–3 consequential gaps with recommendations. `light` covers outcome, observable acceptance, and critical constraints; `standard` adds scope, examples, dependencies, risks, authority, and verification; `thorough` adds applicable architecture, security, data lifecycle, recovery, operations, rollout, accessibility, compatibility, and governance. The current user owns requirements/acceptance.
 
-Stop when independently actionable/verifiable at that depth or unknowns are explicit blockers. Create one human-first current-schema goal with applicable source/value evidence; never invent answers. Use `$execute-zzzops`.
+Run a bounded blind-spot pass for known unknowns, tacit criteria, using a disposable prototype when useful. Skip well-understood work. Stop at an independently actionable/verifiable goal or explicit blockers. Create one human-first current-schema goal with source/value evidence; never invent answers.
 
-Git-free creation: capture makes no branch, commit, push, PR, or empty checkpoint.
-
-Apply `../../rules/CONTINUATION.md`; active same-task execute intent may resume once, while capture-only/replacement/stop wins. Confirm outcome/link and only next-affecting relationships/unknowns.
+Git-free creation: no branch, commit, push, PR, or empty checkpoint. Apply `../../rules/CONTINUATION.md`; active same-task execute intent may resume once unless capture-only/replacement/stop wins. Use `$execute-zzzops` for implementation.
 
 Before stopping or handing off, apply `../../rules/FEEDBACK.md`.

--- a/plugins/zzzops/skills/bootstrap-zzzops-repository/SKILL.md
+++ b/plugins/zzzops/skills/bootstrap-zzzops-repository/SKILL.md
@@ -5,6 +5,8 @@ description: ZzzOps v0.0.0-dev — development plugin. Bootstrap an empty, early
 
 # Bootstrap a ZzzOps Repository
 
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
+
 Establish a clear product outcome and the proportionate engineering harness agents need, then execute the authorized product DAG. Bootstrap coordinates policy, ordinary goals, execution, verification, and migration rather than duplicating them.
 
 1. Read [repository and product analysis](../../zzzops/references/bootstrap/ANALYZE.md). Before harness commitment, run the adaptive product interview to establish beneficiaries, observable success, scope/non-goals, initial milestone, constraints, and applicable risk/governance facts. This is discovery, not an approval gate. Classify the repository from evidence and use [[bounded commitment]](../../concepts/bounded-commitment.md) for unknown technical choices.

--- a/plugins/zzzops/skills/execute-zzzops/SKILL.md
+++ b/plugins/zzzops/skills/execute-zzzops/SKILL.md
@@ -10,6 +10,8 @@ description: >-
 
 # Execute ZzzOps
 
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
+
 Mode: `dry run`, `preview`, or `plan` means read-only inventory, triage simulation, ordering, and blocker reporting; do not initialize/apply, claim, update goals, edit source, run mutating commands, or change Git/external state. Otherwise run the live loop below.
 
 First run `../../rules/INITIALIZATION.md`, then route through `../../rules/BACKENDS.md`. Read `../../rules/GOAL_SYSTEM.md` and the initialized charter; load only what applies.

--- a/plugins/zzzops/skills/execute-zzzops/references/EXECUTE.md
+++ b/plugins/zzzops/skills/execute-zzzops/references/EXECUTE.md
@@ -11,7 +11,7 @@
 
 Execution assumes the user is absent and never asks an interactive question. Persist each unanswered consequential question with category, evidence, recommendation, boundary, safe work, and trigger. Never infer approval; stop affected work only and continue to true queue exhaustion.
 
-Update only for a new result, decision, risk, changed assumption, required action, or long-operation heartbeat; never recap unchanged state. Before substantive work on a new goal/resume, state outcome/scope before edits.
+Update only for a new result, decision, risk, changed assumption, required action, or long-operation heartbeat; never recap unchanged state. Before substantive work on a newly selected goal/resume, state outcome/scope before edits.
 
 ## Execute
 

--- a/plugins/zzzops/skills/execute-zzzops/references/EXECUTE.md
+++ b/plugins/zzzops/skills/execute-zzzops/references/EXECUTE.md
@@ -11,9 +11,7 @@
 
 Execution assumes the user is absent and never asks an interactive question. Persist each unanswered consequential question with category, evidence, recommendation, boundary, safe work, and trigger. Never infer approval; stop affected work only and continue to true queue exhaustion.
 
-Before substantive work on a newly selected goal/resume, state outcome/scope before edits; do not repeat it.
-
-Update only for a new result, decision, risk, changed assumption, required action, or long-operation heartbeat; never recap unchanged state.
+Update only for a new result, decision, risk, changed assumption, required action, or long-operation heartbeat; never recap unchanged state. Before substantive work on a new goal/resume, state outcome/scope before edits.
 
 ## Execute
 

--- a/plugins/zzzops/skills/migrate-to-zzzops/SKILL.md
+++ b/plugins/zzzops/skills/migrate-to-zzzops/SKILL.md
@@ -5,6 +5,8 @@ description: ZzzOps v0.0.0-dev — development plugin. Discover, plan, migrate, 
 
 # Migrate to ZzzOps
 
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
+
 Mode: `dry run`, `preview`, or `plan` reports candidates and a proposed plan in chat without creating plan/summary files or changing state. Otherwise build the review artifacts below; apply only after explicit approval.
 
 Run `../../rules/INITIALIZATION.md`, then `../../rules/BACKENDS.md`. Use `../../zzzops/templates/project-goals/` for artifact shapes.

--- a/plugins/zzzops/skills/review-agentic-engineering/SKILL.md
+++ b/plugins/zzzops/skills/review-agentic-engineering/SKILL.md
@@ -5,6 +5,8 @@ description: ZzzOps v0.0.0-dev — development plugin. Review completed software
 
 # Review Agentic Engineering
 
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
+
 Run only when explicitly invoked. Help the user improve how they use software agents across projects without assuming that friction was their prompting fault.
 
 1. Read [evidence and attribution](references/ATTRIBUTION.md). Inspect several substantial completed work items when available, using evidence already visible in the current environment. Do not create a prompt archive or copy raw project content into attribution input or output.

--- a/plugins/zzzops/skills/review-zzzops-policy/SKILL.md
+++ b/plugins/zzzops/skills/review-zzzops-policy/SKILL.md
@@ -5,6 +5,8 @@ description: ZzzOps v0.0.0-dev — development plugin. Review, initialize, summa
 
 # Review ZzzOps Policy
 
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
+
 Follow `../../rules/INITIALIZATION.md`; only this workflow changes or confirms policy.
 
 Before optional tools, reuse capabilities; never invoke an unavailable path—use an alternative or block once.

--- a/plugins/zzzops/skills/send-zzzops-feedback/SKILL.md
+++ b/plugins/zzzops/skills/send-zzzops-feedback/SKILL.md
@@ -5,6 +5,8 @@ description: ZzzOps v0.0.0-dev — development plugin. Preview and send user fee
 
 # Send ZzzOps Feedback
 
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
+
 Run `../../rules/INITIALIZATION.md`, then read `../../rules/FEEDBACK.md`. Use the resolved Python interpreter for all CLI calls.
 
 Use checkpoint only for readiness; detailed inputs are local reports and explicit feedback, never goal bodies/history.

--- a/plugins/zzzops/skills/suggest-zzzops-work/SKILL.md
+++ b/plugins/zzzops/skills/suggest-zzzops-work/SKILL.md
@@ -5,6 +5,8 @@ description: ZzzOps v0.0.0-dev — development plugin. Suggest, discover, or aud
 
 # Suggest ZzzOps Work
 
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
+
 Run `../../rules/INITIALIZATION.md`, then `../../rules/BACKENDS.md`. Read project instructions, charter, and minimal evidence; hydrate only likely duplicates, and history only when needed.
 
 1. Mode defaults to `dry-run`: no edits to source, Git, goals, or index. `apply` requires explicit user request or a `$execute-zzzops` invocation explicitly allowed by reviewed PROJECT refill policy.

--- a/plugins/zzzops/skills/validate-zzzops-installation/SKILL.md
+++ b/plugins/zzzops/skills/validate-zzzops-installation/SKILL.md
@@ -5,6 +5,8 @@ description: ZzzOps v0.0.0-dev — development plugin. Validate one repository a
 
 # Validate ZzzOps Installation
 
+Read `../../rules/COMMUNICATION.md` for user-facing messages.
+
 This workflow owns the installation check, so skip `INITIALIZATION.md`'s validation handoff and do not recurse. Resolve Python and the installed package CLI as described there.
 
 1. Run `installation status`. Automatic routing stops immediately when the current package record is `clean` or `declined`; explicit invocation continues to a fresh audit.


### PR DESCRIPTION
Tracks #354. Adds one shared, policy-backed communication guide that every shipped skill loads, retains universal clarity and safety boundaries, removes duplicated guidance, and accounts for the guide in prompt budgets. Verified with the complete Windows product-validation suite and prompt budget check.