### PR TITLE
fix(review): guard admin fallback for stacked PRs

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -2969,6 +2969,41 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("gh stack rebase", review_queue)
         self.assertIn("provider readback", review_queue)
 
+    def test_admin_stack_merge_fallback_is_guarded_and_recoverable(self):
+        root = PLUGIN_ROOT / "skills" / "execute-zzzops" / "references"
+        branch_review = (root / "BRANCH_REVIEW.md").read_text(encoding="utf-8")
+        fallback = (root / "ADMIN_STACK_MERGE.md").read_text(encoding="utf-8").lower()
+        provider_failures = {
+            "native atomic merge": "approving review is required",
+            "ordinary admin merge": "asynchronous merge endpoint",
+        }
+        for operation, failure in provider_failures.items():
+            with self.subTest(operation=operation):
+                self.assertIn(failure, fallback)
+        guarded_scenarios = {
+            "preferred atomic path": "merge-async",
+            "no scoped bypass authority": "preserve the stack",
+            "consequence disclosure": "stack metadata",
+            "immutable provider readback": "re-read",
+            "explicit unstack": "gh stack unstack",
+            "bottom-up integration": "bottom pr first",
+            "trunk ancestry proof": "exact head reached the trunk",
+            "independent next layer": "independently reviewed diff",
+            "partial failure recovery": "persist the actual provider state",
+            "changed head denied": "changed head",
+            "pending check denied": "pending check",
+            "failed check denied": "failed check",
+            "review feedback denied": "unresolved feedback",
+            "cross-repository topology denied": "cross-repository",
+            "ruleset workaround denied": "never change repository rules",
+        }
+        for scenario, expected in guarded_scenarios.items():
+            with self.subTest(scenario=scenario):
+                self.assertIn(expected, fallback)
+        self.assertIn("ADMIN_STACK_MERGE.md", branch_review)
+        review_queue = (root / "REVIEW_QUEUE.md").read_text(encoding="utf-8")
+        self.assertIn("ADMIN_STACK_MERGE.md", review_queue)
+
     def test_parallel_and_refill_defaults_are_structured(self):
         root = PLUGIN_ROOT / "zzzops"
         plan = json.loads((root / "templates" / "project-goals" / "INIT_PLAN.json").read_text(encoding="utf-8"))

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -24,6 +24,8 @@ The active `dev` ruleset targets only `refs/heads/dev` and:
 
 `dev-required-tests` is the stable aggregate emitted on every PR to `dev`. It succeeds only when `Core validation (Linux, Python <version>)`, `Plugin core validation (Windows)`, and `Plugin core validation (macOS)` have all succeeded. The workflow has no path filters, dynamic check names, secrets, or write permission, so protection can rely on that one stable context.
 
+Native stacked PRs merge through GitHub's asynchronous stack operation, which does not support administrator bypass. If a fully verified stack is rejected only by a bypassable review rule, preserve it by default. An exact user authorization may permit unstacking after the metadata loss and non-atomic consequence are disclosed, followed by bottom-up `--admin` merges pinned to each head SHA. Failed or pending checks, changed heads, unresolved feedback, and release or safety gates are never bypassed.
+
 ## `main`
 
 The active `main` ruleset targets only `refs/heads/main` and blocks deletion, non-fast-forward updates, and direct updates. It currently has no bypass actors and no required-status-check rule.

--- a/docs/EXECUTION.md
+++ b/docs/EXECUTION.md
@@ -26,6 +26,8 @@ Canonical goal state records branch/base/target/PR and review checkpoint. After 
 
 Requested changes reuse the affected branch and create a new verified checkpoint. When an ancestor changes, execution pauses only its affected descendants, invalidates their stale checkpoints and approvals, retargets or rebases exclusively owned unintegrated branches in dependency order, recomputes every immediate-base diff, and reruns the relevant probes and required checks. Unsafe or unauthorized reconciliation blocks that chain while unrelated work continues. After approval, the agent merges only with authority, verifies the target, resolves the blocker, and completes the goal.
 
