### PR TITLE
feat(performance): profile CLI timing phases

### DIFF
--- a/.agents/test_zzzops.py
+++ b/.agents/test_zzzops.py
@@ -221,6 +221,15 @@ class DiagnosticsModuleTests(unittest.TestCase):
             with broken_clock.span("startup"):
                 raise RuntimeError("original workload failure")
 
+    def test_command_total_can_contain_sequential_leaf_spans(self):
+        session = zzzops.TimingSession(clock=iter([1.0, 1.1, 1.2, 1.3]).__next__)
+        with session.command():
+            with session.span("startup"):
+                pass
+        phases = session.snapshot()["phases"]
+        self.assertEqual(100, phases["startup"]["total_ms"])
+        self.assertEqual(300, phases["command_total"]["total_ms"])
+
     def test_local_records_are_content_addressed_bounded_and_purgeable(self):
         for duration in range(zzzops._diagnostics.MAX_RECORDS + 2):
             session = zzzops.TimingSession(clock=iter([1.0, 1.0 + duration / 1000]).__next__)
@@ -243,6 +252,42 @@ class DiagnosticsModuleTests(unittest.TestCase):
         purged = zzzops.purge_diagnostics(self.repo)
         self.assertEqual(zzzops._diagnostics.MAX_RECORDS, purged["purged"])
         self.assertEqual(0, zzzops.list_diagnostics(self.repo)["count"])
+
+    def test_profile_flag_preserves_checkpoint_output_and_records_only_when_enabled(self):
+        checkpoint = {"ready": True, "schema_version": 1, "value": "unchanged"}
+        with (
+            mock.patch.object(zzzops, "configure_cli_stdout"),
+            mock.patch.object(zzzops._package, "package_status", return_value={"ok": True}),
+            mock.patch.object(zzzops, "decision_checkpoint", return_value=checkpoint),
+            mock.patch.object(zzzops, "record_diagnostic") as record,
+        ):
+            plain_stream = io.StringIO()
+            with mock.patch.object(sys, "argv", ["zzzops", "--repo", str(self.repo), "checkpoint"]), mock.patch.object(sys, "stdout", plain_stream):
+                self.assertEqual(0, zzzops.main())
+            self.assertFalse(record.called)
+
+            profiled_stream = io.StringIO()
+            with mock.patch.object(sys, "argv", ["zzzops", "--repo", str(self.repo), "checkpoint", "--profile"]), mock.patch.object(sys, "stdout", profiled_stream):
+                self.assertEqual(0, zzzops.main())
+            self.assertEqual(plain_stream.getvalue(), profiled_stream.getvalue())
+            diagnostic = record.call_args.args[1]
+            self.assertIn("package", diagnostic["phases"])
+            self.assertIn("rendering", diagnostic["phases"])
+            self.assertIn("command_total", diagnostic["phases"])
+
+    def test_profiled_interrupt_preserves_cli_behavior_and_records_failed_total(self):
+        with (
+            mock.patch.object(zzzops, "configure_cli_stdout"),
+            mock.patch.object(zzzops._package, "package_status", return_value={"ok": True}),
+            mock.patch.object(zzzops, "decision_checkpoint", side_effect=KeyboardInterrupt),
+            mock.patch.object(zzzops, "record_diagnostic") as record,
+        ):
+            stream = io.StringIO()
+            with mock.patch.object(sys, "argv", ["zzzops", "--repo", str(self.repo), "checkpoint", "--profile"]), mock.patch.object(sys, "stdout", stream):
+                self.assertEqual(0, zzzops.main())
+        self.assertEqual("\nNo further changes made.\n", stream.getvalue())
+        diagnostic = record.call_args.args[1]
+        self.assertEqual(1, diagnostic["phases"]["command_total"]["failures"])
 
 
 class ReservationModuleTests(unittest.TestCase):
@@ -2134,10 +2179,11 @@ class PortfolioTests(unittest.TestCase):
                 SimpleNamespace(returncode=0, stdout=json.dumps(body_payload(issue_one, feedback)), stderr=""),
             ]
             snapshot = zzzops.portfolio_snapshot(repo)
+            timing = zzzops.TimingSession(clock=iter([10.0, 10.125, 20.0, 20.009, 30.0, 30.050]).__next__)
             _, included = zzzops.github_repository_portfolio_snapshot(
                 repo, {"backend": "github_issues", "repository": {"identity": "owner/repo"},
                        "policy": {"sections": [{"id": "autonomy_approval_parallelism", "settings": {"resource_reservations": TEST_RESOURCE_POLICY}}]}},
-                include_feedback=True,
+                include_feedback=True, timing=timing,
             )
         self.assertEqual([1, 3], [goal["key"] for goal in snapshot["goals"]])
         self.assertEqual([1, 2, 3], [goal["key"] for goal in included["goals"]])
@@ -2164,6 +2210,25 @@ class PortfolioTests(unittest.TestCase):
         self.assertEqual("https://example.test/owner/repo/issues/1", snapshot["goals"][0]["url"])
         self.assertLess(snapshot["summary"]["discovery_raw_bytes"], snapshot["summary"]["raw_bytes"])
         self.assertEqual(4, run.call_count)
+        phases = timing.snapshot()["phases"]
+        self.assertEqual(125, phases["github_discovery"]["total_ms"])
+        self.assertEqual(9, phases["goal_hydration"]["total_ms"])
+        self.assertEqual(50, phases["graph_validation"]["total_ms"])
+
+    @mock.patch.object(zzzops.shutil, "which", return_value="gh")
+    @mock.patch.object(zzzops.subprocess, "run")
+    def test_github_timing_preserves_provider_failure_without_retaining_error_text(self, run, _which):
+        run.return_value = SimpleNamespace(returncode=1, stdout="", stderr="private provider detail")
+        timing = zzzops.TimingSession(clock=iter([1.0, 1.050]).__next__)
+        project = {"backend": "github_issues", "repository": {"identity": "owner/repo"}}
+
+        with self.assertRaisesRegex(ValueError, "private provider detail"):
+            zzzops.github_repository_portfolio_snapshot(Path("."), project, timing=timing)
+
+        diagnostic = timing.snapshot()
+        self.assertEqual(1, diagnostic["phases"]["github_discovery"]["failures"])
+        self.assertNotIn("private", json.dumps(diagnostic))
+        self.assertNotIn("owner/repo", json.dumps(diagnostic))
 
     @mock.patch.object(zzzops.shutil, "which", side_effect=lambda command: command)
     @mock.patch.object(zzzops.subprocess, "run")

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -16,6 +16,19 @@ Deterministic fixtures require a valid initialized checkpoint's reported decisio
 
 Agents still perform one targeted concurrency re-read before mutating the selected goal.
 
+## Opt-in timing diagnostics
+
+Add `--profile` to an explicit checkpoint or portfolio command to retain one local timing aggregate while preserving the command's ordinary stdout, exit behavior, and reported process counts:
+
+```powershell
+<python> <zzzops-cli> --repo . checkpoint --profile
+<python> <zzzops-cli> --repo . portfolio --format json --profile
+```
+
+The profile uses fixed phase and provenance enums plus bounded integer milliseconds. It records no repository identity, paths, prompts, goal content, raw output, secrets, hostnames, or usernames. Aggregates are content-addressed under `zzzops/timing-diagnostics` in Git's ignored common directory, shared safely across worktrees, capped at 32 records, and removable through the stable `purge_diagnostics` API. Profiling performs one extra local Git-common-directory lookup only after the normal result and process counts have been constructed. It has no submission path.
+
+Four process-cold Windows checkpoint samples on 2026-08-31 recorded internal command totals of 2,343–2,640 ms. GitHub discovery was the largest measured phase at 1,250–1,687 ms, followed by goal hydration at 735–875 ms; graph validation was 0–16 ms, two package validations totaled 109–110 ms, Git origin was 47–62 ms, and repository-size measurement was 46–62 ms. Three externally measured invocations took 2,554–2,872 ms. The difference includes interpreter/import startup and final diagnostic persistence, which the in-process profiler does not pretend to attribute; `startup` is therefore recorded as `unavailable`. These samples establish a diagnostic baseline, not a CI threshold.
+
 Execution performs no scheduled entropy scan, completion bookkeeping, or changed-line analysis. Only a concrete observation already exposed by ordinary work causes one small atomic Git-local file creation. Every explicit work-suggestion run reads the compact inbox once and spends audit tokens only validating policy-eligible observations; excluded categories remain unread in the returned evidence set.
 
 The utility reports malformed records, duplicate/self/missing/cyclic relations, status/dependency conflicts, stale claims, review checkpoint errors, GitHub label/state drift, and snapshot changes. It never prioritizes, repairs, mutates, caches, or replaces agent judgment.