+Native stacks use GitHub's atomic asynchronous merge after every layer passes its exact-head, check, feedback, review, mergeability, and authority gates. If a repository rule rejects that operation, execution preserves the stack and reports the action needed. Only explicit administrator-bypass authority for that exact stack permits the non-atomic fallback: disclose that native stack metadata will be removed, re-read immutable provider state, unstack, then merge bottom-to-top while verifying and recording each result. A partial failure stops remaining layers with a recoverable next action; bypass never excuses a failed or pending check, changed head, unresolved feedback, or safety/release gate.
+
 The workflow remains agent-driven. ZzzOps deliberately has no universal branch-management script: repository instructions, hosting rules, dependency ancestry, dirty state, and merge authority require contextual inspection.
 
 ## Continuation after capture

--- a/plugins/zzzops/skills/execute-zzzops/references/ADMIN_STACK_MERGE.md
+++ b/plugins/zzzops/skills/execute-zzzops/references/ADMIN_STACK_MERGE.md
@@ -1,0 +1,22 @@
+# Guarded administrator fallback for native stack merges
+
+Load this only when an otherwise-ready native GitHub stack cannot merge because a repository rule needs an administrator bypass. This is a destructive, non-atomic fallback—not the normal merge path.
+
+## Default and stop boundary
+
+1. Reverify the stack identity, same-repository topology, trunk, ordered PRs and immediate bases, every [[exact head]](../../../concepts/exact-head.md), successful required check, resolved feedback, review decision, mergeability, and project merge/release authority.
+2. Prefer the atomic asynchronous stack merge (`gh stack merge ... --yes`; GitHub uses `merge-async`). It either merges every PR through the selected layer or none. The observed rule failure contains `approving review is required`.
+3. Do not retry with ordinary `gh pr merge --admin` while membership exists: stacked PRs require the `asynchronous merge endpoint`, whose documented options provide no administrator bypass. Preserve the stack and record one action unless the user explicitly authorized administrator bypass for this exact current stack.
+4. Never infer bypass authority from conversational approval, ordinary merge authority, repository administration, or an earlier stack. Never change repository rules or install tooling as a workaround.
+
+## Authorized fallback
+
+Before mutation, explain that unstacking removes GitHub stack metadata but retains the branches and PRs, and that later merges are no longer atomic. Then:
+
+1. Re-read provider state immediately. Stop on a changed head, failed check, pending check, unresolved feedback, draft/closed/unmergeable PR, altered membership/base/trunk, missing exact scoped authority, cross-repository topology, or any safety, privacy, release, or project-policy gate.
+2. Run `gh stack unstack STACK_NUMBER` without `--local`. Require provider readback that every intended PR is unstacked while its branch, PR, exact head, and immediate base still match. Any partial or unverifiable unstack stops.
+3. Merge the bottom PR first with the authorized method, `--admin`, and `--match-head-commit EXACT_SHA`. Read back that its exact head reached the trunk before changing goal state.
+4. Re-read the next PR. Require its expected retarget, exact head, clean mergeability, successful checks, resolved feedback, and independently reviewed diff; then repeat bottom-to-top. Never reuse an earlier read.
+5. After each merge, persist the actual provider state and goal result. If a later layer fails, keep every completed merge recorded, stop the remaining layers, and give the exact recoverable next action. Never report the fallback as atomic or retry blindly.
+
+The fallback cannot bypass failed or pending checks, changed heads, unresolved feedback, safety/privacy constraints, merge or release authority, or any unrelated requirement.

--- a/plugins/zzzops/skills/execute-zzzops/references/BRANCH_REVIEW.md
+++ b/plugins/zzzops/skills/execute-zzzops/references/BRANCH_REVIEW.md
@@ -10,9 +10,11 @@ Apply PROJECT Git/review policy; capture stays Git-free. Never absorb unrelated 
 
 Create/resume the recorded branch before edits. Stop on unattributable dirt; record authorized topology exceptions.
 
-Compare overlapping PRs to their immediate base; inherited commits are not overlap. Branches stay exclusive. Sibling PRs may share a target; a child may target its reviewed parent/dependency. Before opening a PR and each review checkpoint, inspect immediate-base history and apply `EXECUTION_STRATEGY.md` final-state cleanup.
+Compare PRs to their immediate base; inherited commits are not overlap. Branches stay exclusive. Siblings may share a target; children may target a reviewed parent/dependency. Before opening a PR and each review checkpoint, inspect immediate-base history and apply `EXECUTION_STRATEGY.md` final-state cleanup.
 
-Apply PROJECT's PR mode. For native GitHub stacks, first check the documented `gh` minimum and official `gh stack` capability. Installing/upgrading host tooling needs explicit approval. Link ordered same-repository PRs bottom-to-top with noninteractive `gh stack link --base TRUNK ...`; then require provider readback proving one stack identity, trunk, size/positions, and every immediate PR base. Capability absence, denied installation, cross-repository topology, command failure, or unverifiable readback means the PRs are **chained PRs**, never claimed as stacked; follow PROJECT's fallback or block. Preserve branch/PR ownership, exact-head evidence, checks, review, merge, and release authority in either mode.
+Apply PROJECT's PR mode. For native GitHub stacks, check the documented `gh` minimum and official `gh stack` capability; host tooling changes need explicit approval. Link ordered same-repository PRs bottom-to-top with noninteractive `gh stack link --base TRUNK ...`, then require provider readback of one identity, trunk, positions, and immediate bases. Missing capability, denied installation, unsupported topology, failure, or unverifiable state means **chained PRs**; follow PROJECT's fallback or block. Preserve ownership, exact heads, checks, review, merge, and release authority.
+
+Prefer atomic stack merge. On a bypassable rule rejection, preserve it unless exact administrator-bypass authority permits the [guarded fallback](ADMIN_STACK_MERGE.md).
 
 For verified-checkpoint continuation, exhaustion handoff, or ancestor feedback, follow [the PR review queue](REVIEW_QUEUE.md). Recheck target, mergeability, immediate-base diff, overlap, conflict, and risk before review/integration.
 

--- a/plugins/zzzops/skills/execute-zzzops/references/REVIEW_QUEUE.md
+++ b/plugins/zzzops/skills/execute-zzzops/references/REVIEW_QUEUE.md
@@ -8,6 +8,8 @@ For `human_at_exhaustion`, record the [[exact head]](../../../concepts/exact-hea
 
 For `human_after_checks`, surface that goal's review action immediately. A separate `stack_from_reviewed_checkpoint` setting may still permit descendants; completed-dependency policy waits. Neither mode marks the goal done, self-approves, merges, bypasses checks, or weakens release authority.
 
+After every gate passes, prefer atomic stack merge. A rule rejection preserves it unless exact administrator-bypass authority permits the [guarded fallback](ADMIN_STACK_MERGE.md).
+
 ## Exhaustion handoff
 
 When no safe `triage`, `prepare`, or `write` work remains, present one concise review queue in dependency/merge order. For each PR give its goal link, PR link, immediate target, check state, material risk or decision, and the action that resumes work. Separate non-review authority blockers. Do not ask for commands such as `approve goal 1`; the repository's PR review UI is the approval surface.
@@ -19,7 +21,7 @@ After an ancestor checkpoint changes:
 1. stop writes on affected descendants and read the ancestor feedback/exact head once;
 2. implement only authorized feedback, reverify the ancestor, and record its new checkpoint;
 3. invalidate every affected descendant checkpoint and approval;
-4. update bases and PR targets in dependency order, using noninteractive `gh stack rebase`/`push` when locally tracked, otherwise guarded Git rebase/push; re-link and require provider readback for native stacks, and keep chained PRs explicit; recompute each immediate-base diff and resolve conflicts only when authorized;
+4. update bases/targets in dependency order with `gh stack rebase`/`push` when tracked, otherwise guarded Git; require provider readback for native stacks or keep chained PRs explicit; recompute each immediate-base diff and resolve only authorized conflicts;
 5. rerun each affected narrow probe and required check, then record replacement checkpoints; and
 6. block only the affected chain when reconciliation is unsafe, unauthorized, ambiguous, or fails, while continuing unrelated work.
 


### PR DESCRIPTION
## Outcome

Adds a progressively disclosed, authorization-sensitive fallback for the GitHub limitation that native stack merges cannot use administrator bypass.

- preserves the native stack by default when atomic merge is rejected
- requires exact scoped bypass authority and consequence disclosure before unstacking
- revalidates every immutable checkpoint, then merges bottom-up with partial-failure recovery
- retains failed/pending-check, changed-head, feedback, safety, and release gates

## Verification

- focused two-error contract failed before guidance and now passes
- all 30 workflow contract tests pass
- prompt-budget tests and plugin/concept validation pass
- execution prompt remains within its committed limit (8460 / 8465 estimated tokens)

Tracks #358