--- a/plugins/zzzops/zzzops/diagnostics.py
+++ b/plugins/zzzops/zzzops/diagnostics.py
@@ -19,7 +19,7 @@ MAX_RECORDS = 32
 MAX_DURATION_MS = 86_400_000
 MAX_TOTAL_MS = MAX_DURATION_MS * 1_000_000
 PHASES = frozenset({
-    "startup", "package", "policy_validation", "git_origin", "repository_size",
+    "command_total", "startup", "package", "policy_validation", "git_origin", "repository_size",
     "github_discovery", "goal_hydration", "graph_validation", "rendering",
     "tool_wait", "model", "context_compaction",
 })
@@ -183,6 +183,23 @@ class TimingSession:
         if not isinstance(started, (int, float)) or not isinstance(ended, (int, float)) or ended < started:
             raise DiagnosticError("monotonic clock returned an invalid interval")
         self.mark(phase, provenance="measured", milliseconds=round((ended - started) * 1000), failed=failed)
+
+    @contextmanager
+    def command(self) -> Iterator[None]:
+        """Record one command total while allowing sequential leaf spans inside it."""
+        started = self._clock()
+        failed = False
+        try:
+            yield
+        except BaseException:
+            failed = True
+            raise
+        finally:
+            try:
+                self._finish_span("command_total", started, failed=failed)
+            except DiagnosticError:
+                if not failed:
+                    raise
 
     def snapshot(self) -> dict[str, Any]:
         value = {

--- a/plugins/zzzops/zzzops/zzzops.py
+++ b/plugins/zzzops/zzzops/zzzops.py
@@ -221,6 +221,13 @@ list_diagnostics = _diagnostics.list_diagnostics
 purge_diagnostics = _diagnostics.purge_diagnostics
 DiagnosticError = _diagnostics.DiagnosticError
 
+
+def _timed_call(timing: Any, phase: str, operation: Any) -> Any:
+    if timing is None:
+        return operation()
+    with timing.span(phase):
+        return operation()
+
 execution_reports_enabled = _feedback.execution_reports_enabled
 execution_report_directory = _feedback.execution_report_directory
 execution_report_id = _feedback.execution_report_id
@@ -853,21 +860,12 @@ def github_repository_goal_index(
     )
 
 
-def github_repository_portfolio_snapshot(
-    repo: Path, project: dict[str, Any], include_feedback: bool = False,
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    identity = _project_repository_identity(project)
-    owner, name = identity.split("/", 1)
-    executable = shutil.which("gh")
-    if not executable:
-        raise ValueError("GitHub CLI is unavailable")
-    repository_probe, selected, findings, discovery_bytes, discovery_reads, excluded = github_repository_goal_index(
-        repo, project, include_feedback,
-    )
+def _portfolio_from_hydrated_goals(
+    project: dict[str, Any], selected: list[dict[str, Any]], bodies: dict[int, dict[str, Any]],
+    findings: list[dict[str, Any]], discovery_bytes: int, discovery_reads: int,
+    hydration_bytes: int, hydration_processes: int, excluded: int,
+) -> dict[str, Any]:
     open_selected = [issue for issue in selected if issue["state"] == "open"]
-    bodies, hydration_bytes, hydration_processes = _github_goal_bodies(
-        repo, executable, owner, name, [issue["number"] for issue in open_selected],
-    )
     managed = []
     for issue in open_selected:
         hydrated = bodies[issue["number"]]
@@ -915,10 +913,36 @@ def github_repository_portfolio_snapshot(
     snapshot["summary"]["discovery_raw_bytes"] = discovery_bytes
     snapshot["summary"]["hydration_raw_bytes"] = hydration_bytes
     snapshot["summary"]["processes"] = 1 + hydration_processes
-    return repository_probe, compact_portfolio_output(snapshot)
+    return compact_portfolio_output(snapshot)
 
 
-def portfolio_snapshot(repo: Path, include_feedback: bool = False) -> dict[str, Any]:
+def github_repository_portfolio_snapshot(
+    repo: Path, project: dict[str, Any], include_feedback: bool = False, *, timing: Any = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    identity = _project_repository_identity(project)
+    owner, name = identity.split("/", 1)
+    executable = shutil.which("gh")
+    if not executable:
+        raise ValueError("GitHub CLI is unavailable")
+    repository_probe, selected, findings, discovery_bytes, discovery_reads, excluded = _timed_call(
+        timing, "github_discovery", lambda: github_repository_goal_index(repo, project, include_feedback),
+    )
+    open_selected = [issue for issue in selected if issue["state"] == "open"]
+    bodies, hydration_bytes, hydration_processes = _timed_call(
+        timing, "goal_hydration", lambda: _github_goal_bodies(
+            repo, executable, owner, name, [issue["number"] for issue in open_selected],
+        ),
+    )
+    snapshot = _timed_call(
+        timing, "graph_validation", lambda: _portfolio_from_hydrated_goals(
+            project, selected, bodies, findings, discovery_bytes, discovery_reads,
+            hydration_bytes, hydration_processes, excluded,
+        ),
+    )
+    return repository_probe, snapshot
+
+
+def _validated_portfolio_project(repo: Path) -> dict[str, Any]:
     _path, _text, project = read_project_state(repo)
     if project is None:
         raise ValueError("Project policy is missing; run the review-zzzops-policy skill")
@@ -926,7 +950,14 @@ def portfolio_snapshot(repo: Path, include_feedback: bool = False) -> dict[str, 
     errors.extend(validate_project_artifacts(repo, project))
     if errors or not project or not project.get("initialized"):
         raise ValueError("Project policy is not initialized: " + "; ".join(errors or ["review pending"]))
-    _repository, snapshot = github_repository_portfolio_snapshot(repo, project, include_feedback)
+    return project
+
+
+def portfolio_snapshot(repo: Path, include_feedback: bool = False, *, timing: Any = None) -> dict[str, Any]:
+    project = _timed_call(timing, "policy_validation", lambda: _validated_portfolio_project(repo))
+    _repository, snapshot = github_repository_portfolio_snapshot(
+        repo, project, include_feedback, timing=timing,
+    )
     return snapshot
 
 
@@ -1165,7 +1196,7 @@ def inspect_initialization(repo: Path) -> dict[str, Any]:
     }
 
 
-def decision_checkpoint(repo: Path, include_feedback: bool = False) -> dict[str, Any]:
+def _checkpoint_policy_state(repo: Path) -> tuple[Path, str, dict[str, Any] | None, str | None, list[str], bool]:
     path, text = read_project(repo)
     error = None
     try:
@@ -1179,7 +1210,16 @@ def decision_checkpoint(repo: Path, include_feedback: bool = False) -> dict[str,
         error = str(exc)
     blockers = policy_blockers(state.get("policy")) if state else ["policy:missing"]
     initialized = bool(state and state.get("initialized") is True and not blockers and error is None)
-    git_remote = command_probe(["git", "remote", "get-url", "origin"], repo)
+    return path, text, state, error, blockers, initialized
+
+
+def decision_checkpoint(repo: Path, include_feedback: bool = False, *, timing: Any = None) -> dict[str, Any]:
+    path, text, state, error, blockers, initialized = _timed_call(
+        timing, "policy_validation", lambda: _checkpoint_policy_state(repo),
+    )
+    git_remote = _timed_call(
+        timing, "git_origin", lambda: command_probe(["git", "remote", "get-url", "origin"], repo),
+    )
     github_available = shutil.which("gh") is not None
     github_processes = 0
     plugin_package = {
@@ -1206,11 +1246,13 @@ def decision_checkpoint(repo: Path, include_feedback: bool = False) -> dict[str,
         "detail": "initialization required",
     }
     if initialized and state:
-        plugin_package = _package.package_status()
+        plugin_package = _timed_call(timing, "package", _package.package_status)
     if initialized and state and plugin_package.get("ok") is True:
         github_processes = 1 if github_available else 0
         try:
-            github_repository, portfolio = github_repository_portfolio_snapshot(repo, state, include_feedback)
+            github_repository, portfolio = github_repository_portfolio_snapshot(
+                repo, state, include_feedback, timing=timing,
+            )
             github_processes = int(portfolio.get("summary", {}).get("processes", github_processes))
             github_auth = {"available": True, "ok": True, "detail": "github.com"}
         except ValueError as exc:
@@ -1242,6 +1284,7 @@ def decision_checkpoint(repo: Path, include_feedback: bool = False) -> dict[str,
         and portfolio.get("complete") is True
         and portfolio.get("valid") is True
     )
+    repository_size = _timed_call(timing, "repository_size", lambda: repository_size_profile(repo))
     return {
         "schema_version": PLAN_SCHEMA_VERSION,
         "project_path": str(path),
@@ -1257,7 +1300,7 @@ def decision_checkpoint(repo: Path, include_feedback: bool = False) -> dict[str,
             "github_auth": github_auth,
             "github_repository": github_repository,
         },
-        "repository_size": repository_size_profile(repo),
+        "repository_size": repository_size,
         "portfolio": portfolio,
         "processes": {
             "total": (
@@ -1706,6 +1749,73 @@ def confirm_project(repo: Path, digest: str, reviewer: str, section_ids: list[st
     }
 
 
+def _run_profiled(repo: Path, operation: Any) -> tuple[int, str]:
+    timing = TimingSession()
+    failed = False
+    try:
+        with timing.command():
+            return operation(timing)
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        try:
+            record_diagnostic(repo, timing.snapshot())
+        except DiagnosticError:
+            if not failed:
+                raise
+
+
+def _profiled_checkpoint_cli(repo: Path, args: argparse.Namespace) -> tuple[int, str]:
+    def operation(timing: Any) -> tuple[int, str]:
+        timing.mark("startup", provenance="unavailable")
+        package = _timed_call(timing, "package", _package.package_status)
+        if package.get("ok") is not True:
+            return 2, str(package.get("detail") or "The ZzzOps Agent Plugin package is invalid.")
+        result = decision_checkpoint(repo, args.include_feedback, timing=timing)
+        rendered = _timed_call(
+            timing, "rendering",
+            lambda: json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        )
+        return (0 if result["ready"] else 2), rendered
+
+    try:
+        return _run_profiled(repo, operation)
+    except ValueError as exc:
+        return 2, f"Could not continue: {exc}"
+
+
+def _profiled_portfolio_cli(repo: Path, args: argparse.Namespace) -> tuple[int, str]:
+    def operation(timing: Any) -> tuple[int, str]:
+        timing.mark("startup", provenance="unavailable")
+        package = _timed_call(timing, "package", _package.package_status)
+        if package.get("ok") is not True:
+            return 2, str(package.get("detail") or "The ZzzOps Agent Plugin package is invalid.")
+        result = portfolio_snapshot(repo, args.include_feedback, timing=timing)
+        if args.compare:
+            prior = json.loads(args.compare.resolve().read_text(encoding="utf-8-sig"))
+            result["changes"] = compare_portfolios(result, prior)
+        rendered = _timed_call(
+            timing, "rendering",
+            lambda: (
+                json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+                if args.output_format == "json"
+                else render_portfolio_summary(result, args.include_done)
+            ),
+        )
+        return 0, rendered
+
+    try:
+        return _run_profiled(repo, operation)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        if args.output_format == "json":
+            return 2, json.dumps(
+                {"schema_version": PORTFOLIO_SCHEMA_VERSION, "complete": False, "valid": False, "error": str(exc)},
+                ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+            )
+        return 2, f"Could not load goals: {exc}"
+
+
 def main() -> int:
     configure_cli_stdout()
     parser = argparse.ArgumentParser(description="ZzzOps project control CLI")
@@ -1725,6 +1835,7 @@ def main() -> int:
     confirm_command.add_argument("--all", action="store_true", help="Approve every current policy section")
     checkpoint_parser = commands.add_parser("checkpoint", help="Validate initialized state, GitHub capability, and the goal portfolio once")
     checkpoint_parser.add_argument("--include-feedback", action="store_true", help="Include specially tagged feedback goals for this session")
+    checkpoint_parser.add_argument("--profile", action="store_true", help="Record one local privacy-safe timing aggregate")
     installation = commands.add_parser("installation", help="Check or record per-repository plugin validation")
     installation_commands = installation.add_subparsers(dest="installation_command", required=True)
     installation_commands.add_parser("status", help="Report whether this installed package needs repository validation")
@@ -1749,6 +1860,7 @@ def main() -> int:
     portfolio_parser.add_argument("--include-done", action="store_true", help="Include terminal goals in summary output")
     portfolio_parser.add_argument("--compare", type=Path, help="Prior JSON snapshot used only to report digest/revision drift")
     portfolio_parser.add_argument("--include-feedback", action="store_true", help="Include specially tagged feedback goals")
+    portfolio_parser.add_argument("--profile", action="store_true", help="Record one local privacy-safe timing aggregate")
     goal_command = commands.add_parser("goal", help="Create, transition, or inspect validated GitHub-backed goals")
     goal_commands = goal_command.add_subparsers(dest="goal_command", required=True)
     create_goal_command = goal_commands.add_parser("create", help="Create one goal from a validated UTF-8 request file")
@@ -1804,6 +1916,22 @@ def main() -> int:
             feedback_command.add_argument("--confirm", required=True, help="Exact digest shown by feedback prepare")
     args = parser.parse_args()
     repo = args.repo.resolve()
+    if args.command == "checkpoint" and args.profile:
+        try:
+            code, output = _profiled_checkpoint_cli(repo, args)
+            print(output)
+            return code
+        except (EOFError, KeyboardInterrupt):
+            print("\nNo further changes made.")
+            return 0
+    if args.command == "portfolio" and args.profile:
+        try:
+            code, output = _profiled_portfolio_cli(repo, args)
+            print(output)
+            return code
+        except (EOFError, KeyboardInterrupt):
+            print("\nNo further changes made.")
+            return 0
     package = _package.package_status()
     if package.get("ok") is not True:
         print(str(package.get("detail") or "The ZzzOps Agent Plugin package is invalid."))


### PR DESCRIPTION
## Summary

- add explicit `--profile` support to checkpoint and portfolio without changing normal output, exit behavior, or reported process counts
- attribute local policy, Git, package, provider discovery, hydration, graph, repository-size, rendering, and command-total phases with injected monotonic timing
- retain failure timings without preserving provider error text and mark interpreter/import startup unavailable instead of guessing
- document a four-sample Windows baseline showing GitHub discovery and goal hydration dominate the measured path

## Verification

- `python .agents/test_zzzops.py DiagnosticsModuleTests PortfolioTests`
- `python -m compileall -q plugins/zzzops/zzzops/diagnostics.py plugins/zzzops/zzzops/zzzops.py .agents/test_zzzops.py`
- exact output/exit comparison for checkpoint and JSON portfolio with and without `--profile`
- `git diff --check`

Tracks #367

<sub>Part of GitHub stack #374; immediate base is PR #372.</sub>
